### PR TITLE
Remove references to nonexistant F* formalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ Don't forget format to use `make format` before you commit to ensure a uniform s
 
 ## Formal semantics
 
-The `formal_semantics` folder contains two separate formalizations for the core of the
+The `formal_semantics` folder contains the formalization for the core of the
 M language, that roughly corresponds to the `Mir` internal representation in Mlang.
-The reference formalization is the Coq one, in file `semantique.v`. The F* formalization
-is a proof of concept. See [the research paper](https://hal.inria.fr/hal-02320347) for
+The reference formalization is written in Coq, in file `semantique.v`.
+See [the research paper](https://hal.inria.fr/hal-02320347) for
 more details.
 
 ## License


### PR DESCRIPTION
F* formalization was previously removed from project, this commits removes references to that file from the main README.