### PR TITLE
Split M code in rules in pipeline without optimisations

### DIFF
--- a/src/mlang/backend_compilers/bir_to_python.ml
+++ b/src/mlang/backend_compilers/bir_to_python.ml
@@ -358,6 +358,8 @@ and generate_stmt program oc stmt =
         cond_name (generate_python_expr false) (Pos.same_pos_as cond stmt) cond_name cond_name
         (generate_stmts program) tt cond_name (generate_stmts program) ff
   | SVerif v -> generate_var_cond v oc
+  | SRuleCall _ -> assert false
+(* Removed with [Bir.get_all_statements] below *)
 
 let generate_return oc (function_spec : Bir_interface.bir_function) =
   let returned_variables = List.map fst (VariableMap.bindings function_spec.func_outputs) in
@@ -382,5 +384,5 @@ let generate_python_program (program : Bir.program) (function_spec : Bir_interfa
   let _oc = open_out filename in
   let oc = Format.formatter_of_out_channel _oc in
   Format.fprintf oc "%a%a%a%a" generate_header () generate_input_handling function_spec
-    (generate_stmts program) program.statements generate_return function_spec;
+    (generate_stmts program) (Bir.get_all_statements program) generate_return function_spec;
   close_out _oc

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -12,115 +12,118 @@
    You should have received a copy of the GNU General Public License along with this program. If
    not, see <https://www.gnu.org/licenses/>. *)
 
-type stmt = stmt_kind Pos.marked
+type rule_id = int
+
+module RuleMap = Map.Make (struct
+  type t = rule_id
+
+  let compare = compare
+end)
+
+type rule = { rule_id : rule_id; rule_name : string; rule_stmts : stmt list }
+
+and stmt = stmt_kind Pos.marked
 
 and stmt_kind =
   | SAssign of Mir.Variable.t * Mir.variable_data
   | SConditional of Mir.expression * stmt list * stmt list
   | SVerif of Mir.condition_data
+  | SRuleCall of rule_id
 
 type program = {
+  rules : rule RuleMap.t;
   statements : stmt list;
   idmap : Mir.idmap;
   mir_program : Mir.program;
   outputs : unit Mir.VariableMap.t;
 }
 
+let get_all_statements program =
+  let rec get_block_statements stmts =
+    List.fold_left
+      (fun stmts stmt ->
+        match Pos.unmark stmt with
+        | SRuleCall r -> List.rev (RuleMap.find r program.rules).rule_stmts @ stmts
+        | SConditional (e, t, f) ->
+            let t = get_block_statements t in
+            let f = get_block_statements f in
+            Pos.same_pos_as (SConditional (e, t, f)) stmt :: stmts
+        | _ -> stmt :: stmts)
+      [] stmts
+    |> List.rev
+  in
+  get_block_statements program.statements
+
 let count_instructions (p : program) : int =
   let rec cond_instr_blocks (stmts : stmt list) : int =
     List.fold_left
       (fun acc stmt ->
         match Pos.unmark stmt with
-        | SAssign _ | SVerif _ -> acc + 1
+        | SAssign _ | SVerif _ | SRuleCall _ -> acc + 1
         | SConditional (_, s1, s2) -> acc + 1 + cond_instr_blocks s1 + cond_instr_blocks s2)
       0 stmts
   in
   cond_instr_blocks p.statements
 
 let get_assigned_variables (p : program) : unit Mir.VariableMap.t =
-  let rec get_assigned_variables_block (stmts : stmt list) : unit Mir.VariableMap.t =
+  let rec get_assigned_variables_block acc (stmts : stmt list) : unit Mir.VariableMap.t =
     List.fold_left
       (fun acc stmt ->
         match Pos.unmark stmt with
         | SVerif _ -> acc
         | SAssign (var, _) -> Mir.VariableMap.add var () acc
         | SConditional (_, s1, s2) ->
-            Mir.VariableMap.union
-              (fun _ _ _ -> Some ())
-              acc
-              (Mir.VariableMap.union
-                 (fun _ _ _ -> Some ())
-                 (get_assigned_variables_block s1) (get_assigned_variables_block s2)))
-      Mir.VariableMap.empty stmts
+            let acc = get_assigned_variables_block acc s1 in
+            get_assigned_variables_block acc s2
+        | SRuleCall _ -> assert false)
+      acc stmts
   in
-  get_assigned_variables_block p.statements
+  get_assigned_variables_block Mir.VariableMap.empty (get_all_statements p)
 
 let get_local_variables (p : program) : unit Mir.LocalVariableMap.t =
-  let rec get_local_vars_expr (e : Mir.expression Pos.marked) : unit Mir.LocalVariableMap.t =
+  let rec get_local_vars_expr acc (e : Mir.expression Pos.marked) : unit Mir.LocalVariableMap.t =
     match Pos.unmark e with
-    | Mir.Unop (_, e) | Mir.Index (_, e) -> get_local_vars_expr e
+    | Mir.Unop (_, e) | Mir.Index (_, e) -> get_local_vars_expr acc e
     | Mir.Comparison (_, e1, e2) | Mir.Binop (_, e1, e2) ->
-        Mir.LocalVariableMap.union
-          (fun _ _ _ -> Some ())
-          (get_local_vars_expr e1) (get_local_vars_expr e2)
+        let acc = get_local_vars_expr acc e1 in
+        get_local_vars_expr acc e2
     | Mir.Conditional (e1, e2, e3) ->
-        Mir.LocalVariableMap.union
-          (fun _ _ _ -> Some ())
-          (Mir.LocalVariableMap.union
-             (fun _ _ _ -> Some ())
-             (get_local_vars_expr e1) (get_local_vars_expr e2))
-          (get_local_vars_expr e3)
+        let acc = get_local_vars_expr acc e1 in
+        let acc = get_local_vars_expr acc e2 in
+        get_local_vars_expr acc e3
     | Mir.FunctionCall (_, args) ->
         List.fold_left
-          (fun (acc : unit Mir.LocalVariableMap.t) arg ->
-            Mir.LocalVariableMap.union (fun _ _ _ -> Some ()) (get_local_vars_expr arg) acc)
-          Mir.LocalVariableMap.empty args
-    | Mir.Literal _ | Mir.Var _ | Mir.GenericTableIndex | Mir.Error -> Mir.LocalVariableMap.empty
-    | Mir.LocalVar lvar -> Mir.LocalVariableMap.singleton lvar ()
+          (fun (acc : unit Mir.LocalVariableMap.t) arg -> get_local_vars_expr acc arg)
+          acc args
+    | Mir.Literal _ | Mir.Var _ | Mir.GenericTableIndex | Mir.Error -> acc
+    | Mir.LocalVar lvar -> Mir.LocalVariableMap.add lvar () acc
     | Mir.LocalLet (lvar, e1, e2) ->
-        Mir.LocalVariableMap.add lvar ()
-          (Mir.LocalVariableMap.union
-             (fun _ _ _ -> Some ())
-             (get_local_vars_expr e1) (get_local_vars_expr e2))
+        let acc = get_local_vars_expr acc e1 in
+        let acc = get_local_vars_expr acc e2 in
+        Mir.LocalVariableMap.add lvar () acc
   in
-  let rec get_local_vars_block (stmts : stmt list) : unit Mir.LocalVariableMap.t =
+  let rec get_local_vars_block acc (stmts : stmt list) : unit Mir.LocalVariableMap.t =
     List.fold_left
       (fun acc stmt ->
         match Pos.unmark stmt with
-        | SVerif cond ->
-            Mir.LocalVariableMap.union
-              (fun _ _ _ -> Some ())
-              (get_local_vars_expr cond.Mir.cond_expr)
-              acc
+        | SVerif cond -> get_local_vars_expr acc cond.Mir.cond_expr
         | SAssign (_, data) -> (
             match data.Mir.var_definition with
-            | Mir.SimpleVar e ->
-                Mir.LocalVariableMap.union (fun _ _ _ -> Some ()) (get_local_vars_expr e) acc
+            | Mir.SimpleVar e -> get_local_vars_expr acc e
             | Mir.TableVar (_, defs) -> (
                 match defs with
                 | Mir.IndexTable es ->
-                    Mir.IndexMap.fold
-                      (fun _ e acc ->
-                        Mir.LocalVariableMap.union
-                          (fun _ _ _ -> Some ())
-                          (get_local_vars_expr e) acc)
-                      es acc
-                | Mir.IndexGeneric e ->
-                    Mir.LocalVariableMap.union (fun _ _ _ -> Some ()) (get_local_vars_expr e) acc)
+                    Mir.IndexMap.fold (fun _ e acc -> get_local_vars_expr acc e) es acc
+                | Mir.IndexGeneric e -> get_local_vars_expr acc e)
             | _ -> acc)
         | SConditional (cond, s1, s2) ->
-            Mir.LocalVariableMap.union
-              (fun _ _ _ -> Some ())
-              acc
-              (Mir.LocalVariableMap.union
-                 (fun _ _ _ -> Some ())
-                 (get_local_vars_expr (cond, Pos.no_pos))
-                 (Mir.LocalVariableMap.union
-                    (fun _ _ _ -> Some ())
-                    (get_local_vars_block s1) (get_local_vars_block s2))))
-      Mir.LocalVariableMap.empty stmts
+            let acc = get_local_vars_expr acc (cond, Pos.no_pos) in
+            let acc = get_local_vars_block acc s1 in
+            get_local_vars_block acc s2
+        | SRuleCall _ -> assert false)
+      acc stmts
   in
-  get_local_vars_block p.statements
+  get_local_vars_block Mir.LocalVariableMap.empty (get_all_statements p)
 
 let rec remove_empty_conditionals (stmts : stmt list) : stmt list =
   List.rev

--- a/src/mlang/backend_ir/bir_instrumentation.ml
+++ b/src/mlang/backend_ir/bir_instrumentation.ml
@@ -102,6 +102,7 @@ let rec get_code_locs_stmt (stmt : Bir.stmt) (loc : Bir_interpreter.code_locatio
         (get_code_locs_stmts f (Bir_interpreter.ConditionalBranch false :: loc))
   | Bir.SVerif _ -> CodeLocationMap.empty
   | Bir.SAssign (var, _) -> CodeLocationMap.singleton loc var
+  | Bir.SRuleCall _ -> CodeLocationMap.empty
 
 and get_code_locs_stmts (stmts : Bir.stmt list) (loc : Bir_interpreter.code_location) : code_locs =
   let locs, _ =
@@ -116,4 +117,6 @@ and get_code_locs_stmts (stmts : Bir.stmt list) (loc : Bir_interpreter.code_loca
   in
   locs
 
-let get_code_locs (p : Bir.program) : code_locs = get_code_locs_stmts p.statements []
+let get_code_locs (p : Bir.program) : code_locs =
+  let statements = Bir.get_all_statements p in
+  get_code_locs_stmts statements []

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -524,6 +524,9 @@ module Make (N : Bir_number.NumberInterface) = struct
         match evaluate_expr ctx p.mir_program data.cond_expr with
         | Number f when not (N.is_zero f) -> report_violatedcondition data ctx
         | _ -> ctx)
+    | Bir.SRuleCall _ ->
+        (* removed with [Bir.get_all_statements] below *)
+        assert false
 
   and evaluate_stmts (p : Bir.program) (ctx : ctx) (stmts : Bir.stmt list) (loc : code_location)
       (start_value : int) : ctx =
@@ -536,7 +539,8 @@ module Make (N : Bir_number.NumberInterface) = struct
 
   let evaluate_program (p : Bir.program) (ctx : ctx) (code_loc_start_value : int) : ctx =
     try
-      let ctx = evaluate_stmts p ctx p.statements [] code_loc_start_value in
+      let statements = Bir.get_all_statements p in
+      let ctx = evaluate_stmts p ctx statements [] code_loc_start_value in
       ctx
     with RuntimeError (e, ctx) ->
       if !exit_on_rte then raise_runtime_as_structured e ctx p.mir_program

--- a/src/mlang/backend_ir/format_bir.ml
+++ b/src/mlang/backend_ir/format_bir.ml
@@ -30,8 +30,19 @@ let rec format_stmt fmt (stmt : stmt) =
         (Pos.unmark cond_data.cond_expr)
         (Format_mast.pp_print_list_comma Format_mir.format_error)
         cond_data.cond_errors
+  | SRuleCall r -> Format.fprintf fmt "call_rule(%d)@\n" r
 
 and format_stmts fmt (stmts : stmt list) =
   Format.pp_print_list ~pp_sep:(fun _ () -> ()) format_stmt fmt stmts
 
-let format_program fmt (p : program) = Format.fprintf fmt "%a" format_stmts p.statements
+let format_rule fmt rule =
+  Format.fprintf fmt "rule %d:@\n@[<h 2>  %a@]@\n" rule.rule_id format_stmts rule.rule_stmts
+
+let format_rules fmt rules =
+  Format.pp_print_list
+    ~pp_sep:(fun _ () -> ())
+    format_rule fmt
+    (Bir.RuleMap.bindings rules |> List.map snd)
+
+let format_program fmt (p : program) =
+  Format.fprintf fmt "%a%a" format_rules p.rules format_stmts p.statements

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -175,6 +175,8 @@ module VariableMap = struct
       map
 end
 
+module VariableSet = Set.Make (Variable)
+
 module LocalVariableMap = struct
   include Map.Make (LocalVariable)
 
@@ -243,6 +245,23 @@ type variable_data = {
       name = "variable_data_iter";
     }]
 
+type rule_id = int
+
+let fresh_rule_id =
+  let count = ref 0 in
+  fun () ->
+    let n = !count in
+    incr count;
+    n
+
+type rule_data = { rule_vars : Variable.t list; rule_name : Mast.rule_name }
+
+module RuleMap = Map.Make (struct
+  type t = rule_id
+
+  let compare = compare
+end)
+
 (**{1 Verification conditions}*)
 
 (** Errors are first-class objects *)
@@ -287,6 +306,7 @@ type exec_pass = { exec_pass_set_variables : literal Pos.marked VariableMap.t }
 
 type program = {
   program_vars : variable_data VariableMap.t;
+  program_rules : rule_data RuleMap.t;
   program_conds : condition_data VariableMap.t;  (** Conditions are affected to dummy variables *)
   program_idmap : idmap;
   program_exec_passes : exec_pass list;

--- a/src/mlang/m_ir/mir_interface.ml
+++ b/src/mlang/m_ir/mir_interface.ml
@@ -51,10 +51,43 @@ let reset_all_outputs (p : program) : program =
 
 type full_program = {
   dep_graph : Mir_dependency_graph.G.t;
-  execution_order : Mir_dependency_graph.execution_order;
+  main_execution_order : Mir.rule_id list;
+  rules_execution_order : Mir_dependency_graph.execution_order Mir.RuleMap.t;
+  vars_execution_order : Mir_dependency_graph.execution_order;
   program : Mir.program;
 }
 
 let to_full_program (program : program) : full_program =
-  let dep_graph = Mir_dependency_graph.create_dependency_graph program in
-  { program; dep_graph; execution_order = Mir_dependency_graph.get_execution_order dep_graph }
+  let dep_graph = Mir_dependency_graph.create_program_dependency_graph program in
+  let vars_to_rules, rules_execution_order =
+    Mir.RuleMap.fold
+      (fun rule_id { rule_vars; _ } (conv, orders) ->
+        let conv =
+          List.fold_left (fun conv var -> VariableMap.add var rule_id conv) conv rule_vars
+        in
+        let orders =
+          let vars =
+            List.fold_left
+              (fun vars var -> VariableMap.add var (VariableMap.find var program.program_vars) vars)
+              VariableMap.empty rule_vars
+          in
+          let order =
+            Mir_dependency_graph.create_vars_dependency_graph vars
+            |> Mir_dependency_graph.get_execution_order
+          in
+          Mir.RuleMap.add rule_id order orders
+        in
+        (conv, orders))
+      program.program_rules
+      (VariableMap.empty, Mir.RuleMap.empty)
+  in
+  let main_execution_order =
+    Mir_dependency_graph.create_rules_dependency_graph program vars_to_rules dep_graph
+    |> Mir_dependency_graph.get_rules_execution_order
+  in
+  let vars_execution_order =
+    List.concat_map
+      (fun rule_id -> Mir.RuleMap.find rule_id rules_execution_order)
+      main_execution_order
+  in
+  { program; dep_graph; main_execution_order; rules_execution_order; vars_execution_order }

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -11,10 +11,31 @@ end)
 type translation_ctx = {
   new_variables : Mir.Variable.t StringMap.t;
   variables_used_as_inputs : unit Mir.VariableMap.t;
+  rule_instances : Bir.rule Bir.RuleMap.t;
 }
 
 let emtpy_translation_ctx : translation_ctx =
-  { new_variables = StringMap.empty; variables_used_as_inputs = Mir.VariableMap.empty }
+  {
+    new_variables = StringMap.empty;
+    variables_used_as_inputs = Mir.VariableMap.empty;
+    rule_instances = Bir.RuleMap.empty;
+  }
+
+let ctx_join ctx1 ctx2 =
+  {
+    new_variables =
+      (* CR keryan : I assume there shouldn't be conflict there, kept the behavior of
+         [translate_mpp_stmt:SConditional] just in case, which could erase [ctx1] by [ctx2] *)
+      StringMap.union (fun _ _ v2 -> Some v2) ctx1.new_variables ctx2.new_variables;
+    variables_used_as_inputs =
+      Mir.VariableMap.union
+        (fun _ _ _ -> Some ())
+        ctx1.variables_used_as_inputs ctx2.variables_used_as_inputs;
+    rule_instances =
+      Bir.RuleMap.union
+        (fun _ r1 _r2 -> (* if r1 = r2 then *) Some r1 (* else assert false *))
+        ctx1.rule_instances ctx2.rule_instances;
+  }
 
 let translate_to_binop (b : Mpp_ast.binop) : Mast.binop =
   match b with And -> And | Or -> Or | _ -> assert false
@@ -132,6 +153,123 @@ let reset_and_add_outputs (p : Mir_interface.full_program) (outputs : string Pos
   in
   { p with program }
 
+let translate_m_code (m_program : Mir_interface.full_program) execution_order =
+  list_map_opt
+    (fun var ->
+      try
+        let vdef = Mir.VariableMap.find var m_program.program.program_vars in
+        match vdef.var_definition with
+        | InputVar -> None
+        | _ ->
+            (* variables used in the context should not be reassigned *)
+            Some (Bir.SAssign (var, vdef), var.Mir.Variable.execution_number.pos)
+      with Not_found -> None)
+    execution_order
+
+(* let generate_rule_instance (m_program : Mir_interface.full_program) (rule_id : Mir.rule_id)
+ *     (rule_stmts : Bir.stmt list) (ctx : translation_ctx)
+ *   : Mir.rule_id * Pos.t * translation_ctx =
+ *   Printf.eprintf "generate_instance \n%!";
+ *   let instance_id = Mir.fresh_rule_id () in
+ *   let rule = Mir.RuleMap.find rule_id m_program.program.program_rules in
+ *   let pos, rule_name =
+ *     let pos = List.hd rule.Mir.rule_name |> Pos.get_position in
+ *     let name = List.map Pos.unmark rule.Mir.rule_name |> String.concat "_" in
+ *     (pos, name ^ "_i" ^ string_of_int instance_id)
+ *   in
+ *   let instance = Bir.{ rule_id = instance_id; rule_name; rule_stmts } in
+ *   ( instance_id,
+ *     pos,
+ *     { ctx with rule_instances = Bir.RuleMap.add instance_id instance ctx.rule_instances } ) *)
+
+let generate_rule_instance (m_program : Mir_interface.full_program) (rule_id : Mir.rule_id)
+    (ctx : translation_ctx) : Mir.rule_id * Pos.t * translation_ctx =
+  let instance_id = Mir.fresh_rule_id () in
+  let rule = Mir.RuleMap.find rule_id m_program.program.program_rules in
+  let exec_order = Mir.RuleMap.find rule_id m_program.rules_execution_order in
+  let rule_stmts = translate_m_code m_program exec_order in
+  let pos, rule_name =
+    let pos = List.hd rule.Mir.rule_name |> Pos.get_position in
+    let name = List.map Pos.unmark rule.Mir.rule_name |> String.concat "_" in
+    (pos, name ^ "_i" ^ string_of_int instance_id)
+  in
+  let instance = Bir.{ rule_id = instance_id; rule_name; rule_stmts } in
+  ( instance_id,
+    pos,
+    { ctx with rule_instances = Bir.RuleMap.add instance_id instance ctx.rule_instances } )
+
+let wrap_m_code_call (m_program : Mir_interface.full_program) execution_order
+    (defined_vars : Mir.Variable.t list) (args : Mpp_ir.scoped_var list) (ctx : translation_ctx) :
+    translation_ctx * Bir.stmt list =
+  let m_program =
+    reset_and_add_outputs m_program
+      (List.map
+         (function Mpp_ir.Mbased (s, _) -> s.Mir.Variable.name | Local l -> (l, Pos.no_pos))
+         args)
+  in
+  let m_program =
+    {
+      m_program with
+      program =
+        Bir_interpreter.RegularFloatInterpreter.replace_undefined_with_input_variables
+          m_program.program
+          (Mir.VariableMap.map (fun () -> Mir.Undefined) ctx.variables_used_as_inputs);
+    }
+  in
+  (* let rules_stmts =
+   *   List.map (fun rule_id ->
+   *       let exec_order = Mir.RuleMap.find rule_id m_program.rules_execution_order in
+   *       Printf.eprintf "before_translate \n%!";
+   *       let rule_stmts = translate_m_code m_program exec_order in
+   *       Printf.eprintf "after_translate \n%!";
+   *       (rule_id, rule_stmts))
+   *     execution_order
+   * in
+   * let ctx, program_stmts =
+   *   List.fold_left_map
+   *     (fun ctx (rule_id, rule_stmts) ->
+   *       let instance_id, pos, ctx =
+   *         generate_rule_instance m_program rule_id rule_stmts ctx
+   *       in
+   *       (ctx, (Bir.SRuleCall instance_id, pos)))
+   *     ctx rules_stmts
+   * in *)
+  let program_stmts, ctx =
+    List.fold_left
+      (fun (stmts, ctx) rule_id ->
+        let instance_id, pos, ctx = generate_rule_instance m_program rule_id ctx in
+        ((Bir.SRuleCall instance_id, pos) :: stmts, ctx))
+      ([], ctx) execution_order
+  in
+  let program_stmts = List.rev program_stmts in
+  let clean_state =
+    (* no cleaning or no arguments: we may want anything afterwards, so no cleaning *)
+    if (not !Cli.m_clean_calls) || args = [] then []
+    else
+      list_map_opt
+        (fun var ->
+          try
+            let vdef = Mir.VariableMap.find var m_program.program.program_vars in
+            match (vdef.var_definition, vdef.var_io) with
+            | InputVar, _ -> None
+            | _, Regular ->
+                let pos = var.Mir.Variable.execution_number.pos in
+                Some
+                  ( Bir.SAssign
+                      ( var,
+                        {
+                          var_definition = SimpleVar (Mir.Literal Undefined, pos);
+                          var_typ = vdef.var_typ;
+                          var_io = vdef.var_io;
+                        } ),
+                    pos )
+            | _ -> None
+          with Not_found -> None)
+        defined_vars
+  in
+  Cli.var_info_print "|clean_state| += %d" (List.length clean_state);
+  (ctx, program_stmts @ clean_state)
+
 let rec translate_mpp_function (mpp_program : Mpp_ir.mpp_compute list)
     (m_program : Mir_interface.full_program) (compute_decl : Mpp_ir.mpp_compute)
     (args : Mpp_ir.scoped_var list) (ctx : translation_ctx) : translation_ctx * Bir.stmt list =
@@ -233,19 +371,8 @@ and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
   | Mpp_ir.Conditional (e, t, f) ->
       let e' = translate_mpp_expr m_program ctx e in
       let ctx1, rt' = translate_mpp_stmts mpp_program m_program func_args ctx t in
-      let ctx2, rf' =
-        translate_mpp_stmts mpp_program m_program func_args
-          { ctx with new_variables = ctx1.new_variables }
-          f
-      in
-      ( {
-          ctx2 with
-          variables_used_as_inputs =
-            Mir.VariableMap.union
-              (fun _ _ _ -> Some ())
-              ctx1.variables_used_as_inputs ctx2.variables_used_as_inputs;
-        },
-        [ Pos.same_pos_as (Bir.SConditional (e', rt', rf')) stmt ] )
+      let ctx2, rf' = translate_mpp_stmts mpp_program m_program func_args ctx f in
+      (ctx_join ctx1 ctx2, [ Pos.same_pos_as (Bir.SConditional (e', rt', rf')) stmt ])
   | Mpp_ir.Delete (Mbased (var, _)) ->
       ( ctx,
         [
@@ -280,62 +407,8 @@ and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
         real_args ctx
   | Mpp_ir.Expr (Call (Program, args), _) ->
       let real_args = match args with [ Mpp_ir.Local "outputs" ] -> func_args | _ -> args in
-      let m_program =
-        reset_and_add_outputs m_program
-          (List.map
-             (function Mpp_ir.Mbased (s, _) -> s.Mir.Variable.name | Local l -> (l, Pos.no_pos))
-             real_args)
-      in
-      let m_program =
-        {
-          m_program with
-          program =
-            Bir_interpreter.RegularFloatInterpreter.replace_undefined_with_input_variables
-              m_program.program
-              (Mir.VariableMap.map (fun () -> Mir.Undefined) ctx.variables_used_as_inputs);
-        }
-      in
-      let exec_order = m_program.execution_order in
-      let inlined_program =
-        list_map_opt
-          (fun var ->
-            try
-              let vdef = Mir.VariableMap.find var m_program.program.program_vars in
-              match vdef.var_definition with
-              | InputVar -> None
-              | _ ->
-                  (* variables used in the context should not be reassigned *)
-                  Some (Bir.SAssign (var, vdef), var.Mir.Variable.execution_number.pos)
-            with Not_found -> None)
-          exec_order
-      in
-      let clean_state =
-        (* no cleaning or no arguments: we may want anything afterwards, so no cleaning *)
-        if (not !Cli.m_clean_calls) || real_args = [] then []
-        else
-          list_map_opt
-            (fun var ->
-              try
-                let vdef = Mir.VariableMap.find var m_program.program.program_vars in
-                match (vdef.var_definition, vdef.var_io) with
-                | InputVar, _ -> None
-                | _, Regular ->
-                    let pos = var.Mir.Variable.execution_number.pos in
-                    Some
-                      ( Bir.SAssign
-                          ( var,
-                            {
-                              var_definition = SimpleVar (Mir.Literal Undefined, pos);
-                              var_typ = vdef.var_typ;
-                              var_io = vdef.var_io;
-                            } ),
-                        pos )
-                | _ -> None
-              with Not_found -> None)
-            exec_order
-      in
-      Cli.var_info_print "|clean_state| += %d" (List.length clean_state);
-      (ctx, inlined_program @ clean_state)
+      let exec_order = m_program.main_execution_order in
+      wrap_m_code_call m_program exec_order m_program.vars_execution_order real_args ctx
   | Mpp_ir.Partition (filter, body) ->
       let func_of_filter = match filter with Mpp_ir.VarIsTaxBenefit -> var_is_ "avfisc" in
       let ctx, partition_pre, partition_post =
@@ -361,18 +434,17 @@ and generate_partition mpp_program m_program func_args (filter : Mir.Variable.t 
       (fun var _ acc -> if filter var then var :: acc else acc)
       m_program.program.program_vars []
   in
-  let ctx, mpp_pre, mpp_post =
+  let mpp_pre, mpp_post =
     List.fold_left
-      (fun (ctx, stmts_pre, stmts_post) var ->
+      (fun (stmts_pre, stmts_post) var ->
         let shadow_var_name = "_" ^ Pos.unmark var.Mir.Variable.name in
         let open Mpp_ir in
         let shadow_var = Local shadow_var_name in
         let var = Mbased (var, Output) in
-        ( ctx,
-          (Assign (shadow_var, (Variable var, pos)), pos) :: (Delete var, pos) :: stmts_pre,
+        ( (Assign (shadow_var, (Variable var, pos)), pos) :: (Delete var, pos) :: stmts_pre,
           (Assign (var, (Variable shadow_var, pos)), pos) :: (Delete shadow_var, pos) :: stmts_post
         ))
-      (ctx, [], []) vars_to_move
+      ([], []) vars_to_move
   in
   let ctx, pre = translate_mpp_stmts mpp_program m_program func_args ctx mpp_pre in
   let ctx, post = translate_mpp_stmts mpp_program m_program func_args ctx mpp_post in
@@ -398,15 +470,29 @@ let create_combined_program (m_program : Mir_interface.full_program)
         Errors.raise_error
           (Format.asprintf "M++ function %s not found in M++ file!" mpp_function_to_extract)
     in
-    let stmts =
-      snd @@ translate_mpp_function mpp_program m_program decl_to_extract [] emtpy_translation_ctx
+    let ctx, statements =
+      translate_mpp_function mpp_program m_program decl_to_extract [] emtpy_translation_ctx
     in
-    let stmts_verif =
-      generate_verif_conds m_program.execution_order m_program.program.program_conds
+    let conds_verif =
+      generate_verif_conds m_program.vars_execution_order m_program.program.program_conds
     in
-
+    (* let rules =
+     *   Bir.RuleMap.fold
+     *     (fun instance_id rule_id rules ->
+     *       let rule = Mir.RuleMap.find rule_id m_program.program.program_rules in
+     *       let exec_order = Mir.RuleMap.find rule_id m_program.rules_execution_order in
+     *       let rule_stmts = translate_m_code m_program exec_order in
+     *       let rule_name =
+     *         let name = List.map Pos.unmark rule.Mir.rule_name |> String.concat "_" in
+     *         name ^ "_i" ^ string_of_int instance_id
+     *       in
+     *       let rule = Bir.{ rule_id = instance_id; rule_name; rule_stmts } in
+     *       Bir.RuleMap.add instance_id rule rules)
+     *     ctx.rule_instances Bir.RuleMap.empty
+     * in *)
     {
-      statements = stmts @ stmts_verif;
+      rules = ctx.rule_instances;
+      statements = statements @ conds_verif;
       (* we append the M verification conditions at the end, when everything has already been
          computed *)
       idmap = m_program.program.program_idmap;

--- a/src/mlang/test_framework/test_interpreter.ml
+++ b/src/mlang/test_framework/test_interpreter.ml
@@ -100,7 +100,7 @@ let add_test_conds_to_combined_program (p : Bir.program) (conds : condition_data
     Bir.program =
   (* because evaluate_program redefines everything each time, we have to make sure that the
      redefinitions of our constant inputs are removed from the main list of statements *)
-  let new_stmts =
+  let filter_stmts stmts =
     List.filter_map
       (fun stmt ->
         match Pos.unmark stmt with
@@ -120,8 +120,9 @@ let add_test_conds_to_combined_program (p : Bir.program) (conds : condition_data
             | InputVar -> None
             | _ -> Some (Pos.same_pos_as (Bir.SAssign (var, new_var_data)) stmt))
         | _ -> Some stmt)
-      p.Bir.statements
+      stmts
   in
+  let new_stmts = filter_stmts p.Bir.statements in
   let conditions_stmts =
     VariableMap.fold
       (fun _ cond stmts -> (Bir.SVerif cond, Pos.get_position cond.cond_expr) :: stmts)


### PR DESCRIPTION
This addresses issue #26.

For now it only applies to unoptimized compilation pipeline, and only changes the C backend.

For a reason yet unknown, it decreases efficiency and performance of the optimisations passes (yes, even without actually changing things). I hope a review could give some insight on this.