### PR TITLE
Removed obsolete ppx features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 ENV APT_DEPS opam libgmp-dev libmpfr-dev m4 perl python3 clang git
 
-ENV OPAM_DEPS ppx_deriving ANSITerminal re ocamlgraph dune menhir cmdliner dune-build-info visitors parmap num ocamlformat mlgmpidl
+ENV OPAM_DEPS ANSITerminal re ocamlgraph dune menhir cmdliner dune-build-info parmap num ocamlformat mlgmpidl
 
 ENV TERM xterm-256color
 

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ default: build
 ##################################################
 
 deps:
-	opam install ppx_deriving ANSITerminal re ocamlgraph dune menhir \
-		cmdliner dune-build-info visitors parmap num ocamlformat mlgmpidl \
+	opam install ANSITerminal re ocamlgraph dune menhir \
+		cmdliner dune-build-info parmap num ocamlformat mlgmpidl \
 		ocamlformat
 	git submodule update --init --recursive
 

--- a/dune-project
+++ b/dune-project
@@ -35,10 +35,6 @@
    (= 0.8.2))
   (re
    (= 1.9.0))
-  (ppx_deriving
-   (= 4.5))
-  (visitors
-   (>= 20200210))
   (ocamlgraph
    (= 1.8.8))
   (dune-build-info

--- a/mlang.opam
+++ b/mlang.opam
@@ -19,8 +19,6 @@ depends: [
   "dune" {build}
   "ANSITerminal" {= "0.8.2"}
   "re" {= "1.9.0"}
-  "ppx_deriving" {= "4.5"}
-  "visitors" {>= "20200210"}
   "ocamlgraph" {= "1.8.8"}
   "dune-build-info" {= "2.5.1"}
   "num" {>= "1.3"}

--- a/src/dune
+++ b/src/dune
@@ -9,6 +9,4 @@
  (public_name mlang)
  (ocamlopt_flags
   (-cclib -lstdc++))
- (libraries mlang)
- (preprocess
-  (pps ppx_deriving.std visitors.ppx)))
+ (libraries mlang))

--- a/src/mlang/dune
+++ b/src/mlang/dune
@@ -5,9 +5,7 @@
  (ocamlopt_flags
   (-cclib -lstdc++))
  (libraries ocamlgraph re ANSITerminal parmap cmdliner threads
-   dune-build-info num gmp)
- (preprocess
-  (pps ppx_deriving.std visitors.ppx)))
+   dune-build-info num gmp))
 
 (documentation
  (package mlang)

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -111,9 +111,8 @@ end
 
 (** Type of MVG values *)
 type typ = Real
-[@@deriving visitors { variety = "iter"; nude = true; polymorphic = true; name = "typ_iter" }]
 
-type literal = Float of float | Undefined [@@deriving eq, ord]
+type literal = Float of float | Undefined
 
 let false_literal = Float 0.
 
@@ -141,17 +140,6 @@ type func =
     Because translating to MVG requires a lot of unrolling and expansion, we introduce a [LocalLet]
     construct to avoid code duplication. *)
 
-let current_visitor_pos : Pos.t ref = ref Pos.no_pos
-
-(** Custom visitor for the [Pos.marked] type *)
-class ['self] marked_iter =
-  object
-    method visit_marked : 'env 'a. ('env -> 'a -> unit) -> 'env -> 'a Pos.marked -> unit =
-      fun f env x ->
-        current_visitor_pos := Pos.get_position x;
-        f env (Pos.unmark x)
-  end
-
 type expression =
   | Unop of (Mast.unop[@opaque]) * expression Pos.marked
   | Comparison of (Mast.comp_op[@opaque]) Pos.marked * expression Pos.marked * expression Pos.marked
@@ -165,7 +153,6 @@ type expression =
   | GenericTableIndex
   | Error
   | LocalLet of (LocalVariable.t[@opaque]) * expression Pos.marked * expression Pos.marked
-[@@deriving visitors { variety = "iter"; ancestors = [ "marked_iter" ]; name = "expression_iter" }]
 
 (** MVG programs are just mapping from variables to their definitions, and make a massive use of
     [VariableMap]. *)
@@ -229,34 +216,15 @@ module IndexMap = struct
       map
 end
 
-(** Custom visitor for the [IndexMap.t] type *)
-class ['self] index_map_iter =
-  object
-    method visit_index_map : 'env 'a. ('env -> 'a -> unit) -> 'env -> 'a IndexMap.t -> unit =
-      fun f env x -> IndexMap.iter (fun _ x -> f env x) x
-  end
-
 type index_def =
   | IndexTable of (expression Pos.marked IndexMap.t[@name "index_map"])
   | IndexGeneric of expression Pos.marked
-[@@deriving
-  visitors
-    {
-      variety = "iter";
-      ancestors = [ "index_map_iter"; "expression_iter" ];
-      nude = true;
-      name = "index_def_iter";
-    }]
 
 (** The definitions here are modeled closely to the source M language. One could also adopt a more
     lambda-calculus-compatible model with functions used to model tables. *)
 type variable_def = SimpleVar of expression Pos.marked | TableVar of int * index_def | InputVar
-[@@deriving
-  visitors
-    { variety = "iter"; ancestors = [ "index_def_iter" ]; nude = true; name = "variable_def_iter" }]
 
 type io = Input | Output | Regular
-[@@deriving visitors { variety = "iter"; nude = true; name = "io_iter" }]
 
 type variable_data = {
   var_definition : variable_def;
@@ -264,14 +232,6 @@ type variable_data = {
       (** The typing info here comes from the variable declaration in the source program *)
   var_io : io;
 }
-[@@deriving
-  visitors
-    {
-      variety = "iter";
-      ancestors = [ "variable_def_iter"; "io_iter"; "typ_iter" ];
-      nude = true;
-      name = "variable_data_iter";
-    }]
 
 type rule_id = int
 
@@ -348,14 +308,6 @@ module Error = struct
 end
 
 type condition_data = { cond_expr : expression Pos.marked; cond_errors : (Error.t[@opaque]) list }
-[@@deriving
-  visitors
-    {
-      variety = "iter";
-      ancestors = [ "expression_iter" ];
-      nude = true;
-      name = "condition_data_iter";
-    }]
 
 type idmap = Variable.t list Pos.VarNameToID.t
 (** We translate string variables into first-class unique {!type: Mir.Variable.t}, so we need to

--- a/src/mlang/optimizing_ir/partial_evaluation.ml
+++ b/src/mlang/optimizing_ir/partial_evaluation.ml
@@ -13,7 +13,7 @@
 
 open Oir
 
-type partial_expr = PartialLiteral of Mir.literal | UnknownFloat [@@deriving ord]
+type partial_expr = PartialLiteral of Mir.literal | UnknownFloat
 
 let format_partial_expr fmt pe =
   match pe with
@@ -72,7 +72,6 @@ let expr_to_partial (e : Mir.expression) (d : definedness) : partial_expr option
   | _ -> None
 
 type var_literal = SimpleVar of partial_expr | TableVar of int * partial_expr array
-[@@deriving ord]
 
 let format_var_literal fmt v =
   match v with
@@ -168,7 +167,7 @@ let get_closest_dominating_def (var : Mir.Variable.t) (ctx : partial_ev_ctx) : v
                     Paths.check_path ctx.ctx_paths def_block intermediate_block
                     && Paths.check_path ctx.ctx_paths intermediate_block curr_block
                     (* if the definition is the same, this is not an issue *)
-                    && (Option.compare compare_var_literal) ov (Some def) <> 0)
+                    && (Option.compare Stdlib.compare) ov (Some def) <> 0)
                 defs
             in
             if BlockMap.cardinal exists_other_def_in_between > 0 then


### PR DESCRIPTION
There were exactly *one* remaining occurrence of call to derived functions, that could be replaced with `Stdlib.compare` which should be semantically equivalent.