### PR TITLE
Fix error raising

### DIFF
--- a/src/mlang/backend_compilers/bir_to_c.ml
+++ b/src/mlang/backend_compilers/bir_to_c.ml
@@ -171,7 +171,7 @@ let generate_var_def (var_indexes : int Mir.VariableMap.t) (var : Mir.Variable.t
 
 let generate_var_cond (var_indexes : int Mir.VariableMap.t) (cond : condition_data)
     (oc : Format.formatter) =
-  if List.exists (fun (item : Error.t) -> item.typ = Mast.Anomaly) cond.cond_errors then
+  if (fst cond.cond_error).typ = Mast.Anomaly then
     let scond, defs = generate_c_expr cond.cond_expr var_indexes in
     let percent = Re.Pcre.regexp "%" in
     Format.fprintf oc
@@ -187,13 +187,11 @@ let generate_var_cond (var_indexes : int Mir.VariableMap.t) (cond : condition_da
        }@\n"
       (format_local_vars_defs var_indexes)
       defs scond
-      (Format.pp_print_list
-         ~pp_sep:(fun fmt () -> Format.fprintf fmt "; ")
-         (fun fmt err ->
-           let error_descr = Mir.Error.err_descr_string err |> Pos.unmark in
-           let error_descr = Re.Pcre.substitute ~rex:percent ~subst:(fun _ -> "%%") error_descr in
-           Format.fprintf fmt "%s: %s" (Pos.unmark err.Error.name) error_descr))
-      cond.cond_errors
+      (fun fmt err ->
+        let error_descr = Mir.Error.err_descr_string err |> Pos.unmark in
+        let error_descr = Re.Pcre.substitute ~rex:percent ~subst:(fun _ -> "%%") error_descr in
+        Format.fprintf fmt "%s: %s" (Pos.unmark err.Error.name) error_descr)
+      (fst cond.cond_error)
 
 let fresh_cond_counter = ref 0
 

--- a/src/mlang/backend_compilers/bir_to_python.ml
+++ b/src/mlang/backend_compilers/bir_to_python.ml
@@ -305,7 +305,7 @@ let sanitize_str (s, p) =
     s
 
 let generate_var_cond cond oc =
-  if List.exists (fun (item : Error.t) -> item.typ = Mast.Anomaly) cond.cond_errors then
+  if (fst cond.cond_error).typ = Mast.Anomaly then
     Format.fprintf oc
       "# Verification condition %a@\n\
        cond = %a@\n\
@@ -314,12 +314,10 @@ let generate_var_cond cond oc =
        @\n"
       Pos.format_position_short (Pos.get_position cond.cond_expr) (generate_python_expr true)
       cond.cond_expr
-      (Format.pp_print_list
-         ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
-         (fun fmt err ->
-           Format.fprintf fmt "%s: %s" (sanitize_str err.Error.name)
-             (Error.err_descr_string err |> sanitize_str)))
-      cond.cond_errors
+      (fun fmt err ->
+        Format.fprintf fmt "%s: %s" (sanitize_str err.Error.name)
+          (Error.err_descr_string err |> sanitize_str))
+      (fst cond.cond_error)
 
 let rec generate_stmts (program : Bir.program) oc stmts =
   Format.pp_print_list (generate_stmt program) oc stmts

--- a/src/mlang/backend_ir/bir_interface.ml
+++ b/src/mlang/backend_ir/bir_interface.ml
@@ -117,7 +117,7 @@ let translate_external_conditions idmap (conds : Mast.expression Pos.marked list
           Errors.raise_spanned_error "condition should have type bool" (Pos.get_position cond)
         else
           Pos.same_pos_as
-            { Mast.verif_cond_expr = mk_neg cond; verif_cond_errors = [ ("-1", Pos.no_pos) ] }
+            { Mast.verif_cond_expr = mk_neg cond; verif_cond_error = (("-1", Pos.no_pos), None) }
             cond
           :: acc)
       [] conds

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -76,7 +76,7 @@ module type S = sig
     | IncorrectOutputVariable of string * Pos.t
     | UnknownInputVariable of string * Pos.t
     | ConditionViolated of
-        Mir.Error.t list * Mir.expression Pos.marked * (Mir.Variable.t * var_value) list
+        Mir.Error.t * Mir.expression Pos.marked * (Mir.Variable.t * var_value) list
     | NanOrInf of string * Mir.expression Pos.marked
     | StructuredError of (string * (string option * Pos.t) list * (unit -> unit) option)
 
@@ -187,7 +187,7 @@ module Make (N : Bir_number.NumberInterface) = struct
     | IndexOutOfBounds of string * Pos.t
     | IncorrectOutputVariable of string * Pos.t
     | UnknownInputVariable of string * Pos.t
-    | ConditionViolated of Error.t list * expression Pos.marked * (Variable.t * var_value) list
+    | ConditionViolated of Error.t * expression Pos.marked * (Variable.t * var_value) list
     | NanOrInf of string * expression Pos.marked
     | StructuredError of (string * (string option * Pos.t) list * (unit -> unit) option)
 
@@ -292,7 +292,7 @@ module Make (N : Bir_number.NumberInterface) = struct
         Errors.raise_spanned_error (Format.asprintf "Unknown input variable: %s" s) pos
     | IncorrectOutputVariable (s, pos) ->
         Errors.raise_spanned_error (Format.asprintf "Incorrect output variable: %s" s) pos
-    | ConditionViolated (errors, condition, bindings) ->
+    | ConditionViolated (error, condition, bindings) ->
         Errors.raise_spanned_error_with_continuation
           (Format.asprintf
              "Verification condition failed! Errors thrown:\n\
@@ -301,10 +301,10 @@ module Make (N : Bir_number.NumberInterface) = struct
              \  * %a\n\
               Values of the relevant variables at this point:\n\
               %a"
-             (Format_mast.pp_print_list_endline (fun fmt err ->
-                  Format.fprintf fmt "Error %s [%s]" (Pos.unmark err.Error.name)
-                    (Pos.unmark @@ Error.err_descr_string err)))
-             errors Format_mir.format_expression (Pos.unmark condition)
+             (fun fmt err ->
+               Format.fprintf fmt "Error %s [%s]" (Pos.unmark err.Error.name)
+                 (Pos.unmark @@ Error.err_descr_string err))
+             error Format_mir.format_expression (Pos.unmark condition)
              (Format_mast.pp_print_list_endline (fun fmt v ->
                   Format.fprintf fmt "  * %a" format_var_value_with_var v))
              bindings)
@@ -513,31 +513,29 @@ module Make (N : Bir_number.NumberInterface) = struct
     else out
 
   let report_violatedcondition (cond : condition_data) (ctx : ctx) : 'a =
-    List.fold_left
-      (fun ctx err ->
-        match err.Error.typ with
-        | Mast.Anomaly ->
-            raise
-              (RuntimeError
-                 ( ConditionViolated
-                     ( cond.cond_errors,
-                       cond.cond_expr,
-                       List.rev
-                       @@ List.fold_left
-                            (fun acc var -> (var, VariableMap.find var ctx.ctx_vars) :: acc)
-                            []
-                            (List.map
-                               (fun (_, x) -> x)
-                               (Mir.VariableDict.bindings
-                                  (Mir_dependency_graph.get_used_variables cond.cond_expr))) ),
-                   ctx ))
-        | Mast.Discordance ->
-            Cli.warning_print "Anomaly: %s" (Pos.unmark (Error.err_descr_string err));
-            ctx
-        | Mast.Information ->
-            Cli.debug_print "Information: %s" (Pos.unmark (Error.err_descr_string err));
-            ctx)
-      ctx cond.cond_errors
+    let err = fst cond.cond_error in
+    match err.Error.typ with
+    | Mast.Anomaly ->
+        raise
+          (RuntimeError
+             ( ConditionViolated
+                 ( fst cond.cond_error,
+                   cond.cond_expr,
+                   List.rev
+                   @@ List.fold_left
+                        (fun acc var -> (var, VariableMap.find var ctx.ctx_vars) :: acc)
+                        []
+                        (List.map
+                           (fun (_, x) -> x)
+                           (Mir.VariableDict.bindings
+                              (Mir_dependency_graph.get_used_variables cond.cond_expr))) ),
+               ctx ))
+    | Mast.Discordance ->
+        Cli.warning_print "Anomaly: %s" (Pos.unmark (Error.err_descr_string err));
+        ctx
+    | Mast.Information ->
+        Cli.debug_print "Information: %s" (Pos.unmark (Error.err_descr_string err));
+        ctx
 
   let evaluate_variable (p : Bir.program) (ctx : ctx) (vdef : variable_def) : var_value =
     match vdef with

--- a/src/mlang/backend_ir/bir_interpreter.mli
+++ b/src/mlang/backend_ir/bir_interpreter.mli
@@ -91,7 +91,7 @@ module type S = sig
     | IncorrectOutputVariable of string * Pos.t
     | UnknownInputVariable of string * Pos.t
     | ConditionViolated of
-        Mir.Error.t list * Mir.expression Pos.marked * (Mir.Variable.t * var_value) list
+        Mir.Error.t * Mir.expression Pos.marked * (Mir.Variable.t * var_value) list
     | NanOrInf of string * Mir.expression Pos.marked
     | StructuredError of (string * (string option * Pos.t) list * (unit -> unit) option)
 

--- a/src/mlang/backend_ir/format_bir.ml
+++ b/src/mlang/backend_ir/format_bir.ml
@@ -26,10 +26,11 @@ let rec format_stmt fmt (stmt : stmt) =
       Format.fprintf fmt "if(%a):@\n@[<h 2>  %a@]else:@\n@[<h 2>  %a@]@\n"
         Format_mir.format_expression cond format_stmts t format_stmts f
   | SVerif cond_data ->
-      Format.fprintf fmt "assert (%a) or raise %a" Format_mir.format_expression
-        (Pos.unmark cond_data.cond_expr)
-        (Format_mast.pp_print_list_comma Format_mir.format_error)
-        cond_data.cond_errors
+      Format.fprintf fmt "assert (%a) or raise %a%a" Format_mir.format_expression
+        (Pos.unmark cond_data.cond_expr) Format_mir.format_error (fst cond_data.cond_error)
+        (Format.pp_print_option (fun fmt v ->
+             Format.fprintf fmt " (%s)" (Pos.unmark v.Mir.Variable.name)))
+        (snd cond_data.cond_error)
   | SRuleCall r -> Format.fprintf fmt "call_rule(%d)@\n" r
 
 and format_stmts fmt (stmts : stmt list) =

--- a/src/mlang/m_frontend/format_mast.ml
+++ b/src/mlang/m_frontend/format_mast.ml
@@ -215,9 +215,10 @@ let format_variable_decl fmt (v : variable_decl) =
   | InputVar v -> format_input_variable fmt (Pos.unmark v)
 
 let format_verification_condition fmt (vc : verification_condition) =
-  Format.fprintf fmt "si %a\n alors erreur %a;" format_expression (Pos.unmark vc.verif_cond_expr)
-    (pp_print_list_space (pp_unmark format_error_name))
-    vc.verif_cond_errors
+  Format.fprintf fmt "si %a\n alors erreur %a %a;" format_expression (Pos.unmark vc.verif_cond_expr)
+    (pp_unmark format_error_name) (fst vc.verif_cond_error)
+    (Format.pp_print_option (pp_unmark format_variable_name))
+    (snd vc.verif_cond_error)
 
 let format_verification fmt (v : verification) =
   Format.fprintf fmt "verif %a : %a;\n%a" format_verification_name v.verif_name

--- a/src/mlang/m_frontend/mast.ml
+++ b/src/mlang/m_frontend/mast.ml
@@ -227,8 +227,8 @@ type variable_decl =
 
 type verification_condition = {
   verif_cond_expr : expression Pos.marked;
-  verif_cond_errors : error_name Pos.marked list;
-      (** A verification condition can trigger multiple errors *)
+  verif_cond_error : error_name Pos.marked * variable_name Pos.marked option;
+      (** A verification condition error can ba associated to a variable *)
 }
 
 type verification = {

--- a/src/mlang/m_frontend/mast_to_mir.ml
+++ b/src/mlang/m_frontend/mast_to_mir.ml
@@ -1285,19 +1285,25 @@ let get_conds (error_decls : Mir.Error.t list) (idmap : Mir.idmap) (p : Mast.pro
                       }
                       (Pos.unmark verif_cond).Mast.verif_cond_expr
                   in
-                  let errs =
-                    List.map
-                      (fun err_name ->
-                        try
-                          Some
-                            (List.find
-                               (fun e -> Pos.unmark e.Mir.Error.name = Pos.unmark err_name)
-                               error_decls)
-                        with Not_found ->
-                          Cli.var_info_print "undeclared error %s %a" (Pos.unmark err_name)
-                            Pos.format_position (Pos.get_position err_name);
-                          None)
-                      (Pos.unmark verif_cond).Mast.verif_cond_errors
+                  let err =
+                    let err_name, err_var = (Pos.unmark verif_cond).Mast.verif_cond_error in
+                    try
+                      ( List.find
+                          (fun e -> Pos.unmark e.Mir.Error.name = Pos.unmark err_name)
+                          error_decls,
+                        Option.map
+                          (fun v ->
+                            List.sort
+                              (fun v w ->
+                                -Mir.compare_execution_number v.Mir.Variable.execution_number
+                                   w.Mir.Variable.execution_number)
+                              (Pos.VarNameToID.find (Pos.unmark v) idmap)
+                            |> List.hd)
+                          err_var )
+                    with Not_found ->
+                      Errors.raise_error
+                        (Format.asprintf "undeclared error %s %a" (Pos.unmark err_name)
+                           Pos.format_position (Pos.get_position err_name))
                   in
                   let dummy_var =
                     Mir.Variable.new_var
@@ -1312,19 +1318,7 @@ let get_conds (error_decls : Mir.Error.t list) (idmap : Mir.idmap) (p : Mast.pro
                       { Mir.rule_number; Mir.seq_number = 0; Mir.pos = Pos.get_position verif_cond }
                       ~attributes:[] ~is_income:false ~is_table:None
                   in
-                  Mir.VariableMap.add dummy_var
-                    {
-                      Mir.cond_expr = e;
-                      Mir.cond_errors =
-                        List.map
-                          (fun x ->
-                            match x with Some x -> x | None -> assert false
-                            (* should not happen *))
-                          (List.filter
-                             (fun x -> match x with Some _ -> true | None -> false)
-                             errs);
-                    }
-                    conds)
+                  Mir.VariableMap.add dummy_var { Mir.cond_expr = e; Mir.cond_error = err } conds)
                 conds verif.Mast.verif_conditions
           | _ -> conds)
         conds source_file)

--- a/src/mlang/m_frontend/mparser.mly
+++ b/src/mlang/m_frontend/mparser.mly
@@ -280,9 +280,10 @@ verification:
 } }
 
 verification_condition:
-| IF e = expression THEN ERROR e_names = verification_name+ SEMICOLON { ({
+| IF e = expression THEN
+  ERROR e_name = verification_name var = output_name? SEMICOLON { ({
     verif_cond_expr = e;
-    verif_cond_errors = e_names;
+    verif_cond_error = e_name, var;
   }, mk_position $sloc) }
 
 error_name:

--- a/src/mlang/m_ir/format_mir.ml
+++ b/src/mlang/m_ir/format_mir.ml
@@ -106,9 +106,10 @@ let format_error fmt (e : Error.t) =
     (Error.err_descr_string e |> Pos.unmark)
 
 let format_precondition fmt (precond : condition_data) =
-  Format.fprintf fmt "Précondition : %a\nSinon %a" format_expression (Pos.unmark precond.cond_expr)
-    (Format_mast.pp_print_list_comma format_error)
-    precond.cond_errors
+  Format.fprintf fmt "Précondition : %a\nSinon %a%a" format_expression
+    (Pos.unmark precond.cond_expr) format_error (fst precond.cond_error)
+    (Format.pp_print_option (fun fmt v -> Format.fprintf fmt " (%s)" (Pos.unmark v.Variable.name)))
+    (snd precond.cond_error)
 
 let format_program_rules fmt (vars : VariableDict.t) (rules : rule_data RuleMap.t) =
   RuleMap.iter

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -308,7 +308,10 @@ module Error = struct
   let compare (var1 : t) (var2 : t) = compare var1.id var2.id
 end
 
-type condition_data = { cond_expr : expression Pos.marked; cond_errors : (Error.t[@opaque]) list }
+type condition_data = {
+  cond_expr : expression Pos.marked;
+  cond_error : (Error.t[@opaque]) * Variable.t option;
+}
 
 type idmap = Variable.t list Pos.VarNameToID.t
 (** We translate string variables into first-class unique {!type: Mir.Variable.t}, so we need to

--- a/src/mlang/optimizing_ir/format_oir.ml
+++ b/src/mlang/optimizing_ir/format_oir.ml
@@ -22,10 +22,11 @@ let rec format_stmt fmt (stmt : stmt) =
       Format.fprintf fmt "if(%a) then goto %d else goto %d@," Format_mir.format_expression cond b1
         b2
   | SVerif cond_data ->
-      Format.fprintf fmt "assert (%a) or raise %a@," Format_mir.format_expression
-        (Pos.unmark cond_data.cond_expr)
-        (Format_mast.pp_print_list_comma Format_mir.format_error)
-        cond_data.cond_errors
+      Format.fprintf fmt "assert (%a) or raise %a%a@," Format_mir.format_expression
+        (Pos.unmark cond_data.cond_expr) Format_mir.format_error (fst cond_data.cond_error)
+        (Format.pp_print_option (fun fmt v ->
+             Format.fprintf fmt " (%s)" (Pos.unmark v.Mir.Variable.name)))
+        (snd cond_data.cond_error)
   | SGoto b -> Format.fprintf fmt "goto %d@," b
   | SRuleCall (_rid, name, stmts) ->
       Format.fprintf fmt "call(%s)@[<v 3>{@,%a@]}@," name format_stmts stmts

--- a/src/mlang/optimizing_ir/partial_evaluation.ml
+++ b/src/mlang/optimizing_ir/partial_evaluation.ml
@@ -596,7 +596,7 @@ let rec partially_evaluate_stmt (stmt : stmt) (block_id : block_id) (ctx : parti
           Cli.error_print "Error during partial evaluation!";
           let err, ctx =
             ( Bir_interpreter.RegularFloatInterpreter.ConditionViolated
-                (cond.cond_errors, cond.cond_expr, []),
+                (fst cond.cond_error, cond.cond_expr, []),
               interpreter_ctx_from_partial_ev_ctx ctx )
           in
           if !Bir_interpreter.exit_on_rte then

--- a/src/mlang/test_framework/test_interpreter.ml
+++ b/src/mlang/test_framework/test_interpreter.ml
@@ -191,7 +191,7 @@ let check_all_tests (p : Bir.program) (test_dir : string) (optimize : bool)
   let process (name : string) ((successes, failures, code_coverage_acc) : process_acc) : process_acc
       =
     let report_violated_condition_error (bindings : (Variable.t * Mir.literal) option)
-        (expr : Mir.expression Pos.marked) (err : Error.t list) =
+        (expr : Mir.expression Pos.marked) (err : Error.t) =
       Cli.debug_flag := true;
       match (bindings, Pos.unmark expr) with
       | ( Some (v, l1),
@@ -209,10 +209,7 @@ let check_all_tests (p : Bir.program) (test_dir : string) (optimize : bool)
           let errs_varname = try VariableMap.find v failures with Not_found -> [] in
           (successes, VariableMap.add v ((name, l1, l2) :: errs_varname) failures, code_coverage_acc)
       | _ ->
-          Cli.error_print "Test %s incorrect (error%s %a raised)" name
-            (if List.length err > 1 then "s" else "")
-            (Format.pp_print_list Format.pp_print_string)
-            (List.map (fun x -> Pos.unmark x.Error.name) err);
+          Cli.error_print "Test %s incorrect (error %s raised)" name (Pos.unmark err.Error.name);
           (successes, failures, code_coverage_acc)
     in
     try


### PR DESCRIPTION
Mlang assumed a verification condition could raise several errors at once. But it appears that it always raise exactly one, with sometime an associated variable for what I expect to be reporting purposes.

This may be needed when interfacing with current production practices.