### PR TITLE
Split M code in rules

### DIFF
--- a/src/mlang/backend_compilers/bir_to_c.ml
+++ b/src/mlang/backend_compilers/bir_to_c.ml
@@ -259,7 +259,9 @@ let generate_main_function_signature (oc : Format.formatter) (add_semicolon : bo
 let get_variables_indexes (p : Bir.program) (function_spec : Bir_interface.bir_function) :
     int Mir.VariableMap.t * int =
   let input_vars = List.map fst (VariableMap.bindings function_spec.func_variable_inputs) in
-  let assigned_variables = List.map fst (Mir.VariableMap.bindings (Bir.get_assigned_variables p)) in
+  let assigned_variables =
+    List.map snd (Mir.VariableDict.bindings (Bir.get_assigned_variables p))
+  in
   let output_vars = List.map fst (VariableMap.bindings function_spec.func_outputs) in
   let all_relevant_variables =
     List.fold_left
@@ -330,7 +332,7 @@ let generate_header (oc : Format.formatter) () : unit =
   Format.fprintf oc "#include <stdio.h>\n";
   Format.fprintf oc "#include \"m_value.h\"\n\n"
 
-let generate_footer (oc: Format.formatter) () : unit =
+let generate_footer (oc : Format.formatter) () : unit =
   Format.fprintf oc "\n#endif /* IR_HEADER_ */"
 
 let generate_empty_input_prototype (oc : Format.formatter) (add_semicolon : bool) =
@@ -516,8 +518,7 @@ let generate_c_program (program : Bir.program) (function_spec : Bir_interface.bi
   let _oc = open_out header_filename in
   let var_indexes, var_table_size = get_variables_indexes program function_spec in
   let oc = Format.formatter_of_out_channel _oc in
-  Format.fprintf oc "%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a" 
-    generate_header () generate_input_type
+  Format.fprintf oc "%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a" generate_header () generate_input_type
     function_spec generate_empty_input_prototype true generate_input_from_array_prototype true
     generate_get_input_index_prototype true generate_get_input_num_prototype true
     generate_get_input_name_from_index_prototype true generate_output_type function_spec

--- a/src/mlang/backend_compilers/bir_to_python.ml
+++ b/src/mlang/backend_compilers/bir_to_python.ml
@@ -358,6 +358,8 @@ and generate_stmt program oc stmt =
         cond_name (generate_python_expr false) (Pos.same_pos_as cond stmt) cond_name cond_name
         (generate_stmts program) tt cond_name (generate_stmts program) ff
   | SVerif v -> generate_var_cond v oc
+  | SRuleCall _ -> assert false
+(* Removed with [Bir.get_all_statements] below *)
 
 let generate_return oc (function_spec : Bir_interface.bir_function) =
   let returned_variables = List.map fst (VariableMap.bindings function_spec.func_outputs) in
@@ -382,5 +384,5 @@ let generate_python_program (program : Bir.program) (function_spec : Bir_interfa
   let _oc = open_out filename in
   let oc = Format.formatter_of_out_channel _oc in
   Format.fprintf oc "%a%a%a%a" generate_header () generate_input_handling function_spec
-    (generate_stmts program) program.statements generate_return function_spec;
+    (generate_stmts program) (Bir.get_all_statements program) generate_return function_spec;
   close_out _oc

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -34,12 +34,13 @@ type program = {
   outputs : unit Mir.VariableMap.t;
 }
 
-let get_all_statements program =
+(** Returns program statements with all rules inlined *)
+let get_all_statements (p : program) : stmt list =
   let rec get_block_statements stmts =
     List.fold_left
       (fun stmts stmt ->
         match Pos.unmark stmt with
-        | SRuleCall r -> List.rev (RuleMap.find r program.rules).rule_stmts @ stmts
+        | SRuleCall r -> List.rev (RuleMap.find r p.rules).rule_stmts @ stmts
         | SConditional (e, t, f) ->
             let t = get_block_statements t in
             let f = get_block_statements f in
@@ -48,7 +49,7 @@ let get_all_statements program =
       [] stmts
     |> List.rev
   in
-  get_block_statements program.statements
+  get_block_statements p.statements
 
 let count_instructions (p : program) : int =
   let rec cond_instr_blocks (stmts : stmt list) : int =

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -12,13 +12,9 @@
    You should have received a copy of the GNU General Public License along with this program. If
    not, see <https://www.gnu.org/licenses/>. *)
 
-type rule_id = int
+type rule_id = Mir.rule_id
 
-module RuleMap = Map.Make (struct
-  type t = rule_id
-
-  let compare = compare
-end)
+module RuleMap = Mir.RuleMap
 
 type rule = { rule_id : rule_id; rule_name : string; rule_stmts : stmt list }
 
@@ -65,20 +61,20 @@ let count_instructions (p : program) : int =
   in
   cond_instr_blocks p.statements
 
-let get_assigned_variables (p : program) : unit Mir.VariableMap.t =
-  let rec get_assigned_variables_block acc (stmts : stmt list) : unit Mir.VariableMap.t =
+let get_assigned_variables (p : program) : Mir.VariableDict.t =
+  let rec get_assigned_variables_block acc (stmts : stmt list) : Mir.VariableDict.t =
     List.fold_left
       (fun acc stmt ->
         match Pos.unmark stmt with
         | SVerif _ -> acc
-        | SAssign (var, _) -> Mir.VariableMap.add var () acc
+        | SAssign (var, _) -> Mir.VariableDict.add var acc
         | SConditional (_, s1, s2) ->
             let acc = get_assigned_variables_block acc s1 in
             get_assigned_variables_block acc s2
         | SRuleCall _ -> assert false)
       acc stmts
   in
-  get_assigned_variables_block Mir.VariableMap.empty (get_all_statements p)
+  get_assigned_variables_block Mir.VariableDict.empty (get_all_statements p)
 
 let get_local_variables (p : program) : unit Mir.LocalVariableMap.t =
   let rec get_local_vars_expr acc (e : Mir.expression Pos.marked) : unit Mir.LocalVariableMap.t =

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -12,115 +12,118 @@
    You should have received a copy of the GNU General Public License along with this program. If
    not, see <https://www.gnu.org/licenses/>. *)
 
-type stmt = stmt_kind Pos.marked
+type rule_id = int
+
+module RuleMap = Map.Make (struct
+  type t = rule_id
+
+  let compare = compare
+end)
+
+type rule = { rule_id : rule_id; rule_name : string; rule_stmts : stmt list }
+
+and stmt = stmt_kind Pos.marked
 
 and stmt_kind =
   | SAssign of Mir.Variable.t * Mir.variable_data
   | SConditional of Mir.expression * stmt list * stmt list
   | SVerif of Mir.condition_data
+  | SRuleCall of rule_id
 
 type program = {
+  rules : rule RuleMap.t;
   statements : stmt list;
   idmap : Mir.idmap;
   mir_program : Mir.program;
   outputs : unit Mir.VariableMap.t;
 }
 
+let get_all_statements program =
+  let rec get_block_statements stmts =
+    List.fold_left
+      (fun stmts stmt ->
+        match Pos.unmark stmt with
+        | SRuleCall r -> List.rev (RuleMap.find r program.rules).rule_stmts @ stmts
+        | SConditional (e, t, f) ->
+            let t = get_block_statements t in
+            let f = get_block_statements f in
+            Pos.same_pos_as (SConditional (e, t, f)) stmt :: stmts
+        | _ -> stmt :: stmts)
+      [] stmts
+    |> List.rev
+  in
+  get_block_statements program.statements
+
 let count_instructions (p : program) : int =
   let rec cond_instr_blocks (stmts : stmt list) : int =
     List.fold_left
       (fun acc stmt ->
         match Pos.unmark stmt with
-        | SAssign _ | SVerif _ -> acc + 1
+        | SAssign _ | SVerif _ | SRuleCall _ -> acc + 1
         | SConditional (_, s1, s2) -> acc + 1 + cond_instr_blocks s1 + cond_instr_blocks s2)
       0 stmts
   in
   cond_instr_blocks p.statements
 
 let get_assigned_variables (p : program) : unit Mir.VariableMap.t =
-  let rec get_assigned_variables_block (stmts : stmt list) : unit Mir.VariableMap.t =
+  let rec get_assigned_variables_block acc (stmts : stmt list) : unit Mir.VariableMap.t =
     List.fold_left
       (fun acc stmt ->
         match Pos.unmark stmt with
         | SVerif _ -> acc
         | SAssign (var, _) -> Mir.VariableMap.add var () acc
         | SConditional (_, s1, s2) ->
-            Mir.VariableMap.union
-              (fun _ _ _ -> Some ())
-              acc
-              (Mir.VariableMap.union
-                 (fun _ _ _ -> Some ())
-                 (get_assigned_variables_block s1) (get_assigned_variables_block s2)))
-      Mir.VariableMap.empty stmts
+            let acc = get_assigned_variables_block acc s1 in
+            get_assigned_variables_block acc s2
+        | SRuleCall _ -> assert false)
+      acc stmts
   in
-  get_assigned_variables_block p.statements
+  get_assigned_variables_block Mir.VariableMap.empty (get_all_statements p)
 
 let get_local_variables (p : program) : unit Mir.LocalVariableMap.t =
-  let rec get_local_vars_expr (e : Mir.expression Pos.marked) : unit Mir.LocalVariableMap.t =
+  let rec get_local_vars_expr acc (e : Mir.expression Pos.marked) : unit Mir.LocalVariableMap.t =
     match Pos.unmark e with
-    | Mir.Unop (_, e) | Mir.Index (_, e) -> get_local_vars_expr e
+    | Mir.Unop (_, e) | Mir.Index (_, e) -> get_local_vars_expr acc e
     | Mir.Comparison (_, e1, e2) | Mir.Binop (_, e1, e2) ->
-        Mir.LocalVariableMap.union
-          (fun _ _ _ -> Some ())
-          (get_local_vars_expr e1) (get_local_vars_expr e2)
+        let acc = get_local_vars_expr acc e1 in
+        get_local_vars_expr acc e2
     | Mir.Conditional (e1, e2, e3) ->
-        Mir.LocalVariableMap.union
-          (fun _ _ _ -> Some ())
-          (Mir.LocalVariableMap.union
-             (fun _ _ _ -> Some ())
-             (get_local_vars_expr e1) (get_local_vars_expr e2))
-          (get_local_vars_expr e3)
+        let acc = get_local_vars_expr acc e1 in
+        let acc = get_local_vars_expr acc e2 in
+        get_local_vars_expr acc e3
     | Mir.FunctionCall (_, args) ->
         List.fold_left
-          (fun (acc : unit Mir.LocalVariableMap.t) arg ->
-            Mir.LocalVariableMap.union (fun _ _ _ -> Some ()) (get_local_vars_expr arg) acc)
-          Mir.LocalVariableMap.empty args
-    | Mir.Literal _ | Mir.Var _ | Mir.GenericTableIndex | Mir.Error -> Mir.LocalVariableMap.empty
-    | Mir.LocalVar lvar -> Mir.LocalVariableMap.singleton lvar ()
+          (fun (acc : unit Mir.LocalVariableMap.t) arg -> get_local_vars_expr acc arg)
+          acc args
+    | Mir.Literal _ | Mir.Var _ | Mir.GenericTableIndex | Mir.Error -> acc
+    | Mir.LocalVar lvar -> Mir.LocalVariableMap.add lvar () acc
     | Mir.LocalLet (lvar, e1, e2) ->
-        Mir.LocalVariableMap.add lvar ()
-          (Mir.LocalVariableMap.union
-             (fun _ _ _ -> Some ())
-             (get_local_vars_expr e1) (get_local_vars_expr e2))
+        let acc = get_local_vars_expr acc e1 in
+        let acc = get_local_vars_expr acc e2 in
+        Mir.LocalVariableMap.add lvar () acc
   in
-  let rec get_local_vars_block (stmts : stmt list) : unit Mir.LocalVariableMap.t =
+  let rec get_local_vars_block acc (stmts : stmt list) : unit Mir.LocalVariableMap.t =
     List.fold_left
       (fun acc stmt ->
         match Pos.unmark stmt with
-        | SVerif cond ->
-            Mir.LocalVariableMap.union
-              (fun _ _ _ -> Some ())
-              (get_local_vars_expr cond.Mir.cond_expr)
-              acc
+        | SVerif cond -> get_local_vars_expr acc cond.Mir.cond_expr
         | SAssign (_, data) -> (
             match data.Mir.var_definition with
-            | Mir.SimpleVar e ->
-                Mir.LocalVariableMap.union (fun _ _ _ -> Some ()) (get_local_vars_expr e) acc
+            | Mir.SimpleVar e -> get_local_vars_expr acc e
             | Mir.TableVar (_, defs) -> (
                 match defs with
                 | Mir.IndexTable es ->
-                    Mir.IndexMap.fold
-                      (fun _ e acc ->
-                        Mir.LocalVariableMap.union
-                          (fun _ _ _ -> Some ())
-                          (get_local_vars_expr e) acc)
-                      es acc
-                | Mir.IndexGeneric e ->
-                    Mir.LocalVariableMap.union (fun _ _ _ -> Some ()) (get_local_vars_expr e) acc)
+                    Mir.IndexMap.fold (fun _ e acc -> get_local_vars_expr acc e) es acc
+                | Mir.IndexGeneric e -> get_local_vars_expr acc e)
             | _ -> acc)
         | SConditional (cond, s1, s2) ->
-            Mir.LocalVariableMap.union
-              (fun _ _ _ -> Some ())
-              acc
-              (Mir.LocalVariableMap.union
-                 (fun _ _ _ -> Some ())
-                 (get_local_vars_expr (cond, Pos.no_pos))
-                 (Mir.LocalVariableMap.union
-                    (fun _ _ _ -> Some ())
-                    (get_local_vars_block s1) (get_local_vars_block s2))))
-      Mir.LocalVariableMap.empty stmts
+            let acc = get_local_vars_expr acc (cond, Pos.no_pos) in
+            let acc = get_local_vars_block acc s1 in
+            get_local_vars_block acc s2
+        | SRuleCall _ -> assert false)
+      acc stmts
   in
-  get_local_vars_block p.statements
+  get_local_vars_block Mir.LocalVariableMap.empty (get_all_statements p)
 
 let rec remove_empty_conditionals (stmts : stmt list) : stmt list =
   List.rev

--- a/src/mlang/backend_ir/bir_instrumentation.ml
+++ b/src/mlang/backend_ir/bir_instrumentation.ml
@@ -102,6 +102,7 @@ let rec get_code_locs_stmt (stmt : Bir.stmt) (loc : Bir_interpreter.code_locatio
         (get_code_locs_stmts f (Bir_interpreter.ConditionalBranch false :: loc))
   | Bir.SVerif _ -> CodeLocationMap.empty
   | Bir.SAssign (var, _) -> CodeLocationMap.singleton loc var
+  | Bir.SRuleCall _ -> CodeLocationMap.empty
 
 and get_code_locs_stmts (stmts : Bir.stmt list) (loc : Bir_interpreter.code_location) : code_locs =
   let locs, _ =
@@ -116,4 +117,6 @@ and get_code_locs_stmts (stmts : Bir.stmt list) (loc : Bir_interpreter.code_loca
   in
   locs
 
-let get_code_locs (p : Bir.program) : code_locs = get_code_locs_stmts p.statements []
+let get_code_locs (p : Bir.program) : code_locs =
+  let statements = Bir.get_all_statements p in
+  get_code_locs_stmts statements []

--- a/src/mlang/backend_ir/bir_interface.ml
+++ b/src/mlang/backend_ir/bir_interface.ml
@@ -181,7 +181,7 @@ let adapt_program_to_function (p : Bir.program) (f : bir_function) : Bir.program
       f.func_constant_inputs []
   in
   let unused_input_stmts =
-    Mir.VariableMap.fold
+    Mir.fold_vars
       (fun var def acc ->
         match def.Mir.var_definition with
         | Mir.InputVar ->
@@ -198,7 +198,7 @@ let adapt_program_to_function (p : Bir.program) (f : bir_function) : Bir.program
                 pos )
               :: acc
         | _ -> acc)
-      p.mir_program.program_vars []
+      p.mir_program []
   in
   let conds_stmts =
     Mir.VariableMap.fold

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -524,6 +524,9 @@ module Make (N : Bir_number.NumberInterface) = struct
         match evaluate_expr ctx p.mir_program data.cond_expr with
         | Number f when not (N.is_zero f) -> report_violatedcondition data ctx
         | _ -> ctx)
+    | Bir.SRuleCall _ ->
+        (* removed with [Bir.get_all_statements] below *)
+        assert false
 
   and evaluate_stmts (p : Bir.program) (ctx : ctx) (stmts : Bir.stmt list) (loc : code_location)
       (start_value : int) : ctx =
@@ -536,7 +539,8 @@ module Make (N : Bir_number.NumberInterface) = struct
 
   let evaluate_program (p : Bir.program) (ctx : ctx) (code_loc_start_value : int) : ctx =
     try
-      let ctx = evaluate_stmts p ctx p.statements [] code_loc_start_value in
+      let statements = Bir.get_all_statements p in
+      let ctx = evaluate_stmts p ctx statements [] code_loc_start_value in
       ctx
     with RuntimeError (e, ctx) ->
       if !exit_on_rte then raise_runtime_as_structured e ctx p.mir_program

--- a/src/mlang/backend_ir/format_bir.ml
+++ b/src/mlang/backend_ir/format_bir.ml
@@ -30,8 +30,19 @@ let rec format_stmt fmt (stmt : stmt) =
         (Pos.unmark cond_data.cond_expr)
         (Format_mast.pp_print_list_comma Format_mir.format_error)
         cond_data.cond_errors
+  | SRuleCall r -> Format.fprintf fmt "call_rule(%d)@\n" r
 
 and format_stmts fmt (stmts : stmt list) =
   Format.pp_print_list ~pp_sep:(fun _ () -> ()) format_stmt fmt stmts
 
-let format_program fmt (p : program) = Format.fprintf fmt "%a" format_stmts p.statements
+let format_rule fmt rule =
+  Format.fprintf fmt "rule %d:@\n@[<h 2>  %a@]@\n" rule.rule_id format_stmts rule.rule_stmts
+
+let format_rules fmt rules =
+  Format.pp_print_list
+    ~pp_sep:(fun _ () -> ())
+    format_rule fmt
+    (Bir.RuleMap.bindings rules |> List.map snd)
+
+let format_program fmt (p : program) =
+  Format.fprintf fmt "%a%a" format_rules p.rules format_stmts p.statements

--- a/src/mlang/m_frontend/mast_to_mvg.ml
+++ b/src/mlang/m_frontend/mast_to_mvg.ml
@@ -1055,147 +1055,142 @@ let add_var_def (var_data : Mir.variable_data Mir.VariableMap.t) (var_lvalue : M
     defined) and whose values are the expressions corresponding to the definitions. *)
 let get_rules_and_var_data (idmap : Mir.idmap) (var_decl_data : var_decl_data Mir.VariableMap.t)
     (int_const_vals : int Mir.VariableMap.t) (p : Mast.program) :
-    Mir.rule_data Mir.RuleMap.t * Mir.variable_data Mir.VariableMap.t =
-  let out =
-    List.fold_left
-      (fun (rule_data, var_data) source_file ->
-        List.fold_left
-          (fun (rule_data, var_data) source_file_item ->
-            match Pos.unmark source_file_item with
-            | Mast.Rule r ->
-                let rule_number = Mast.rule_number r.Mast.rule_name in
-                if not (belongs_to_iliad_app r.Mast.rule_applications) then (rule_data, var_data)
-                else
-                  let rule_vars, var_data, _ =
-                    List.fold_left
-                      (fun (rule_vars, var_data, seq_number) formula ->
-                        match Pos.unmark formula with
-                        | Mast.SingleFormula f ->
-                            let ctx =
-                              {
-                                idmap;
-                                lc = None;
-                                int_const_values = int_const_vals;
-                                table_definition = false;
-                                exec_number =
-                                  {
-                                    Mir.rule_number;
-                                    Mir.seq_number;
-                                    Mir.pos = Pos.get_position f.Mast.lvalue;
-                                  };
-                                current_lvalue =
-                                  "" (* dummy, will be filled by [translate_lvalue] *);
-                              }
-                            in
-                            let ctx, var_lvalue, def_kind = translate_lvalue ctx f.Mast.lvalue in
-                            let rule_vars = var_lvalue :: rule_vars in
-                            let var_expr = translate_expression ctx f.Mast.formula in
-                            let var_data =
-                              add_var_def var_data var_lvalue var_expr def_kind var_decl_data idmap
-                            in
-                            (rule_vars, var_data, seq_number + 1)
-                        | Mast.MultipleFormulaes (lvs, f) ->
-                            let ctx =
-                              {
-                                idmap;
-                                lc = None;
-                                int_const_values = int_const_vals;
-                                table_definition = false;
-                                exec_number =
-                                  {
-                                    Mir.rule_number;
-                                    Mir.seq_number;
-                                    Mir.pos = Pos.get_position f.Mast.lvalue;
-                                  };
-                                current_lvalue = "";
-                              }
-                            in
-                            let loop_context_provider = translate_loop_variables lvs ctx in
-                            let translator lc idx =
-                              let new_ctx =
+    (Mir.Variable.t list * Mast.rule_name) Mir.RuleMap.t * Mir.variable_data Mir.VariableMap.t =
+  List.fold_left
+    (fun (rule_data, var_data) source_file ->
+      List.fold_left
+        (fun (rule_data, var_data) source_file_item ->
+          match Pos.unmark source_file_item with
+          | Mast.Rule r ->
+              let rule_number = Mast.rule_number r.Mast.rule_name in
+              if not (belongs_to_iliad_app r.Mast.rule_applications) then (rule_data, var_data)
+              else
+                let rule_vars, var_data, _ =
+                  List.fold_left
+                    (fun (rule_vars, var_data, seq_number) formula ->
+                      match Pos.unmark formula with
+                      | Mast.SingleFormula f ->
+                          let ctx =
+                            {
+                              idmap;
+                              lc = None;
+                              int_const_values = int_const_vals;
+                              table_definition = false;
+                              exec_number =
                                 {
-                                  ctx with
-                                  lc = Some lc;
-                                  exec_number =
-                                    {
-                                      Mir.rule_number;
-                                      Mir.seq_number = seq_number + idx;
-                                      Mir.pos = Pos.get_position f.Mast.lvalue;
-                                    };
-                                }
-                              in
-                              let new_ctx, var_lvalue, def_kind =
-                                translate_lvalue new_ctx f.Mast.lvalue
-                              in
-                              let var_expr = translate_expression new_ctx f.Mast.formula in
-                              (var_lvalue, var_expr, def_kind)
+                                  Mir.rule_number;
+                                  Mir.seq_number;
+                                  Mir.pos = Pos.get_position f.Mast.lvalue;
+                                };
+                              current_lvalue = "" (* dummy, will be filled by [translate_lvalue] *);
+                            }
+                          in
+                          let ctx, var_lvalue, def_kind = translate_lvalue ctx f.Mast.lvalue in
+                          let rule_vars = var_lvalue :: rule_vars in
+                          let var_expr = translate_expression ctx f.Mast.formula in
+                          let var_data =
+                            add_var_def var_data var_lvalue var_expr def_kind var_decl_data idmap
+                          in
+                          (rule_vars, var_data, seq_number + 1)
+                      | Mast.MultipleFormulaes (lvs, f) ->
+                          let ctx =
+                            {
+                              idmap;
+                              lc = None;
+                              int_const_values = int_const_vals;
+                              table_definition = false;
+                              exec_number =
+                                {
+                                  Mir.rule_number;
+                                  Mir.seq_number;
+                                  Mir.pos = Pos.get_position f.Mast.lvalue;
+                                };
+                              current_lvalue = "";
+                            }
+                          in
+                          let loop_context_provider = translate_loop_variables lvs ctx in
+                          let translator lc idx =
+                            let new_ctx =
+                              {
+                                ctx with
+                                lc = Some lc;
+                                exec_number =
+                                  {
+                                    Mir.rule_number;
+                                    Mir.seq_number = seq_number + idx;
+                                    Mir.pos = Pos.get_position f.Mast.lvalue;
+                                  };
+                              }
                             in
-                            let data_to_add = loop_context_provider translator in
-                            List.fold_left
-                              (fun (rule_vars, var_data, seq_number)
-                                   (var_lvalue, var_expr, def_kind) ->
-                                let var_data =
-                                  add_var_def var_data var_lvalue var_expr def_kind var_decl_data
-                                    idmap
-                                in
-                                let rule_vars = var_lvalue :: rule_vars in
-                                (rule_vars, var_data, seq_number + 1))
-                              (rule_vars, var_data, seq_number) data_to_add)
-                      ([], var_data, 0) r.Mast.rule_formulaes
-                  in
-                  let rule = Mir.{ rule_vars = List.rev rule_vars; rule_name = r.rule_name } in
-                  (Mir.RuleMap.add (Mir.fresh_rule_id ()) rule rule_data, var_data)
-            | Mast.VariableDecl (Mast.ConstVar (name, lit)) ->
-                let var =
-                  get_var_from_name_lax idmap name (dummy_exec_number (Pos.get_position name)) false
+                            let new_ctx, var_lvalue, def_kind =
+                              translate_lvalue new_ctx f.Mast.lvalue
+                            in
+                            let var_expr = translate_expression new_ctx f.Mast.formula in
+                            (var_lvalue, var_expr, def_kind)
+                          in
+                          let data_to_add = loop_context_provider translator in
+                          List.fold_left
+                            (fun (rule_vars, var_data, seq_number) (var_lvalue, var_expr, def_kind) ->
+                              let var_data =
+                                add_var_def var_data var_lvalue var_expr def_kind var_decl_data
+                                  idmap
+                              in
+                              let rule_vars = var_lvalue :: rule_vars in
+                              (rule_vars, var_data, seq_number + 1))
+                            (rule_vars, var_data, seq_number) data_to_add)
+                    ([], var_data, 0) r.Mast.rule_formulaes
                 in
-                let var_data =
-                  add_var_def var_data var
-                    (Pos.same_pos_as
-                       (Mir.Literal
-                          (match Pos.unmark lit with
-                          | Mast.Variable var ->
-                              Errors.raise_spanned_error
-                                (Format.asprintf
-                                   "const variable %a cannot be defined by using another variable"
-                                   Format_mast.format_variable var)
-                                (Pos.get_position source_file_item)
-                          | Mast.Float f -> Mir.Float f))
-                       lit)
-                    NoIndex var_decl_data idmap
-                in
-                (rule_data, var_data)
-            | Mast.VariableDecl (Mast.InputVar (var, pos)) ->
-                let var =
-                  get_var_from_name_lax idmap var.Mast.input_name (dummy_exec_number pos) false
-                in
-                let var_decl =
-                  try Mir.VariableMap.find var var_decl_data with Not_found -> assert false
-                  (* should not happen *)
-                in
-                let typ =
-                  translate_value_typ
-                    (match var_decl.var_decl_typ with
-                    | Some x -> Some (x, Pos.get_position var.Mir.Variable.name)
-                    | None -> None)
-                in
-                let var_data =
-                  Mir.VariableMap.add var
-                    { Mir.var_definition = Mir.InputVar; Mir.var_typ = typ; Mir.var_io = Mir.Input }
-                    var_data
-                in
-                (rule_data, var_data)
-            | _ -> (rule_data, var_data))
-          (rule_data, var_data) source_file)
-      (Mir.RuleMap.empty, Mir.VariableMap.empty)
-      (List.rev p)
-  in
-  out
+                let rule = (List.rev rule_vars, r.rule_name) in
+                (Mir.RuleMap.add (Mir.fresh_rule_id ()) rule rule_data, var_data)
+          | Mast.VariableDecl (Mast.ConstVar (name, lit)) ->
+              let var =
+                get_var_from_name_lax idmap name (dummy_exec_number (Pos.get_position name)) false
+              in
+              let var_data =
+                add_var_def var_data var
+                  (Pos.same_pos_as
+                     (Mir.Literal
+                        (match Pos.unmark lit with
+                        | Mast.Variable var ->
+                            Errors.raise_spanned_error
+                              (Format.asprintf
+                                 "const variable %a cannot be defined by using another variable"
+                                 Format_mast.format_variable var)
+                              (Pos.get_position source_file_item)
+                        | Mast.Float f -> Mir.Float f))
+                     lit)
+                  NoIndex var_decl_data idmap
+              in
+              (rule_data, var_data)
+          | Mast.VariableDecl (Mast.InputVar (var, pos)) ->
+              let var =
+                get_var_from_name_lax idmap var.Mast.input_name (dummy_exec_number pos) false
+              in
+              let var_decl =
+                try Mir.VariableMap.find var var_decl_data with Not_found -> assert false
+                (* should not happen *)
+              in
+              let typ =
+                translate_value_typ
+                  (match var_decl.var_decl_typ with
+                  | Some x -> Some (x, Pos.get_position var.Mir.Variable.name)
+                  | None -> None)
+              in
+              let var_data =
+                Mir.VariableMap.add var
+                  { Mir.var_definition = Mir.InputVar; Mir.var_typ = typ; Mir.var_io = Mir.Input }
+                  var_data
+              in
+              (rule_data, var_data)
+          | _ -> (rule_data, var_data))
+        (rule_data, var_data) source_file)
+    (Mir.RuleMap.empty, Mir.VariableMap.empty)
+    (List.rev p)
 
 (** At this point [var_data] contains the definition data for all the times a variable is defined.
     However the M language deals with undefined variable, so for each variable we have to insert a
     dummy definition corresponding to the declaration and whose value is [Undefined]. *)
-let add_dummy_definition_for_variable_declaration (var_data : Mir.variable_data Mir.VariableMap.t)
+let add_dummy_definitions_for_variable_declarations (var_data : Mir.variable_data Mir.VariableMap.t)
     (var_decl_data : var_decl_data Mir.VariableMap.t) (idmap : Mir.idmap) :
     Mir.variable_data Mir.VariableMap.t =
   Mir.VariableMap.fold
@@ -1395,8 +1390,37 @@ let translate (p : Mast.program) : Mir.program =
   let var_decl_data, idmap, int_const_vals = get_constants p in
   let var_decl_data, error_decls, idmap = get_variables_decl p var_decl_data idmap in
   let idmap = get_var_redefinitions p idmap int_const_vals in
-  let rules, var_data = get_rules_and_var_data idmap var_decl_data int_const_vals p in
-  let var_data = add_dummy_definition_for_variable_declaration var_data var_decl_data idmap in
+  let rule_data, var_data = get_rules_and_var_data idmap var_decl_data int_const_vals p in
+  let var_data = add_dummy_definitions_for_variable_declarations var_data var_decl_data idmap in
+  let rules, rule_vars =
+    Mir.RuleMap.fold
+      (fun rule_id (rule_vars, rule_name) (rules, vars) ->
+        let rule_vars, vars =
+          List.fold_left
+            (fun (rule_vars, vars) var ->
+              ( (var.Mir.Variable.id, Mir.VariableMap.find var var_data) :: rule_vars,
+                Mir.VariableDict.add var vars ))
+            ([], vars) (List.rev rule_vars)
+        in
+        (Mir.RuleMap.add rule_id Mir.{ rule_vars; rule_name } rules, vars))
+      rule_data
+      (Mir.RuleMap.empty, Mir.VariableDict.empty)
+  in
+  let var_data, orphans =
+    Mir.VariableMap.fold
+      (fun var data (var_dict, orphans) ->
+        let orphans =
+          if Mir.VariableDict.mem var rule_vars then orphans
+          else (var.Mir.Variable.id, data) :: orphans
+        in
+        (Mir.VariableDict.add var var_dict, orphans))
+      var_data (Mir.VariableDict.empty, [])
+  in
+  let rules =
+    Mir.RuleMap.add Mir.initial_undef_rule_id
+      Mir.{ rule_vars = orphans; rule_name = [ ("var_init", Pos.no_pos) ] }
+      rules
+  in
   let conds = get_conds error_decls idmap p in
   {
     Mir.program_vars = var_data;

--- a/src/mlang/m_ir/format_mir.ml
+++ b/src/mlang/m_ir/format_mir.ml
@@ -94,7 +94,7 @@ let format_variable_data fmt (def : variable_data) =
       match def.var_typ with None -> Format.fprintf fmt "unknown" | Some t -> format_typ fmt t)
     () format_io def.var_io format_variable_def def.var_definition
 
-let format_program_vars fmt (p : variable_data VariableMap.t) =
+let format_variables fmt (p : variable_data VariableMap.t) =
   VariableMap.map_printer
     (fun fmt var ->
       Format.fprintf fmt "Variable %s%s" (Pos.unmark var.Variable.name)
@@ -109,14 +109,29 @@ let format_precondition fmt (precond : condition_data) =
     (Format_mast.pp_print_list_comma format_error)
     precond.cond_errors
 
+let format_program_rules fmt (vars : VariableDict.t) (rules : rule_data RuleMap.t) =
+  RuleMap.iter
+    (fun _ { rule_vars; rule_name } ->
+      let var_defs =
+        List.fold_left
+          (fun var_defs (vid, def) ->
+            let var = VariableDict.find vid vars in
+            VariableMap.add var def var_defs)
+          VariableMap.empty rule_vars
+      in
+      Format.fprintf fmt "Regle %a\n%a\n" Format_mast.format_rule_name rule_name format_variables
+        var_defs)
+    rules
+
 let format_program_conds fmt (conds : condition_data VariableMap.t) =
   Format_mast.pp_print_list_endline
     (fun fmt (_, cond) -> format_precondition fmt cond)
     fmt (VariableMap.bindings conds)
 
 let format_program fmt (p : program) =
-  Format.fprintf fmt "%a\n\n%a" format_program_vars p.program_vars format_program_conds
-    p.program_conds
+  Format.fprintf fmt "%a\n\n%a"
+    (fun fmt -> format_program_rules fmt p.program_vars)
+    p.program_rules format_program_conds p.program_conds
 
 let format_variable fmt (v : Variable.t) =
   Format.fprintf fmt "%s: %s" (Pos.unmark v.Variable.name) (Pos.unmark v.Variable.descr)

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -59,25 +59,28 @@ let same_execution_number (en1 : execution_number) (en2 : execution_number) : bo
   en1.rule_number = en2.rule_number && en1.seq_number = en2.seq_number
 
 module Variable = struct
+  type id = int
+  (** Each variable has an unique ID *)
+
   type t = {
     name : string Pos.marked;  (** The position is the variable declaration *)
     execution_number : execution_number;
         (** The number associated with the rule of verification condition in which the variable is
             defined *)
     alias : string option;  (** Input variable have an alias *)
-    id : int;  (** Each variable has an unique ID *)
+    id : id;
     descr : string Pos.marked;  (** Description taken from the variable declaration *)
     attributes : (Mast.input_variable_attribute Pos.marked * Mast.literal Pos.marked) list;
     is_income : bool;
     is_table : int option;
   }
 
-  let counter : int ref = ref 0
-
-  let fresh_id () : int =
-    let v = !counter in
-    counter := !counter + 1;
-    v
+  let fresh_id : unit -> id =
+    let counter : int ref = ref 0 in
+    fun () ->
+      let v = !counter in
+      counter := !counter + 1;
+      v
 
   let new_var (name : string Pos.marked) (alias : string option) (descr : string Pos.marked)
       (execution_number : execution_number)
@@ -175,6 +178,31 @@ module VariableMap = struct
       map
 end
 
+(** Variable dictionary, act as a set but refered by keys *)
+module VariableDict = struct
+  module Map = Map.Make (struct
+    type t = Variable.id
+
+    let compare = compare
+  end)
+
+  include Map
+
+  type t = Variable.t Map.t
+
+  let singleton v = singleton v.Variable.id v
+
+  let add v t = add v.Variable.id v t
+
+  let mem v t = mem v.Variable.id t
+
+  let fold f t acc = fold (fun _ v acc -> f v acc) t acc
+
+  let union t1 t2 = union (fun _ v _ -> Some v) t1 t2
+
+  let for_all f t = for_all (fun _ v -> f v) t
+end
+
 module VariableSet = Set.Make (Variable)
 
 module LocalVariableMap = struct
@@ -254,7 +282,10 @@ let fresh_rule_id =
     incr count;
     n
 
-type rule_data = { rule_vars : Variable.t list; rule_name : Mast.rule_name }
+(** Special rule id for initial definition of variables *)
+let initial_undef_rule_id = -1
+
+type rule_data = { rule_vars : (Variable.id * variable_data) list; rule_name : Mast.rule_name }
 
 module RuleMap = Map.Make (struct
   type t = rule_id
@@ -305,7 +336,7 @@ type idmap = Variable.t list Pos.VarNameToID.t
 type exec_pass = { exec_pass_set_variables : literal Pos.marked VariableMap.t }
 
 type program = {
-  program_vars : variable_data VariableMap.t;
+  program_vars : VariableDict.t;
   program_rules : rule_data RuleMap.t;
   program_conds : condition_data VariableMap.t;  (** Conditions are affected to dummy variables *)
   program_idmap : idmap;
@@ -317,8 +348,8 @@ type program = {
 (** Throws an error in case of alias not found *)
 let find_var_name_by_alias (p : program) (alias : string Pos.marked) : string =
   let v =
-    VariableMap.fold
-      (fun v _ acc ->
+    VariableDict.fold
+      (fun v acc ->
         match (acc, v.Variable.alias) with
         | Some _, _ | None, None -> acc
         | None, Some v_alias ->
@@ -350,3 +381,46 @@ let find_var_by_name (p : program) (name : string Pos.marked) : Variable.t =
            (fun v1 v2 -> compare v1.Variable.execution_number v2.Variable.execution_number)
            (Pos.VarNameToID.find name p.program_idmap))
     with Not_found -> Errors.raise_spanned_error "unknown variable" (Pos.get_position name))
+
+(** Explores the rules to find rule and variable data *)
+let find_var_definition (p : program) (var : Variable.t) : rule_data * variable_data =
+  (* using exceptions to cut short exploration *)
+  let exception Found_rule of rule_data * variable_data in
+  let exception Found_var of variable_data in
+  try
+    RuleMap.iter
+      (fun _ rule_data ->
+        try
+          List.iter
+            (fun (vid, def) -> if var.id = vid then raise (Found_var def))
+            rule_data.rule_vars
+        with Found_var def -> raise (Found_rule (rule_data, def)))
+      p.program_rules;
+    raise Not_found
+  with Found_rule (rule, var) -> (rule, var)
+
+let map_vars (f : Variable.t -> variable_data -> variable_data) (p : program) : program =
+  let program_rules =
+    RuleMap.map
+      (fun rule_data ->
+        let rule_vars =
+          List.map
+            (fun (vid, def) ->
+              let var = VariableDict.find vid p.program_vars in
+              (vid, f var def))
+            rule_data.rule_vars
+        in
+        { rule_data with rule_vars })
+      p.program_rules
+  in
+  { p with program_rules }
+
+let fold_vars (f : Variable.t -> variable_data -> 'a -> 'a) (p : program) (acc : 'a) : 'a =
+  RuleMap.fold
+    (fun _ rule_data acc ->
+      List.fold_left
+        (fun acc (vid, def) ->
+          let var = VariableDict.find vid p.program_vars in
+          f var def acc)
+        acc rule_data.rule_vars)
+    p.program_rules acc

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -175,6 +175,8 @@ module VariableMap = struct
       map
 end
 
+module VariableSet = Set.Make (Variable)
+
 module LocalVariableMap = struct
   include Map.Make (LocalVariable)
 
@@ -243,6 +245,23 @@ type variable_data = {
       name = "variable_data_iter";
     }]
 
+type rule_id = int
+
+let fresh_rule_id =
+  let count = ref 0 in
+  fun () ->
+    let n = !count in
+    incr count;
+    n
+
+type rule_data = { rule_vars : Variable.t list; rule_name : Mast.rule_name }
+
+module RuleMap = Map.Make (struct
+  type t = rule_id
+
+  let compare = compare
+end)
+
 (**{1 Verification conditions}*)
 
 (** Errors are first-class objects *)
@@ -287,6 +306,7 @@ type exec_pass = { exec_pass_set_variables : literal Pos.marked VariableMap.t }
 
 type program = {
   program_vars : variable_data VariableMap.t;
+  program_rules : rule_data RuleMap.t;
   program_conds : condition_data VariableMap.t;  (** Conditions are affected to dummy variables *)
   program_idmap : idmap;
   program_exec_passes : exec_pass list;

--- a/src/mlang/m_ir/mir_dependency_graph.ml
+++ b/src/mlang/m_ir/mir_dependency_graph.ml
@@ -13,31 +13,30 @@
 
 (** Defines the dependency graph of an M program *)
 
-(** Each node corresponds to a variable, each edge to a variable use. The edges in the graph go from
-    output to inputs. *)
-module G = Graph.Persistent.Digraph.ConcreteBidirectional (struct
-  type t = Mir.Variable.t
+(** Each node corresponds to a rule, each edge to variables use. The edges in the graph go from
+    input to outputs. *)
+module RG =
+  Graph.Persistent.Digraph.ConcreteBidirectionalLabeled
+    (struct
+      type t = Mir.rule_id
 
-  let hash v = v.Mir.Variable.id
+      let hash v = v
 
-  let compare v1 v2 = compare v1.Mir.Variable.id v2.Mir.Variable.id
+      let compare = compare
 
-  let equal v1 v2 = v1.Mir.Variable.id = v2.Mir.Variable.id
-end)
+      let equal = ( = )
+    end)
+    (struct
+      type t = string
 
-module RG = Graph.Persistent.Digraph.ConcreteBidirectional (struct
-  type t = Mir.rule_id
+      let compare = String.compare
 
-  let hash v = v
-
-  let compare = compare
-
-  let equal = ( = )
-end)
+      let default = ""
+    end)
 
 (** Add all the sucessors of [lvar] in the graph that are used by [e] *)
-let rec get_used_variables_ (e : Mir.expression Pos.marked) (acc : unit Mir.VariableMap.t) :
-    unit Mir.VariableMap.t =
+let rec get_used_variables_ (e : Mir.expression Pos.marked) (acc : Mir.VariableDict.t) :
+    Mir.VariableDict.t =
   match Pos.unmark e with
   | Mir.Comparison (_, e1, e2) | Mir.Binop (_, e1, e2) | Mir.LocalLet (_, e1, e2) ->
       let acc = get_used_variables_ e1 acc in
@@ -45,7 +44,7 @@ let rec get_used_variables_ (e : Mir.expression Pos.marked) (acc : unit Mir.Vari
       acc
   | Mir.Unop (_, e) -> get_used_variables_ e acc
   | Mir.Index ((var, _), e) ->
-      let acc = Mir.VariableMap.add var () acc in
+      let acc = Mir.VariableDict.add var acc in
       let acc = get_used_variables_ e acc in
       acc
   | Mir.Conditional (e1, e2, e3) ->
@@ -56,160 +55,64 @@ let rec get_used_variables_ (e : Mir.expression Pos.marked) (acc : unit Mir.Vari
   | Mir.FunctionCall (_, args) ->
       List.fold_left (fun acc arg -> get_used_variables_ arg acc) acc args
   | Mir.LocalVar _ | Mir.Literal _ | Mir.GenericTableIndex | Mir.Error -> acc
-  | Mir.Var var -> Mir.VariableMap.add var () acc
+  | Mir.Var var -> Mir.VariableDict.add var acc
 
-let get_used_variables (e : Mir.expression Pos.marked) : unit Mir.VariableMap.t =
-  get_used_variables_ e Mir.VariableMap.empty
+let get_used_variables (e : Mir.expression Pos.marked) : Mir.VariableDict.t =
+  get_used_variables_ e Mir.VariableDict.empty
 
-let add_usages (lvar : Mir.Variable.t) (e : Mir.expression Pos.marked) (acc : G.t) : G.t =
-  let acc = G.add_vertex acc lvar in
-  let add_edge acc var lvar = G.add_edge acc var lvar in
-  let usages = get_used_variables_ e Mir.VariableMap.empty in
-  Mir.VariableMap.fold (fun var _ acc -> add_edge acc var lvar) usages acc
-
-let create_vars_dependency_graph (vars : Mir.variable_data Mir.VariableMap.t) : G.t =
-  Mir.VariableMap.fold
-    (fun var def acc ->
-      match def.Mir.var_definition with
-      | Mir.InputVar -> G.add_vertex acc var
-      | Mir.SimpleVar e -> add_usages var e acc
-      | Mir.TableVar (_, def) -> (
-          match def with
-          | Mir.IndexGeneric e -> add_usages var e acc
-          | Mir.IndexTable es -> Mir.IndexMap.fold (fun _ e acc -> add_usages var e acc) es acc))
-    vars G.empty
+let get_def_used_variables (def : Mir.variable_def) : Mir.VariableDict.t =
+  match def with
+  | Mir.InputVar -> Mir.VariableDict.empty
+  | Mir.SimpleVar e -> get_used_variables e
+  | Mir.TableVar (_, def) -> (
+      match def with
+      | Mir.IndexGeneric e -> get_used_variables e
+      | Mir.IndexTable es ->
+          Mir.IndexMap.fold
+            (fun _ e acc -> Mir.VariableDict.union acc (get_used_variables e))
+            es Mir.VariableDict.empty)
 
 let create_rules_dependency_graph (program : Mir.program)
-    (vars_to_rules : Mir.rule_id Mir.VariableMap.t) (var_dep_graph : G.t) : RG.t =
+    (vars_to_rules : Mir.rule_id Mir.VariableMap.t) : RG.t =
   Mir.RuleMap.fold
     (fun rule_id { Mir.rule_vars; _ } g ->
       List.fold_left
-        (fun g var ->
-          let succs = G.succ var_dep_graph var in
-          List.fold_left
-            (fun g succ ->
-              try RG.add_edge g rule_id (Mir.VariableMap.find succ vars_to_rules)
+        (fun g (_vid, def) ->
+          let succs = get_def_used_variables def.Mir.var_definition in
+          let var_deps =
+            Mir.VariableDict.fold
+              (fun succ var_deps ->
+                let rsucc = Mir.VariableMap.find succ vars_to_rules in
+                let vsuccs =
+                  try Mir.RuleMap.find rsucc var_deps with Not_found -> Mir.VariableDict.empty
+                in
+                Mir.RuleMap.add rsucc (Mir.VariableDict.add succ vsuccs) var_deps)
+              succs Mir.RuleMap.empty
+          in
+          Mir.RuleMap.fold
+            (fun succ vsuccs g ->
+              try
+                let label =
+                  Format.fprintf Format.str_formatter "%a"
+                    (Format.pp_print_list ~pp_sep:Format.pp_print_space Format_mir.format_variable)
+                    (Mir.VariableDict.bindings vsuccs |> List.map snd);
+                  Format.flush_str_formatter ()
+                in
+                let edge = RG.E.create rule_id label succ in
+                RG.add_edge_e g edge
               with Not_found -> g)
-            g succs)
+            var_deps g)
         g rule_vars)
     program.program_rules RG.empty
 
-(** The dependency graph also includes nodes for the conditions to be checked at execution *)
-let create_program_dependency_graph (p : Mir.program) : G.t =
-  let g = create_vars_dependency_graph p.program_vars in
-  (* FIXME: for ocamlgraph to work, output nodes should not have any successors... *)
-  let g =
-    G.fold_vertex
-      (fun (var : Mir.Variable.t) (g : G.t) ->
-        match Mir.VariableMap.find_opt var p.program_vars with
-        | None -> g
-        | Some data ->
-            if data.Mir.var_io = Mir.Output then
-              G.fold_succ
-                (fun (succ : Mir.Variable.t) (g : G.t) -> G.remove_edge g var succ)
-                g var g
-            else g)
-      g g
-  in
-  Mir.VariableMap.fold
-    (fun cond_var cond acc -> add_usages cond_var cond.Mir.cond_expr acc)
-    p.program_conds g
-
-let program_when_printing : Mir.program option ref = ref None
-
-(** The graph is output in the Dot format *)
-module Dot = Graph.Graphviz.Dot (struct
-  include G (* use the graph module from above *)
-
-  let edge_attributes _ = [ `Color 0xffa366 ]
-
-  let default_edge_attributes _ = []
-
-  let get_subgraph _ = None
-
-  let vertex_attributes v =
-    match !program_when_printing with
-    | None -> []
-    | Some p -> (
-        let input_color = 0x66b5ff in
-        let output_color = 0xE6E600 in
-        let cond_color = 0x666633 in
-        let regular_color = 0x8585ad in
-        let text_color = 0xf2f2f2 in
-        try
-          let var_data = Mir.VariableMap.find v p.program_vars in
-          match var_data.Mir.var_io with
-          | Mir.Input ->
-              [
-                `Fillcolor input_color;
-                `Shape `Box;
-                `Style `Filled;
-                `Fontcolor text_color;
-                `Label
-                  (Format.asprintf "%s\n%s"
-                     (match v.Mir.Variable.alias with
-                     | Some s -> s
-                     | None -> Pos.unmark v.Mir.Variable.name)
-                     (Pos.unmark v.Mir.Variable.descr));
-              ]
-          | Mir.Regular ->
-              [
-                `Fillcolor regular_color;
-                `Style `Filled;
-                `Shape `Box;
-                `Fontcolor text_color;
-                `Label
-                  (Format.asprintf "%s\n%s" (Pos.unmark v.Mir.Variable.name)
-                     (Pos.unmark v.Mir.Variable.descr));
-              ]
-          | Mir.Output ->
-              [
-                `Fillcolor output_color;
-                `Shape `Box;
-                `Style `Filled;
-                `Fontcolor text_color;
-                `Label
-                  (Format.asprintf "%s\n%s" (Pos.unmark v.Mir.Variable.name)
-                     (Pos.unmark v.Mir.Variable.descr));
-              ]
-        with Not_found ->
-          let _ = Mir.VariableMap.find v p.program_conds in
-          [
-            `Fillcolor cond_color;
-            `Shape `Box;
-            `Style `Filled;
-            `Fontcolor text_color;
-            `Label
-              (Format.asprintf "%s\n%s" (Pos.unmark v.Mir.Variable.name)
-                 (Pos.unmark v.Mir.Variable.descr));
-          ])
-
-  let vertex_name v = "\"" ^ Pos.unmark v.Mir.Variable.name ^ "\""
-
-  let default_vertex_attributes _ = []
-
-  let graph_attributes _ = [ `Bgcolor 0x00001a ]
-end)
-
-module GOper = Graph.Oper.P (G)
-
-let print_dependency_graph (filename : string) (graph : G.t) (p : Mir.program) : unit =
-  let file = open_out_bin filename in
-  (* let graph = DepgGraphOper.transitive_reduction graph in *)
-  program_when_printing := Some p;
-  Cli.debug_print "Writing variables dependency graph to %s (%d variables)" filename
-    (G.nb_vertex graph);
-  if !Cli.debug_flag then Dot.output_graph file graph;
-  close_out file
-
-module SCC = Graph.Components.Make (G)
+module SCC = Graph.Components.Make (RG)
 (** Tarjan's stongly connected components algorithm, provided by OCamlGraph *)
 
 (** Outputs [true] and a warning in case of cycles. *)
-let check_for_cycle (g : G.t) (p : Mir.program) (print_debug : bool) : bool =
+let check_for_cycle (g : RG.t) (p : Mir.program) (print_debug : bool) : bool =
   (* if there is a cycle, there will be an strongly connected component of cardinality > 1 *)
   let sccs = SCC.scc_list g in
-  if List.length sccs < G.nb_vertex g then begin
+  if List.length sccs < RG.nb_vertex g then begin
     let sccs = List.filter (fun scc -> List.length scc > 1) sccs in
     let cycles_strings = ref [] in
     let dir = "variable_cycles" in
@@ -217,22 +120,25 @@ let check_for_cycle (g : G.t) (p : Mir.program) (print_debug : bool) : bool =
       try Unix.mkdir dir 0o750 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
     end;
     if !Cli.print_cycles_flag && print_debug then begin
-      List.iteri
-        (fun i scc ->
-          let new_g =
-            G.fold_vertex
-              (fun vertex new_g ->
-                if List.mem vertex scc then new_g else G.remove_vertex new_g vertex)
-              g g
+      List.iter
+        (fun scc ->
+          let edges =
+            let loop = scc @ [ List.hd scc ] in
+            let rec get_edges acc = function
+              | [] | [ _ ] -> acc
+              | v1 :: v2 :: vtx -> get_edges ((v1, RG.find_edge g v1 v2) :: acc) (v2 :: vtx)
+            in
+            get_edges [] loop |> List.rev
           in
-          let filename = Format.asprintf "%s/strongly_connected_component_%d.dot" dir i in
-          print_dependency_graph filename new_g p;
           cycles_strings :=
-            Format.asprintf
-              "The following variables are defined circularly: %s\n\
-               The dependency graph of this circular definition has been written to %s"
-              (String.concat " <-> " (List.map (fun var -> Pos.unmark var.Mir.Variable.name) scc))
-              filename
+            Format.asprintf "The following rules contain circular definitions: %s\n"
+              (String.concat "\n^\n|\nv\n"
+                 (List.map
+                    (fun (rule_id, edge) ->
+                      let rule = Mir.RuleMap.find rule_id p.Mir.program_rules in
+                      Format.asprintf "%a with vars: %s" Format_mast.format_rule_name rule.rule_name
+                        (RG.E.label edge))
+                    edges))
             :: !cycles_strings)
         sccs;
       let oc = open_out (dir ^ "/variable_cycles.txt") in
@@ -246,29 +152,6 @@ let check_for_cycle (g : G.t) (p : Mir.program) (print_debug : bool) : bool =
   end
   else false
 
-module OutputToInputReachability =
-  Graph.Fixpoint.Make
-    (G)
-    (struct
-      type vertex = G.E.vertex
-
-      type edge = G.E.t
-
-      type g = G.t
-
-      type data = bool
-
-      let direction = Graph.Fixpoint.Backward
-
-      let equal = ( = )
-
-      let join = ( || )
-
-      let analyze _ x = x
-    end)
-
-module TopologicalOrder = Graph.Topological.Make (G)
-module ExecutionOrder = Graph.Topological.Make (G)
 module RuleExecutionOrder = Graph.Topological.Make (RG)
 
 type execution_order = Mir.Variable.t list
@@ -276,36 +159,5 @@ type execution_order = Mir.Variable.t list
 type rule_execution_order = Mir.rule_id list
 (** Each map is the set of variables defined circularly in this strongly connected component *)
 
-let get_execution_order (dep_graph : G.t) : execution_order =
-  List.rev (ExecutionOrder.fold (fun var exec_order -> var :: exec_order) dep_graph [])
-
 let get_rules_execution_order (dep_graph : RG.t) : rule_execution_order =
-  List.rev (RuleExecutionOrder.fold (fun var exec_order -> var :: exec_order) dep_graph [])
-
-(** This custom visitor uses [get_execution_order] to visit all the expressions in the program in
-    the correct order. *)
-class ['self] program_iter =
-  object (self : 'self)
-    inherit [_] Mir.variable_data_iter
-
-    inherit [_] Mir.condition_data_iter [@@warning "-7"]
-
-    method visit_program env (this : Mir.program) =
-      let dep_graph = create_program_dependency_graph this in
-      let exec_order = get_execution_order dep_graph in
-      List.iter
-        (fun var ->
-          try
-            let data = Mir.VariableMap.find var this.program_vars in
-            self#visit_variable_data env data
-          with Not_found -> (
-            try
-              let cond = Mir.VariableMap.find var this.program_conds in
-              self#visit_condition_data env cond
-            with Not_found -> assert false))
-        exec_order
-  end
-
-let fold_on_vars (f : Mir.Variable.t -> 'a -> 'a) (dep_graph : G.t) (init : 'a) : 'a =
-  let exec_order = get_execution_order dep_graph in
-  List.fold_left (fun acc v -> f v acc) init exec_order
+  RuleExecutionOrder.fold (fun var exec_order -> var :: exec_order) dep_graph []

--- a/src/mlang/m_ir/mir_interface.ml
+++ b/src/mlang/m_ir/mir_interface.ml
@@ -15,79 +15,66 @@
 open Mir
 
 let reset_all_outputs (p : program) : program =
-  {
-    p with
-    program_vars =
-      VariableMap.mapi
-        (fun var var_data ->
-          match var_data.var_io with
-          | Input ->
-              {
-                var_data with
-                var_io = Input;
-                var_definition =
-                  (match var_data.var_definition with
-                  | InputVar | SimpleVar _ -> var_data.var_definition
-                  | TableVar _ ->
-                      Errors.raise_spanned_error
-                        (Format.asprintf
-                           "Defining a\n\
-                           \             variable input for a table variable %s is not supported"
-                           (Pos.unmark var.Variable.name))
-                        (Pos.get_position var.Variable.name));
-              }
-          | _ ->
-              {
-                var_data with
-                var_io = Regular;
-                var_definition =
-                  (match var_data.var_definition with
-                  | InputVar -> assert false
-                  | SimpleVar old -> SimpleVar old
-                  | TableVar (size, old) -> TableVar (size, old));
-              })
-        p.program_vars;
-  }
+  map_vars
+    (fun var var_data ->
+      match var_data.var_io with
+      | Input ->
+          {
+            var_data with
+            var_io = Input;
+            var_definition =
+              (match var_data.var_definition with
+              | InputVar | SimpleVar _ -> var_data.var_definition
+              | TableVar _ ->
+                  Errors.raise_spanned_error
+                    (Format.asprintf
+                       "Defining a\n\
+                       \             variable input for a table variable %s is not supported"
+                       (Pos.unmark var.Variable.name))
+                    (Pos.get_position var.Variable.name));
+          }
+      | _ ->
+          {
+            var_data with
+            var_io = Regular;
+            var_definition =
+              (match var_data.var_definition with
+              | InputVar -> assert false
+              | SimpleVar old -> SimpleVar old
+              | TableVar (size, old) -> TableVar (size, old));
+          })
+    p
 
 type full_program = {
-  dep_graph : Mir_dependency_graph.G.t;
+  dep_graph : Mir_dependency_graph.RG.t;
   main_execution_order : Mir.rule_id list;
-  rules_execution_order : Mir_dependency_graph.execution_order Mir.RuleMap.t;
   vars_execution_order : Mir_dependency_graph.execution_order;
   program : Mir.program;
 }
 
 let to_full_program (program : program) : full_program =
-  let dep_graph = Mir_dependency_graph.create_program_dependency_graph program in
   let vars_to_rules, rules_execution_order =
     Mir.RuleMap.fold
       (fun rule_id { rule_vars; _ } (conv, orders) ->
-        let conv =
-          List.fold_left (fun conv var -> VariableMap.add var rule_id conv) conv rule_vars
+        let conv, order =
+          List.fold_left
+            (fun (conv, order) (vid, _def) ->
+              let var = VariableDict.find vid program.program_vars in
+              let conv = VariableMap.add var rule_id conv in
+              (conv, var :: order))
+            (conv, []) rule_vars
         in
-        let orders =
-          let vars =
-            List.fold_left
-              (fun vars var -> VariableMap.add var (VariableMap.find var program.program_vars) vars)
-              VariableMap.empty rule_vars
-          in
-          let order =
-            Mir_dependency_graph.create_vars_dependency_graph vars
-            |> Mir_dependency_graph.get_execution_order
-          in
-          Mir.RuleMap.add rule_id order orders
-        in
+        let order = List.rev order in
+        let orders = Mir.RuleMap.add rule_id order orders in
         (conv, orders))
       program.program_rules
       (VariableMap.empty, Mir.RuleMap.empty)
   in
-  let main_execution_order =
-    Mir_dependency_graph.create_rules_dependency_graph program vars_to_rules dep_graph
-    |> Mir_dependency_graph.get_rules_execution_order
-  in
+  let dep_graph = Mir_dependency_graph.create_rules_dependency_graph program vars_to_rules in
+  let main_execution_order = Mir_dependency_graph.get_rules_execution_order dep_graph in
   let vars_execution_order =
     List.concat_map
       (fun rule_id -> Mir.RuleMap.find rule_id rules_execution_order)
       main_execution_order
   in
-  { program; dep_graph; main_execution_order; rules_execution_order; vars_execution_order }
+  { program; dep_graph; main_execution_order; vars_execution_order }

--- a/src/mlang/m_ir/mir_interface.ml
+++ b/src/mlang/m_ir/mir_interface.ml
@@ -51,10 +51,43 @@ let reset_all_outputs (p : program) : program =
 
 type full_program = {
   dep_graph : Mir_dependency_graph.G.t;
-  execution_order : Mir_dependency_graph.execution_order;
+  main_execution_order : Mir.rule_id list;
+  rules_execution_order : Mir_dependency_graph.execution_order Mir.RuleMap.t;
+  vars_execution_order : Mir_dependency_graph.execution_order;
   program : Mir.program;
 }
 
 let to_full_program (program : program) : full_program =
-  let dep_graph = Mir_dependency_graph.create_dependency_graph program in
-  { program; dep_graph; execution_order = Mir_dependency_graph.get_execution_order dep_graph }
+  let dep_graph = Mir_dependency_graph.create_program_dependency_graph program in
+  let vars_to_rules, rules_execution_order =
+    Mir.RuleMap.fold
+      (fun rule_id { rule_vars; _ } (conv, orders) ->
+        let conv =
+          List.fold_left (fun conv var -> VariableMap.add var rule_id conv) conv rule_vars
+        in
+        let orders =
+          let vars =
+            List.fold_left
+              (fun vars var -> VariableMap.add var (VariableMap.find var program.program_vars) vars)
+              VariableMap.empty rule_vars
+          in
+          let order =
+            Mir_dependency_graph.create_vars_dependency_graph vars
+            |> Mir_dependency_graph.get_execution_order
+          in
+          Mir.RuleMap.add rule_id order orders
+        in
+        (conv, orders))
+      program.program_rules
+      (VariableMap.empty, Mir.RuleMap.empty)
+  in
+  let main_execution_order =
+    Mir_dependency_graph.create_rules_dependency_graph program vars_to_rules dep_graph
+    |> Mir_dependency_graph.get_rules_execution_order
+  in
+  let vars_execution_order =
+    List.concat_map
+      (fun rule_id -> Mir.RuleMap.find rule_id rules_execution_order)
+      main_execution_order
+  in
+  { program; dep_graph; main_execution_order; rules_execution_order; vars_execution_order }

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -24,9 +24,11 @@ let emtpy_translation_ctx : translation_ctx =
 let ctx_join ctx1 ctx2 =
   {
     new_variables =
-      (* CR keryan : I assume there shouldn't be conflict there, kept the behavior of
-         [translate_mpp_stmt:SConditional] just in case, which could erase [ctx1] by [ctx2] *)
-      StringMap.union (fun _ _ v2 -> Some v2) ctx1.new_variables ctx2.new_variables;
+      StringMap.union
+        (fun _ v1 v2 ->
+          assert (Mir.Variable.compare v1 v2 = 0);
+          Some v2)
+        ctx1.new_variables ctx2.new_variables;
     variables_used_as_inputs =
       Mir.VariableDict.union ctx1.variables_used_as_inputs ctx2.variables_used_as_inputs;
     rule_instances = Bir.RuleMap.union (fun _ r _ -> Some r) ctx1.rule_instances ctx2.rule_instances;

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -11,10 +11,31 @@ end)
 type translation_ctx = {
   new_variables : Mir.Variable.t StringMap.t;
   variables_used_as_inputs : unit Mir.VariableMap.t;
+  rule_instances : Bir.rule Bir.RuleMap.t;
 }
 
 let emtpy_translation_ctx : translation_ctx =
-  { new_variables = StringMap.empty; variables_used_as_inputs = Mir.VariableMap.empty }
+  {
+    new_variables = StringMap.empty;
+    variables_used_as_inputs = Mir.VariableMap.empty;
+    rule_instances = Bir.RuleMap.empty;
+  }
+
+let ctx_join ctx1 ctx2 =
+  {
+    new_variables =
+      (* CR keryan : I assume there shouldn't be conflict there, kept the behavior of
+         [translate_mpp_stmt:SConditional] just in case, which could erase [ctx1] by [ctx2] *)
+      StringMap.union (fun _ _ v2 -> Some v2) ctx1.new_variables ctx2.new_variables;
+    variables_used_as_inputs =
+      Mir.VariableMap.union
+        (fun _ _ _ -> Some ())
+        ctx1.variables_used_as_inputs ctx2.variables_used_as_inputs;
+    rule_instances =
+      Bir.RuleMap.union
+        (fun _ r1 _r2 -> (* if r1 = r2 then *) Some r1 (* else assert false *))
+        ctx1.rule_instances ctx2.rule_instances;
+  }
 
 let translate_to_binop (b : Mpp_ast.binop) : Mast.binop =
   match b with And -> And | Or -> Or | _ -> assert false
@@ -132,6 +153,123 @@ let reset_and_add_outputs (p : Mir_interface.full_program) (outputs : string Pos
   in
   { p with program }
 
+let translate_m_code (m_program : Mir_interface.full_program) execution_order =
+  list_map_opt
+    (fun var ->
+      try
+        let vdef = Mir.VariableMap.find var m_program.program.program_vars in
+        match vdef.var_definition with
+        | InputVar -> None
+        | _ ->
+            (* variables used in the context should not be reassigned *)
+            Some (Bir.SAssign (var, vdef), var.Mir.Variable.execution_number.pos)
+      with Not_found -> None)
+    execution_order
+
+(* let generate_rule_instance (m_program : Mir_interface.full_program) (rule_id : Mir.rule_id)
+ *     (rule_stmts : Bir.stmt list) (ctx : translation_ctx)
+ *   : Mir.rule_id * Pos.t * translation_ctx =
+ *   Printf.eprintf "generate_instance \n%!";
+ *   let instance_id = Mir.fresh_rule_id () in
+ *   let rule = Mir.RuleMap.find rule_id m_program.program.program_rules in
+ *   let pos, rule_name =
+ *     let pos = List.hd rule.Mir.rule_name |> Pos.get_position in
+ *     let name = List.map Pos.unmark rule.Mir.rule_name |> String.concat "_" in
+ *     (pos, name ^ "_i" ^ string_of_int instance_id)
+ *   in
+ *   let instance = Bir.{ rule_id = instance_id; rule_name; rule_stmts } in
+ *   ( instance_id,
+ *     pos,
+ *     { ctx with rule_instances = Bir.RuleMap.add instance_id instance ctx.rule_instances } ) *)
+
+let generate_rule_instance (m_program : Mir_interface.full_program) (rule_id : Mir.rule_id)
+    (ctx : translation_ctx) : Mir.rule_id * Pos.t * translation_ctx =
+  let instance_id = Mir.fresh_rule_id () in
+  let rule = Mir.RuleMap.find rule_id m_program.program.program_rules in
+  let exec_order = Mir.RuleMap.find rule_id m_program.rules_execution_order in
+  let rule_stmts = translate_m_code m_program exec_order in
+  let pos, rule_name =
+    let pos = List.hd rule.Mir.rule_name |> Pos.get_position in
+    let name = List.map Pos.unmark rule.Mir.rule_name |> String.concat "_" in
+    (pos, name ^ "_i" ^ string_of_int instance_id)
+  in
+  let instance = Bir.{ rule_id = instance_id; rule_name; rule_stmts } in
+  ( instance_id,
+    pos,
+    { ctx with rule_instances = Bir.RuleMap.add instance_id instance ctx.rule_instances } )
+
+let wrap_m_code_call (m_program : Mir_interface.full_program) execution_order
+    (defined_vars : Mir.Variable.t list) (args : Mpp_ir.scoped_var list) (ctx : translation_ctx) :
+    translation_ctx * Bir.stmt list =
+  let m_program =
+    reset_and_add_outputs m_program
+      (List.map
+         (function Mpp_ir.Mbased (s, _) -> s.Mir.Variable.name | Local l -> (l, Pos.no_pos))
+         args)
+  in
+  let m_program =
+    {
+      m_program with
+      program =
+        Bir_interpreter.RegularFloatInterpreter.replace_undefined_with_input_variables
+          m_program.program
+          (Mir.VariableMap.map (fun () -> Mir.Undefined) ctx.variables_used_as_inputs);
+    }
+  in
+  (* let rules_stmts =
+   *   List.map (fun rule_id ->
+   *       let exec_order = Mir.RuleMap.find rule_id m_program.rules_execution_order in
+   *       Printf.eprintf "before_translate \n%!";
+   *       let rule_stmts = translate_m_code m_program exec_order in
+   *       Printf.eprintf "after_translate \n%!";
+   *       (rule_id, rule_stmts))
+   *     execution_order
+   * in
+   * let ctx, program_stmts =
+   *   List.fold_left_map
+   *     (fun ctx (rule_id, rule_stmts) ->
+   *       let instance_id, pos, ctx =
+   *         generate_rule_instance m_program rule_id rule_stmts ctx
+   *       in
+   *       (ctx, (Bir.SRuleCall instance_id, pos)))
+   *     ctx rules_stmts
+   * in *)
+  let program_stmts, ctx =
+    List.fold_left
+      (fun (stmts, ctx) rule_id ->
+        let instance_id, pos, ctx = generate_rule_instance m_program rule_id ctx in
+        ((Bir.SRuleCall instance_id, pos) :: stmts, ctx))
+      ([], ctx) execution_order
+  in
+  let program_stmts = List.rev program_stmts in
+  let clean_state =
+    (* no cleaning or no arguments: we may want anything afterwards, so no cleaning *)
+    if (not !Cli.m_clean_calls) || args = [] then []
+    else
+      list_map_opt
+        (fun var ->
+          try
+            let vdef = Mir.VariableMap.find var m_program.program.program_vars in
+            match (vdef.var_definition, vdef.var_io) with
+            | InputVar, _ -> None
+            | _, Regular ->
+                let pos = var.Mir.Variable.execution_number.pos in
+                Some
+                  ( Bir.SAssign
+                      ( var,
+                        {
+                          var_definition = SimpleVar (Mir.Literal Undefined, pos);
+                          var_typ = vdef.var_typ;
+                          var_io = vdef.var_io;
+                        } ),
+                    pos )
+            | _ -> None
+          with Not_found -> None)
+        defined_vars
+  in
+  Cli.var_info_print "|clean_state| += %d" (List.length clean_state);
+  (ctx, program_stmts @ clean_state)
+
 let rec translate_mpp_function (mpp_program : Mpp_ir.mpp_compute list)
     (m_program : Mir_interface.full_program) (compute_decl : Mpp_ir.mpp_compute)
     (args : Mpp_ir.scoped_var list) (ctx : translation_ctx) : translation_ctx * Bir.stmt list =
@@ -233,19 +371,8 @@ and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
   | Mpp_ir.Conditional (e, t, f) ->
       let e' = translate_mpp_expr m_program ctx e in
       let ctx1, rt' = translate_mpp_stmts mpp_program m_program func_args ctx t in
-      let ctx2, rf' =
-        translate_mpp_stmts mpp_program m_program func_args
-          { ctx with new_variables = ctx1.new_variables }
-          f
-      in
-      ( {
-          ctx2 with
-          variables_used_as_inputs =
-            Mir.VariableMap.union
-              (fun _ _ _ -> Some ())
-              ctx1.variables_used_as_inputs ctx2.variables_used_as_inputs;
-        },
-        [ Pos.same_pos_as (Bir.SConditional (e', rt', rf')) stmt ] )
+      let ctx2, rf' = translate_mpp_stmts mpp_program m_program func_args ctx f in
+      (ctx_join ctx1 ctx2, [ Pos.same_pos_as (Bir.SConditional (e', rt', rf')) stmt ])
   | Mpp_ir.Delete (Mbased (var, _)) ->
       ( ctx,
         [
@@ -280,62 +407,8 @@ and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
         real_args ctx
   | Mpp_ir.Expr (Call (Program, args), _) ->
       let real_args = match args with [ Mpp_ir.Local "outputs" ] -> func_args | _ -> args in
-      let m_program =
-        reset_and_add_outputs m_program
-          (List.map
-             (function Mpp_ir.Mbased (s, _) -> s.Mir.Variable.name | Local l -> (l, Pos.no_pos))
-             real_args)
-      in
-      let m_program =
-        {
-          m_program with
-          program =
-            Bir_interpreter.RegularFloatInterpreter.replace_undefined_with_input_variables
-              m_program.program
-              (Mir.VariableMap.map (fun () -> Mir.Undefined) ctx.variables_used_as_inputs);
-        }
-      in
-      let exec_order = m_program.execution_order in
-      let inlined_program =
-        list_map_opt
-          (fun var ->
-            try
-              let vdef = Mir.VariableMap.find var m_program.program.program_vars in
-              match vdef.var_definition with
-              | InputVar -> None
-              | _ ->
-                  (* variables used in the context should not be reassigned *)
-                  Some (Bir.SAssign (var, vdef), var.Mir.Variable.execution_number.pos)
-            with Not_found -> None)
-          exec_order
-      in
-      let clean_state =
-        (* no cleaning or no arguments: we may want anything afterwards, so no cleaning *)
-        if (not !Cli.m_clean_calls) || real_args = [] then []
-        else
-          list_map_opt
-            (fun var ->
-              try
-                let vdef = Mir.VariableMap.find var m_program.program.program_vars in
-                match (vdef.var_definition, vdef.var_io) with
-                | InputVar, _ -> None
-                | _, Regular ->
-                    let pos = var.Mir.Variable.execution_number.pos in
-                    Some
-                      ( Bir.SAssign
-                          ( var,
-                            {
-                              var_definition = SimpleVar (Mir.Literal Undefined, pos);
-                              var_typ = vdef.var_typ;
-                              var_io = vdef.var_io;
-                            } ),
-                        pos )
-                | _ -> None
-              with Not_found -> None)
-            exec_order
-      in
-      Cli.var_info_print "|clean_state| += %d" (List.length clean_state);
-      (ctx, inlined_program @ clean_state)
+      let exec_order = m_program.main_execution_order in
+      wrap_m_code_call m_program exec_order m_program.vars_execution_order real_args ctx
   | Mpp_ir.Partition (filter, body) ->
       let func_of_filter = match filter with Mpp_ir.VarIsTaxBenefit -> var_is_ "avfisc" in
       let ctx, partition_pre, partition_post =
@@ -361,18 +434,17 @@ and generate_partition mpp_program m_program func_args (filter : Mir.Variable.t 
       (fun var _ acc -> if filter var then var :: acc else acc)
       m_program.program.program_vars []
   in
-  let ctx, mpp_pre, mpp_post =
+  let mpp_pre, mpp_post =
     List.fold_left
-      (fun (ctx, stmts_pre, stmts_post) var ->
+      (fun (stmts_pre, stmts_post) var ->
         let shadow_var_name = "_" ^ Pos.unmark var.Mir.Variable.name in
         let open Mpp_ir in
         let shadow_var = Local shadow_var_name in
         let var = Mbased (var, Output) in
-        ( ctx,
-          (Assign (shadow_var, (Variable var, pos)), pos) :: (Delete var, pos) :: stmts_pre,
+        ( (Assign (shadow_var, (Variable var, pos)), pos) :: (Delete var, pos) :: stmts_pre,
           (Assign (var, (Variable shadow_var, pos)), pos) :: (Delete shadow_var, pos) :: stmts_post
         ))
-      (ctx, [], []) vars_to_move
+      ([], []) vars_to_move
   in
   let ctx, pre = translate_mpp_stmts mpp_program m_program func_args ctx mpp_pre in
   let ctx, post = translate_mpp_stmts mpp_program m_program func_args ctx mpp_post in
@@ -398,15 +470,29 @@ let create_combined_program (m_program : Mir_interface.full_program)
         Errors.raise_error
           (Format.asprintf "M++ function %s not found in M++ file!" mpp_function_to_extract)
     in
-    let stmts =
-      snd @@ translate_mpp_function mpp_program m_program decl_to_extract [] emtpy_translation_ctx
+    let ctx, statements =
+      translate_mpp_function mpp_program m_program decl_to_extract [] emtpy_translation_ctx
     in
-    let stmts_verif =
-      generate_verif_conds m_program.execution_order m_program.program.program_conds
+    let conds_verif =
+      generate_verif_conds m_program.vars_execution_order m_program.program.program_conds
     in
-
+    (* let rules =
+     *   Bir.RuleMap.fold
+     *     (fun instance_id rule_id rules ->
+     *       let rule = Mir.RuleMap.find rule_id m_program.program.program_rules in
+     *       let exec_order = Mir.RuleMap.find rule_id m_program.rules_execution_order in
+     *       let rule_stmts = translate_m_code m_program exec_order in
+     *       let rule_name =
+     *         let name = List.map Pos.unmark rule.Mir.rule_name |> String.concat "_" in
+     *         name ^ "_i" ^ string_of_int instance_id
+     *       in
+     *       let rule = Bir.{ rule_id = instance_id; rule_name; rule_stmts } in
+     *       Bir.RuleMap.add instance_id rule rules)
+     *     ctx.rule_instances Bir.RuleMap.empty
+     * in *)
     {
-      statements = stmts @ stmts_verif;
+      rules = ctx.rule_instances;
+      statements = statements @ conds_verif;
       (* we append the M verification conditions at the end, when everything has already been
          computed *)
       idmap = m_program.program.program_idmap;

--- a/src/mlang/optimizing_ir/bir_to_oir.ml
+++ b/src/mlang/optimizing_ir/bir_to_oir.ml
@@ -60,16 +60,25 @@ and translate_statement (p : Bir.program) (s : Bir.stmt) (curr_block_id : Oir.bl
       let last_b2id, blocks = translate_statement_list p l2 b2id blocks in
       let blocks = append_to_block (Oir.SGoto join_block, Pos.no_pos) last_b2id blocks in
       (join_block, blocks)
-  | Bir.SRuleCall _rule_id -> assert false
-(* let rule = Bir.RuleMap.find rule_id p.Bir.rules in
- * translate_statement_list p rule.Bir.rule_stmts curr_block_id blocks *)
+  | Bir.SRuleCall rule_id ->
+      let rule = Bir.RuleMap.find rule_id p.Bir.rules in
+      let stmts =
+        let dummy = fresh_block_id () in
+        let dummy_blocks = initialize_block dummy Oir.BlockMap.empty in
+        let dummy, dummy_blocks = translate_statement_list p rule.rule_stmts dummy dummy_blocks in
+        Oir.BlockMap.find dummy dummy_blocks
+      in
+      let blocks =
+        append_to_block
+          (Pos.same_pos_as (Oir.SRuleCall (rule_id, rule.rule_name, stmts)) s)
+          curr_block_id blocks
+      in
+      (curr_block_id, blocks)
 
 let bir_program_to_oir (p : Bir.program) : Oir.program =
   let entry_block = fresh_block_id () in
   let blocks = initialize_block entry_block Oir.BlockMap.empty in
-  (* CR Keryan: this completely remove rules when optimizing, needs patching *)
-  let statements = Bir.get_all_statements p in
-  let exit_block, blocks = translate_statement_list p statements entry_block blocks in
+  let exit_block, blocks = translate_statement_list p p.statements entry_block blocks in
   let blocks = Oir.BlockMap.map (fun stmts -> List.rev stmts) blocks in
   {
     blocks;
@@ -80,49 +89,62 @@ let bir_program_to_oir (p : Bir.program) : Oir.program =
     outputs = p.outputs;
   }
 
-let rec re_translate_statement (s : Oir.stmt) (blocks : Oir.block Oir.BlockMap.t) :
-    Oir.block_id option * Bir.stmt option =
+let rec re_translate_statement (s : Oir.stmt) (rules : Bir.rule Bir.RuleMap.t)
+    (blocks : Oir.block Oir.BlockMap.t) :
+    Oir.block_id option * Bir.stmt option * Bir.rule Bir.RuleMap.t =
   match Pos.unmark s with
-  | Oir.SAssign (var, data) -> (None, Some (Pos.same_pos_as (Bir.SAssign (var, data)) s))
-  | Oir.SVerif cond -> (None, Some (Pos.same_pos_as (Bir.SVerif cond) s))
+  | Oir.SAssign (var, data) -> (None, Some (Pos.same_pos_as (Bir.SAssign (var, data)) s), rules)
+  | Oir.SVerif cond -> (None, Some (Pos.same_pos_as (Bir.SVerif cond) s), rules)
   | Oir.SConditional (e, b1, b2, join_block) ->
-      let b1 = re_translate_blocks_until b1 blocks (Some join_block) in
-      let b2 = re_translate_blocks_until b2 blocks (Some join_block) in
-      (Some join_block, Some (Pos.same_pos_as (Bir.SConditional (e, b1, b2)) s))
-  | Oir.SGoto b -> (Some b, None)
+      let b1, rules = re_translate_blocks_until b1 blocks rules (Some join_block) in
+      let b2, rules = re_translate_blocks_until b2 blocks rules (Some join_block) in
+      (Some join_block, Some (Pos.same_pos_as (Bir.SConditional (e, b1, b2)) s), rules)
+  | Oir.SGoto b -> (Some b, None, rules)
+  | Oir.SRuleCall (rule_id, rule_name, stmts) ->
+      let _, rule_stmts, rules = re_translate_statement_list stmts rules blocks in
+      if rule_stmts = [] then (None, None, rules)
+      else
+        let rule = Bir.{ rule_id; rule_name; rule_stmts } in
+        (None, Some (Pos.same_pos_as (Bir.SRuleCall rule_id) s), Bir.RuleMap.add rule_id rule rules)
+
+and re_translate_statement_list (stmts : Oir.stmt list) (rules : Bir.rule Bir.RuleMap.t)
+    (blocks : Oir.block Oir.BlockMap.t) =
+  List.fold_left
+    (fun (_, acc, rules) s ->
+      let next_block, stmt, rules = re_translate_statement s rules blocks in
+      (next_block, (match stmt with None -> acc | Some s -> s :: acc), rules))
+    (None, [], rules) stmts
 
 and re_translate_blocks_until (block_id : Oir.block_id) (blocks : Oir.block Oir.BlockMap.t)
-    (stop : Oir.block_id option) : Bir.stmt list =
-  let next_block, stmts = re_translate_block block_id blocks in
-  stmts
-  @
-  match (next_block, stop) with
-  | None, Some _ -> assert false (* should not happen *)
-  | None, None -> []
-  | Some next_block, None -> re_translate_blocks_until next_block blocks stop
-  | Some next_block, Some stop ->
-      if next_block = stop then [] else re_translate_blocks_until next_block blocks (Some stop)
+    (rules : Bir.rule Bir.RuleMap.t) (stop : Oir.block_id option) :
+    Bir.stmt list * Bir.rule Bir.RuleMap.t =
+  let next_block, stmts, rules = re_translate_block block_id rules blocks in
+  let next_stmts, rules =
+    match (next_block, stop) with
+    | None, Some _ -> assert false (* should not happen *)
+    | None, None -> ([], rules)
+    | Some next_block, None -> re_translate_blocks_until next_block blocks rules stop
+    | Some next_block, Some stop ->
+        if next_block = stop then ([], rules)
+        else re_translate_blocks_until next_block blocks rules (Some stop)
+  in
+  (stmts @ next_stmts, rules)
 
-and re_translate_block (block_id : Oir.block_id) (blocks : Oir.block Oir.BlockMap.t) :
-    Oir.block_id option * Bir.stmt list =
+and re_translate_block (block_id : Oir.block_id) (rules : Bir.rule Bir.RuleMap.t)
+    (blocks : Oir.block Oir.BlockMap.t) :
+    Oir.block_id option * Bir.stmt list * Bir.rule Bir.RuleMap.t =
   match Oir.BlockMap.find_opt block_id blocks with
   | None -> assert false (* should not happen *)
   | Some block ->
-      let next_block_id, stmts =
-        List.fold_left
-          (fun (_, acc) s ->
-            let next_block, stmt = re_translate_statement s blocks in
-            (next_block, match stmt with None -> acc | Some s -> s :: acc))
-          (None, []) block
-      in
+      let next_block_id, stmts, rules = re_translate_statement_list block rules blocks in
       let stmts = List.rev stmts in
-      (next_block_id, stmts)
+      (next_block_id, stmts, rules)
 
 let oir_program_to_bir (p : Oir.program) : Bir.program =
-  let statements = re_translate_blocks_until p.entry_block p.blocks None in
+  let statements, rules = re_translate_blocks_until p.entry_block p.blocks Bir.RuleMap.empty None in
   {
     statements = Bir.remove_empty_conditionals statements;
-    rules = Bir.RuleMap.empty;
+    rules;
     idmap = p.idmap;
     mir_program = p.mir_program;
     outputs = p.outputs;

--- a/src/mlang/optimizing_ir/bir_to_oir.ml
+++ b/src/mlang/optimizing_ir/bir_to_oir.ml
@@ -70,7 +70,7 @@ and translate_statement (p : Bir.program) (s : Bir.stmt) (curr_block_id : Oir.bl
       in
       let blocks =
         append_to_block
-          (Pos.same_pos_as (Oir.SRuleCall (rule_id, rule.rule_name, stmts)) s)
+          (Pos.same_pos_as (Oir.SRuleCall (rule_id, rule.rule_name, List.rev stmts)) s)
           curr_block_id blocks
       in
       (curr_block_id, blocks)
@@ -101,7 +101,8 @@ let rec re_translate_statement (s : Oir.stmt) (rules : Bir.rule Bir.RuleMap.t)
       (Some join_block, Some (Pos.same_pos_as (Bir.SConditional (e, b1, b2)) s), rules)
   | Oir.SGoto b -> (Some b, None, rules)
   | Oir.SRuleCall (rule_id, rule_name, stmts) ->
-      let _, rule_stmts, rules = re_translate_statement_list stmts rules blocks in
+      let _, stmts, rules = re_translate_statement_list stmts rules blocks in
+      let rule_stmts = List.rev stmts in
       if rule_stmts = [] then (None, None, rules)
       else
         let rule = Bir.{ rule_id; rule_name; rule_stmts } in

--- a/src/mlang/optimizing_ir/dead_code_removal.ml
+++ b/src/mlang/optimizing_ir/dead_code_removal.ml
@@ -21,10 +21,10 @@ let remove_dead_statements (stmts : block) (id : block_id) (path_checker : Paths
     pos_map * pos_map * stmt list =
   (* used_vars contains, for each variable, the location of the top-most use of this variables in
      every basic block *)
-  let update_used_vars (stmt_used_vars : unit Mir.VariableMap.t) (pos : int) (used_vars : pos_map) :
+  let update_used_vars (stmt_used_vars : Mir.VariableDict.t) (pos : int) (used_vars : pos_map) :
       pos_map =
-    Mir.VariableMap.fold
-      (fun stmt_used_var _ (used_vars : pos_map) ->
+    Mir.VariableDict.fold
+      (fun stmt_used_var (used_vars : pos_map) ->
         Mir.VariableMap.update stmt_used_var
           (fun old_entry ->
             match old_entry with
@@ -42,7 +42,7 @@ let remove_dead_statements (stmts : block) (id : block_id) (path_checker : Paths
         match Pos.unmark stmt with
         | SAssign (var, var_def) ->
             let used_defs_returned =
-              update_used_vars (Mir.VariableMap.singleton var ()) pos used_defs
+              update_used_vars (Mir.VariableDict.singleton var) pos used_defs
             in
             if
               (* here we determine whether this definition is useful or not*)
@@ -106,7 +106,7 @@ let remove_dead_statements (stmts : block) (id : block_id) (path_checker : Paths
                         Mir.IndexMap.fold
                           (fun _ e used_vars ->
                             Mir_dependency_graph.get_used_variables_ e used_vars)
-                          es Mir.VariableMap.empty)
+                          es Mir.VariableDict.empty)
                 | Mir.InputVar -> assert false
                 (* should not happen *)
               in

--- a/src/mlang/optimizing_ir/dead_code_removal.ml
+++ b/src/mlang/optimizing_ir/dead_code_removal.ml
@@ -114,6 +114,7 @@ let remove_dead_statements (stmts : block) (id : block_id) (path_checker : Paths
                 stmt :: acc,
                 pos - 1 )
             else (used_vars, used_defs_returned, acc, pos - 1)
+        (* CR Keryan: why updated [used_defs] here ? This definition is removed *)
         | SVerif cond ->
             let stmt_used_vars = Mir_dependency_graph.get_used_variables cond.cond_expr in
             (update_used_vars stmt_used_vars pos used_vars, used_defs, stmt :: acc, pos - 1)

--- a/src/mlang/optimizing_ir/format_oir.ml
+++ b/src/mlang/optimizing_ir/format_oir.ml
@@ -16,16 +16,19 @@ open Oir
 let rec format_stmt fmt (stmt : stmt) =
   match Pos.unmark stmt with
   | SAssign (v, vdata) ->
-      Format.fprintf fmt "%s = %a" (Pos.unmark v.Mir.Variable.name) Format_mir.format_variable_def
+      Format.fprintf fmt "%s = %a@," (Pos.unmark v.Mir.Variable.name) Format_mir.format_variable_def
         vdata.var_definition
   | SConditional (cond, b1, b2, _) ->
-      Format.fprintf fmt "if(%a) then goto %d else goto %d" Format_mir.format_expression cond b1 b2
+      Format.fprintf fmt "if(%a) then goto %d else goto %d@," Format_mir.format_expression cond b1
+        b2
   | SVerif cond_data ->
-      Format.fprintf fmt "assert (%a) or raise %a" Format_mir.format_expression
+      Format.fprintf fmt "assert (%a) or raise %a@," Format_mir.format_expression
         (Pos.unmark cond_data.cond_expr)
         (Format_mast.pp_print_list_comma Format_mir.format_error)
         cond_data.cond_errors
-  | SGoto b -> Format.fprintf fmt "goto %d" b
+  | SGoto b -> Format.fprintf fmt "goto %d@," b
+  | SRuleCall (_rid, name, stmts) ->
+      Format.fprintf fmt "call(%s)@[<v 3>{@,%a@]}@," name format_stmts stmts
 
 and format_stmts fmt (stmts : stmt list) =
   Format.pp_print_list ~pp_sep:(fun _ () -> ()) format_stmt fmt stmts

--- a/src/mlang/optimizing_ir/inlining.ml
+++ b/src/mlang/optimizing_ir/inlining.ml
@@ -204,12 +204,12 @@ let rec inline_in_expr (e : Mir.expression) (ctx : ctx) (current_block : block_i
       in
       Mir.FunctionCall (f, new_args)
 
-let inline_in_stmt (stmt : stmt) (ctx : ctx) (current_block : block_id) (current_stmt_pos : int) :
-    stmt * ctx =
+let rec inline_in_stmt (stmt : stmt) (ctx : ctx) (current_block : block_id) (current_stmt_pos : int)
+    : stmt * ctx * int =
   match Pos.unmark stmt with
   | SAssign (var, data) -> (
       match data.var_definition with
-      | InputVar -> (stmt, ctx)
+      | InputVar -> (stmt, ctx, current_stmt_pos)
       | SimpleVar def ->
           let new_def = inline_in_expr (Pos.unmark def) ctx current_block current_stmt_pos in
           let new_def = Mir.SimpleVar (Pos.same_pos_as new_def def) in
@@ -217,7 +217,7 @@ let inline_in_stmt (stmt : stmt) (ctx : ctx) (current_block : block_id) (current
             Pos.same_pos_as (SAssign (var, { data with var_definition = new_def })) stmt
           in
           let new_ctx = add_var_def_to_ctx var new_def current_block current_stmt_pos ctx in
-          (new_stmt, new_ctx)
+          (new_stmt, new_ctx, current_stmt_pos)
       | TableVar (size, defs) -> (
           match defs with
           | IndexGeneric def ->
@@ -227,7 +227,7 @@ let inline_in_stmt (stmt : stmt) (ctx : ctx) (current_block : block_id) (current
                 Pos.same_pos_as (SAssign (var, { data with var_definition = new_def })) stmt
               in
               let new_ctx = add_var_def_to_ctx var new_def current_block current_stmt_pos ctx in
-              (new_stmt, new_ctx)
+              (new_stmt, new_ctx, current_stmt_pos)
           | IndexTable defs ->
               let new_defs =
                 Mir.IndexMap.map
@@ -242,18 +242,28 @@ let inline_in_stmt (stmt : stmt) (ctx : ctx) (current_block : block_id) (current
                 Pos.same_pos_as (SAssign (var, { data with var_definition = new_defs })) stmt
               in
               let new_ctx = add_var_def_to_ctx var new_defs current_block current_stmt_pos ctx in
-              (new_stmt, new_ctx)))
+              (new_stmt, new_ctx, current_stmt_pos)))
   | SVerif cond ->
       let new_e = inline_in_expr (Pos.unmark cond.cond_expr) ctx current_block current_stmt_pos in
       let new_stmt =
         Pos.same_pos_as (SVerif { cond with cond_expr = Pos.same_pos_as new_e cond.cond_expr }) stmt
       in
-      (new_stmt, ctx)
+      (new_stmt, ctx, current_stmt_pos)
   | SConditional (cond, b1, b2, join) ->
       let new_cond = inline_in_expr cond ctx current_block current_stmt_pos in
       let new_stmt = Pos.same_pos_as (SConditional (new_cond, b1, b2, join)) stmt in
-      (new_stmt, ctx)
-  | _ -> (stmt, ctx)
+      (new_stmt, ctx, current_stmt_pos)
+  | SGoto _ -> (stmt, ctx, current_stmt_pos)
+  | SRuleCall (rule_id, name, stmts) ->
+      let new_stmts, ctx, new_pos =
+        List.fold_left
+          (fun (stmts, ctx, stmt_pos) stmt ->
+            let new_stmt, new_ctx, new_pos = inline_in_stmt stmt ctx current_block stmt_pos in
+            (new_stmt :: stmts, new_ctx, new_pos + 1))
+          ([], ctx, current_stmt_pos) stmts
+      in
+      let new_stmt = Pos.same_pos_as (SRuleCall (rule_id, name, List.rev new_stmts)) stmt in
+      (new_stmt, ctx, new_pos)
 
 let inlining (p : program) : program =
   let g = get_cfg p in
@@ -264,8 +274,8 @@ let inlining (p : program) : program =
         let new_block, ctx, _ =
           List.fold_left
             (fun (new_block, ctx, stmt_pos) stmt ->
-              let new_stmt, new_ctx = inline_in_stmt stmt ctx block_id stmt_pos in
-              (new_stmt :: new_block, new_ctx, stmt_pos + 1))
+              let new_stmt, new_ctx, new_pos = inline_in_stmt stmt ctx block_id stmt_pos in
+              (new_stmt :: new_block, new_ctx, new_pos + 1))
             ([], ctx, 0) block
         in
         ({ p with blocks = BlockMap.add block_id (List.rev new_block) p.blocks }, ctx))

--- a/src/mlang/optimizing_ir/inlining.ml
+++ b/src/mlang/optimizing_ir/inlining.ml
@@ -124,8 +124,8 @@ let rec inline_in_expr (e : Mir.expression) (ctx : ctx) (current_block : block_i
                             && Paths.check_path ctx.ctx_paths intermediate_block current_block)
                         var_defs
                     in
-                    Mir.VariableMap.for_all
-                      (fun var _ -> not (exists_def_between_previous_x_def_and_here var))
+                    Mir.VariableDict.for_all
+                      (fun var -> not (exists_def_between_previous_x_def_and_here var))
                       vars_used_in_previous_x_def
                     && not (exists_def_between_previous_x_def_and_here var_x)
                 | _ -> false)

--- a/src/mlang/test_framework/test_interpreter.ml
+++ b/src/mlang/test_framework/test_interpreter.ml
@@ -100,7 +100,7 @@ let add_test_conds_to_combined_program (p : Bir.program) (conds : condition_data
     Bir.program =
   (* because evaluate_program redefines everything each time, we have to make sure that the
      redefinitions of our constant inputs are removed from the main list of statements *)
-  let new_stmts =
+  let filter_stmts stmts =
     List.filter_map
       (fun stmt ->
         match Pos.unmark stmt with
@@ -120,8 +120,9 @@ let add_test_conds_to_combined_program (p : Bir.program) (conds : condition_data
             | InputVar -> None
             | _ -> Some (Pos.same_pos_as (Bir.SAssign (var, new_var_data)) stmt))
         | _ -> Some stmt)
-      p.Bir.statements
+      stmts
   in
+  let new_stmts = filter_stmts p.Bir.statements in
   let conditions_stmts =
     VariableMap.fold
       (fun _ cond stmts -> (Bir.SVerif cond, Pos.get_position cond.cond_expr) :: stmts)


### PR DESCRIPTION
This addresses issue #26.

For now it only applies to unoptimized compilation pipeline, and only changes the C backend.

For a reason yet unknown, it decreases efficiency and performance of the optimisations passes (yes, even without actually changing things). I hope a review could give some insight on this.