### PR TITLE
Changes Makefiles to be able to use gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Check Makefile.config.template if you want to override some of the flags
+# in this Makefile.
+
 include Makefile.include
 
 ifeq ($(OPTIMIZE), 1)
@@ -28,8 +31,6 @@ MLANG_DEFAULT_OPTS=\
 	--mpp_function=$(MPP_FUNCTION)
 
 MLANG=$(MLANG_BIN) $(MLANG_DEFAULT_OPTS) $(OPTIMIZE_FLAG) $(CODE_COVERAGE_FLAG)
-
-DUNE_OPTIONS?=
 
 default: build
 

--- a/Makefile.config.template
+++ b/Makefile.config.template
@@ -1,4 +1,4 @@
-# Copy this file as Makefile.config to change some of these variables
+# Copy this file as Makefile.config and change some of these variables
 
 # YEAR=2018
 
@@ -11,3 +11,11 @@
 # M_SPEC_FILE=$(SELF_DIR)/m_specs/complex_case_with_ins_outs_2018.m_spec
 
 # CC:=gcc
+
+# TEST_ERROR_MARGIN=0.
+
+# PRECISION=double
+
+# DUNE_OPTIONS=
+
+# C_COMPILER=clang

--- a/Makefile.include
+++ b/Makefile.include
@@ -35,3 +35,5 @@ else ifeq ($(YEAR), 2020)
 else
     $(error Unsupported year: $(YEAR))
 endif
+
+C_COMPILER?=clang

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ For how to produce ready-to-use income tax computation
 source files for your application, see the
 [dedicated README](examples/README.md).
 
+Some of the `Makefile` flags can be permanently configured by creating
+a file `Makefile.config` in the top directory. Check the file
+`Makefile.config.template` to see some of the options that can be
+configured in that way.
 
 ## Testing
 

--- a/examples/c/Makefile
+++ b/examples/c/Makefile
@@ -28,10 +28,14 @@ ir_%.c: ../../m_specs/%.m_spec $(SOURCE_FILES)
 # Compiling the generated C
 ##################################################
 
-C_COMPILER=clang
+ifeq ($(C_COMPILER), clang)
+    F_BRACKET_OPT=-fbracket-depth=2048
+else
+    F_BRACKET_OPT=
+endif
 
 ir_%.o: ir_%.c
-	$(C_COMPILER) -fbracket-depth=2048 $(C_OPT) -c $< m_value.c
+	$(C_COMPILER) $(F_BRACKET_OPT) $(C_OPT) -c $< m_value.c
 
 %.o: %.c
 	$(C_COMPILER) -c $<
@@ -42,7 +46,7 @@ ir_%.o: ir_%.c
 
 # To call this target, use "make run_<name of file in m_spec/ without extension>.exe"
 run_%.exe: ir_%.o run_%.o m_value.o
-	$(C_COMPILER) -lm -o $@ $^
+	$(C_COMPILER) -o $@ $^ -lm
 
 ##################################################
 # Running the tests

--- a/examples/c/README.md
+++ b/examples/c/README.md
@@ -78,6 +78,11 @@ To produce the executables that link the generated .c with a small tester, use
 
     make run_<name_of_the_m_spec_file>.exe
 
+You can also set the `YEAR` variable in a file `Makefile.config` in the
+top-directory of the project (see the `Makefile.config.template` file
+in that directory). The `C_COMPILER` variable can also be used to use
+in a different C compiler.
+
 ### Testing the correctness of the Mlang backend
 
 The `backend_tests` folder contains a small utility that compares the output

--- a/examples/c/backend_tests/Makefile
+++ b/examples/c/backend_tests/Makefile
@@ -40,7 +40,6 @@ ir_%.c: %.m_spec $(SOURCE_FILES)
 # Compiling the generated C
 ##################################################
 
-C_COMPILER?=clang
 CC=$(C_COMPILER)
 
 ifeq ($(C_COMPILER), clang)
@@ -61,14 +60,14 @@ ir_%.o: ir_%.c
 ##################################################
 
 test_harness.exe: ir_tests.o test_harness.o ../m_value.o
-	$(CC) -fPIE -lm -o $@ $^
+	$(CC) -fPIE -o $@ $^ -lm
 
 run_tests: test_harness.exe FORCE
 	ulimit -s 32768; \
 	./$< $(TESTS_DIR)
 
 perf_harness.exe: ir_tests.o perf_harness.o ../m_value.o
-	$(CC) -fPIE -lm -o $@ $^
+	$(CC) -fPIE -o $@ $^ -lm
 
 run_perf: perf_harness.exe FORCE
 	ulimit -s 32768; \

--- a/examples/dgfip_c/Makefile
+++ b/examples/dgfip_c/Makefile
@@ -30,10 +30,14 @@ ir_%.c: ../../m_specs/%.m_spec $(SOURCE_FILES)
 # Compiling the generated C
 ##################################################
 
-C_COMPILER=clang
+ifeq ($(C_COMPILER), clang)
+    F_BRACKET_OPT=-fbracket-depth=2048
+else
+    F_BRACKET_OPT=
+endif
 
 ir_%.o: ir_%.c
-	$(C_COMPILER) -fbracket-depth=2048 $(C_OPT) -c $< m_value.c
+	$(C_COMPILER) $(F_BRACKET_OPT) $(C_OPT) -c $< m_value.c
 
 %.o: %.c
 	$(C_COMPILER) -c $<

--- a/examples/dgfip_c/backend_tests/Makefile
+++ b/examples/dgfip_c/backend_tests/Makefile
@@ -49,7 +49,6 @@ enchain.c: tests.m_spec $(SOURCE_FILES)
 # Compiling the generated C
 ##################################################
 
-C_COMPILER?=clang
 CC=$(C_COMPILER)
 
 ifeq ($(C_COMPILER), clang)


### PR DESCRIPTION
To use 'gcc', create a file 'Makefile.config' with 'C_COMPILER=gcc'. More options can be changed in that file, see comment in top `Makefile`.