### PR TITLE
Trigger gitlab mirroring using an action

### DIFF
--- a/.github/workflows/trigger_gitlab_mirroring.yml
+++ b/.github/workflows/trigger_gitlab_mirroring.yml
@@ -25,4 +25,5 @@ jobs:
       - name: Trigger gitlab mirroring
         env:
           TOKEN: ${{ secrets.GITLAB_TOKEN }}
-        run: curl --request POST "https://gitlab.com/api/v4/projects/23091471/mirror/pull?private_token=$(TOKEN)"
+        run: curl --request POST "https://gitlab.com/api/v4/projects/23091471/mirror/pull?private_token=$TOKEN" && sleep 30
+        # Sleep is hopefully sufficient to wait for gitlab's ci trigger. Otherwise there is a point in the PR where all checks have passed but gitlab's ci hasn't been triggered yet

--- a/.github/workflows/trigger_gitlab_mirroring.yml
+++ b/.github/workflows/trigger_gitlab_mirroring.yml
@@ -1,0 +1,28 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: all
+  pull_request:
+    branches: all
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: curl
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Trigger gitlab mirroring
+        env:
+          TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        run: curl --request POST "https://gitlab.com/api/v4/projects/23091471/mirror/pull?private_token=$(TOKEN)"

--- a/.github/workflows/trigger_gitlab_mirroring.yml
+++ b/.github/workflows/trigger_gitlab_mirroring.yml
@@ -2,13 +2,13 @@
 
 name: CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: all
+    branches: '**'
   pull_request:
-    branches: all
+    branches: '**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: curl
+    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
@denismerigoux as you suggested. I added a `sleep 30` to avoid the situation where Github thinks everything is good after it has performed its action only. Maybe we can reduce the sleep duration.