### PR TITLE
Separation of definition flag and value computation in dgfip backend, and adaptation to current process

### DIFF
--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -16,28 +16,28 @@
 
 open Mir
 
-let none_value = "m_undefined"
-
-let generate_comp_op (op : Mast.comp_op) : string =
+(* Returns def test operator with the operator itself *)
+let generate_comp_op (op : Mast.comp_op) : string * string =
   match op with
-  | Mast.Gt -> "m_gt"
-  | Mast.Gte -> "m_gte"
-  | Mast.Lt -> "m_lt"
-  | Mast.Lte -> "m_lte"
-  | Mast.Eq -> "m_eq"
-  | Mast.Neq -> "m_neq"
+  | Mast.Gt -> ("&&", ">")
+  | Mast.Gte -> ("&&", ">=")
+  | Mast.Lt -> ("&&", "<")
+  | Mast.Lte -> ("&&", "<=")
+  | Mast.Eq -> ("&&", "==")
+  | Mast.Neq -> ("&&", "!=")
 
-let generate_binop (op : Mast.binop) : string =
+let generate_binop (op : Mast.binop) : string * string =
   match op with
-  | Mast.And -> "m_and"
-  | Mast.Or -> "m_or"
-  | Mast.Add -> "m_add"
-  | Mast.Sub -> "m_sub"
-  | Mast.Mul -> "m_mul"
-  | Mast.Div -> "m_div"
+  | Mast.And -> ("&&", "&&")
+  | Mast.Or -> ("||", "||")
+  | Mast.Add -> ("||", "+")
+  | Mast.Sub -> ("||", "-")
+  | Mast.Mul -> ("&&", "*")
+  | Mast.Div -> assert false
+(* needs special case for division by zero *)
 
 let generate_unop (op : Mast.unop) : string =
-  match op with Mast.Not -> "m_not" | Mast.Minus -> "m_neg"
+  match op with Mast.Not -> "!" | Mast.Minus -> "-"
 
 type offset =
   | GetValueConst of int
@@ -45,243 +45,286 @@ type offset =
   | PassPointer
   | None
 
-let generate_variable (var_indexes : int Mir.VariableMap.t) (offset : offset)
-    (fmt : Format.formatter) (var : Variable.t) : unit =
-  let var_index =
-    match Mir.VariableMap.find_opt var var_indexes with
-    | Some i -> i
-    | None ->
-        Errors.raise_error
-          (Format.asprintf "Variable %s not found in TGV"
-             (Pos.unmark var.Mir.Variable.name))
-  in
-  match offset with
-  | PassPointer ->
-      Format.fprintf fmt "(TGV + %d/*%s*/)" var_index
-        (Pos.unmark var.Mir.Variable.name)
-  | _ ->
-      Format.fprintf fmt "TGV[%d/*%s*/%s]" var_index
-        (Pos.unmark var.Mir.Variable.name)
-        (match offset with
-        | None -> ""
-        | GetValueVar offset -> " + " ^ offset
-        | GetValueConst offset -> " + " ^ string_of_int offset
-        | PassPointer -> assert false)
+let generate_variable (vm : Dgfip_varid.var_id_map) (offset : offset)
+    ?(def_flag = false) (var : Variable.t) : string =
+  try
+    match offset with
+    | PassPointer -> Dgfip_varid.gen_access_pointer vm var
+    | _ ->
+        let offset =
+          match offset with
+          | None -> ""
+          | GetValueVar offset -> " + " ^ offset
+          | GetValueConst offset -> " + " ^ string_of_int offset
+          | PassPointer -> assert false
+        in
+        if def_flag then Dgfip_varid.gen_access_def vm var offset
+        else Dgfip_varid.gen_access_val vm var offset
+  with Not_found ->
+    Errors.raise_error
+      (Format.asprintf "Variable %s not found in TGV"
+         (Pos.unmark var.Mir.Variable.name))
 
-let generate_raw_name (v : Variable.t) : string =
-  match v.alias with Some v -> v | None -> Pos.unmark v.Variable.name
+type expression_composition = {
+  def_test : string;
+  value_comp : string;
+  locals : (string * expression_composition) list;
+}
 
-let generate_name (v : Variable.t) : string = "v_" ^ generate_raw_name v
+let fresh_c_local : string -> string =
+  let c = ref 0 in
+  fun name ->
+    let v = name ^ "_l" ^ string_of_int !c in
+    incr c;
+    v
 
 let rec generate_c_expr (e : expression Pos.marked)
-    (var_indexes : int Mir.VariableMap.t) :
-    string * (LocalVariable.t * expression Pos.marked) list =
+    (var_indexes : Dgfip_varid.var_id_map) : expression_composition =
   match Pos.unmark e with
   | Comparison (op, e1, e2) ->
-      let se1, s1 = generate_c_expr e1 var_indexes in
-      let se2, s2 = generate_c_expr e2 var_indexes in
-      ( Format.asprintf "%s(%s, %s)" (generate_comp_op (Pos.unmark op)) se1 se2,
-        s1 @ s2 )
+      let se1 = generate_c_expr e1 var_indexes in
+      let se2 = generate_c_expr e2 var_indexes in
+      let def_op, comp_op = generate_comp_op (Pos.unmark op) in
+      let def_test =
+        Format.sprintf "(%s %s %s)" se1.def_test def_op se2.def_test
+      in
+      let value_comp =
+        Format.sprintf "(%s %s %s)" se1.value_comp comp_op se2.value_comp
+      in
+      { def_test; value_comp; locals = se1.locals @ se2.locals }
+  | Binop ((Mast.Div, _), e1, e2) ->
+      let se1 = generate_c_expr e1 var_indexes in
+      let se2 = generate_c_expr e2 var_indexes in
+      let def_test = Format.asprintf "(%s && %s)" se1.def_test se2.def_test in
+      let value_comp =
+        Format.asprintf "((%s==0.) ? (%s / %s) : 0.)" se2.value_comp
+          se1.value_comp se2.value_comp
+      in
+      { def_test; value_comp; locals = se1.locals @ se2.locals }
   | Binop (op, e1, e2) ->
-      let se1, s1 = generate_c_expr e1 var_indexes in
-      let se2, s2 = generate_c_expr e2 var_indexes in
-      ( Format.asprintf "%s(%s, %s)" (generate_binop (Pos.unmark op)) se1 se2,
-        s1 @ s2 )
+      let se1 = generate_c_expr e1 var_indexes in
+      let se2 = generate_c_expr e2 var_indexes in
+      let def_op, comp_op = generate_binop (Pos.unmark op) in
+      let def_test =
+        Format.asprintf "(%s %s %s)" se1.def_test def_op se2.def_test
+      in
+      let value_comp =
+        Format.asprintf "(%s %s %s)" se1.value_comp comp_op se2.value_comp
+      in
+      { def_test; value_comp; locals = se1.locals @ se2.locals }
   | Unop (op, e) ->
-      let se, s = generate_c_expr e var_indexes in
-      (Format.asprintf "%s(%s)" (generate_unop op) se, s)
+      let se = generate_c_expr e var_indexes in
+      let def_test = se.def_test in
+      let value_comp =
+        Format.asprintf "(%s%s)" (generate_unop op) se.value_comp
+      in
+      { def_test; value_comp; locals = se.locals }
   | Index (var, e) ->
-      let se, s = generate_c_expr e var_indexes in
+      let idx = generate_c_expr e var_indexes in
       let size = Option.get (Pos.unmark var).Mir.Variable.is_table in
-      ( Format.asprintf "m_array_index(%a, %s, %d)"
-          (generate_variable var_indexes PassPointer)
-          (Pos.unmark var) se size,
-        s )
-  | Conditional (e1, e2, e3) ->
-      let se1, s1 = generate_c_expr e1 var_indexes in
-      let se2, s2 = generate_c_expr e2 var_indexes in
-      let se3, s3 = generate_c_expr e3 var_indexes in
-      (Format.asprintf "m_cond(%s, %s, %s)" se1 se2 se3, s1 @ s2 @ s3)
+      let idx_var = fresh_c_local "idx" in
+      let def_test =
+        Format.asprintf "(%s_d || %s >= %d)" idx_var idx_var size
+      in
+      let value_comp =
+        Format.asprintf "((%s < 0.) ? 0. : (%s[(int)%s]))" idx_var
+          (generate_variable var_indexes PassPointer (Pos.unmark var))
+          idx_var
+      in
+      { def_test; value_comp; locals = [ (idx_var, idx) ] }
+  | Conditional (c, t, f) ->
+      let cond = generate_c_expr c var_indexes in
+      let thenval = generate_c_expr t var_indexes in
+      let elseval = generate_c_expr f var_indexes in
+      let cond_var = fresh_c_local "cond" in
+      let then_var = fresh_c_local "then" in
+      let else_var = fresh_c_local "else" in
+      let def_test =
+        Format.sprintf "(%s_d && (%s ? %s_d : %s_d))" cond_var cond_var then_var
+          else_var
+      in
+      let value_comp =
+        Format.sprintf "(%s_d ? (%s ? %s : %s) : 0.)" cond_var cond_var then_var
+          else_var
+      in
+      {
+        def_test;
+        value_comp;
+        locals = [ (cond_var, cond); (then_var, thenval); (else_var, elseval) ];
+      }
   | FunctionCall (PresentFunc, [ arg ]) ->
-      let se, s = generate_c_expr arg var_indexes in
-      (Format.asprintf "m_present(%s)" se, s)
+      let se = generate_c_expr arg var_indexes in
+      let def_test = "1" in
+      let value_comp = Format.sprintf "(%s ? 1. : 0.)" se.def_test in
+      { def_test; value_comp; locals = se.locals }
   | FunctionCall (NullFunc, [ arg ]) ->
-      let se, s = generate_c_expr arg var_indexes in
-      (Format.asprintf "m_null(%s)" se, s)
+      let se = generate_c_expr arg var_indexes in
+      let def_test = "1" in
+      let value_comp = Format.sprintf "(%s ? 0. : 1.)" se.def_test in
+      { def_test; value_comp; locals = se.locals }
   | FunctionCall (ArrFunc, [ arg ]) ->
-      let se, s = generate_c_expr arg var_indexes in
-      (Format.asprintf "m_round(%s)" se, s)
+      let se = generate_c_expr arg var_indexes in
+      let def_test = se.def_test in
+      let value_comp = Format.sprintf "(my_arr(%s))" se.value_comp in
+      { def_test; value_comp; locals = se.locals }
   | FunctionCall (InfFunc, [ arg ]) ->
-      let se, s = generate_c_expr arg var_indexes in
-      (Format.asprintf "m_floor(%s)" se, s)
+      let se = generate_c_expr arg var_indexes in
+      let def_test = se.def_test in
+      let value_comp = Format.sprintf "(my_floor(%s))" se.value_comp in
+      { def_test; value_comp; locals = se.locals }
   | FunctionCall (MaxFunc, [ e1; e2 ]) ->
-      let se1, s1 = generate_c_expr e1 var_indexes in
-      let se2, s2 = generate_c_expr e2 var_indexes in
-      (Format.asprintf "m_max(%s, %s)" se1 se2, s1 @ s2)
+      let se1 = generate_c_expr e1 var_indexes in
+      let se2 = generate_c_expr e2 var_indexes in
+      let def_test = "1" in
+      let value_comp =
+        Format.sprintf "(fmax(%s, %s))" se1.value_comp se2.value_comp
+      in
+      { def_test; value_comp; locals = se1.locals @ se2.locals }
   | FunctionCall (MinFunc, [ e1; e2 ]) ->
-      let se1, s1 = generate_c_expr e1 var_indexes in
-      let se2, s2 = generate_c_expr e2 var_indexes in
-      (Format.asprintf "m_min(%s, %s)" se1 se2, s1 @ s2)
+      let se1 = generate_c_expr e1 var_indexes in
+      let se2 = generate_c_expr e2 var_indexes in
+      let def_test = "1" in
+      let value_comp =
+        Format.sprintf "(fmin(%s, %s))" se1.value_comp se2.value_comp
+      in
+      { def_test; value_comp; locals = se1.locals @ se2.locals }
   | FunctionCall (Multimax, [ e1; (Var v2, _) ]) ->
-      let se1, s1 = generate_c_expr e1 var_indexes in
-      ( Format.asprintf "m_multimax(%s, %a)" se1
-          (generate_variable var_indexes PassPointer)
-          v2,
-        s1 )
+      let bound = generate_c_expr e1 var_indexes in
+      let bound_var = fresh_c_local "bound" in
+      let def_test = "1." in
+      let value_comp =
+        Format.asprintf "(multimax(%s, %s))" bound_var
+          (generate_variable var_indexes PassPointer v2)
+      in
+      { def_test; value_comp; locals = [ (bound_var, bound) ] }
   | FunctionCall _ -> assert false (* should not happen *)
   | Literal (Float f) ->
-      (Format.asprintf "m_literal(%s)" (string_of_float f), [])
-  | Literal Undefined -> (Format.asprintf "%s" none_value, [])
+      { def_test = "1"; value_comp = string_of_float f; locals = [] }
+  | Literal Undefined -> { def_test = "0"; value_comp = "0."; locals = [] }
   | Var var ->
-      (Format.asprintf "%a" (generate_variable var_indexes None) var, [])
-  | LocalVar lvar -> (Format.asprintf "LOCAL[%d]" lvar.LocalVariable.id, [])
-  | GenericTableIndex -> (Format.asprintf "m_literal(generic_index)", [])
+      {
+        def_test = generate_variable ~def_flag:true var_indexes None var;
+        value_comp = generate_variable var_indexes None var;
+        locals = [];
+      }
+  | LocalVar lvar ->
+      {
+        def_test = "1";
+        value_comp = "mlocal" ^ string_of_int lvar.Mir.LocalVariable.id;
+        locals = [];
+      }
+  | GenericTableIndex ->
+      { def_test = "1"; value_comp = "generic_index"; locals = [] }
   | Error -> assert false (* should not happen *)
   | LocalLet (lvar, e1, e2) ->
-      let _, s1 = generate_c_expr e1 var_indexes in
-      let se2, s2 = generate_c_expr e2 var_indexes in
-      (Format.asprintf "%s" se2, s1 @ ((lvar, e1) :: s2))
+      let se1 = generate_c_expr e1 var_indexes in
+      let se2 = generate_c_expr e2 var_indexes in
+      let local_var = "mlocal" ^ string_of_int lvar.Mir.LocalVariable.id in
+      let def_test = se2.def_test in
+      let value_comp = se2.value_comp in
+      { def_test; value_comp; locals = (local_var, se1) :: se2.locals }
 
-let format_local_vars_defs (var_indexes : int Mir.VariableMap.t)
-    (fmt : Format.formatter)
-    (defs : (LocalVariable.t * expression Pos.marked) list) =
+let rec format_local_vars_defs (fmt : Format.formatter)
+    (defs : (string * expression_composition) list) : unit =
   List.iter
-    (fun (lvar, e) ->
-      let se, _ = generate_c_expr e var_indexes in
-      Format.fprintf fmt "LOCAL[%d] = %s;@\n" lvar.LocalVariable.id se)
+    (fun (lvar, se) ->
+      Format.fprintf fmt "%aint %s_d = %s;@\ndouble %s = %s;@\n"
+        format_local_vars_defs se.locals lvar se.def_test lvar se.value_comp)
     defs
 
-let generate_var_def (var_indexes : int Mir.VariableMap.t)
+let generate_var_def (var_indexes : Dgfip_varid.var_id_map)
     (var : Mir.Variable.t) (data : Mir.variable_data) (oc : Format.formatter) :
     unit =
   match data.var_definition with
   | SimpleVar e ->
-      let se, defs = generate_c_expr e var_indexes in
-      Format.fprintf oc "%a%a = %s;@\n"
-        (format_local_vars_defs var_indexes)
-        defs
-        (generate_variable var_indexes None)
-        var se
+      let se = generate_c_expr e var_indexes in
+      Format.fprintf oc "%a%s = %s;@\n%s = %s;@\n" format_local_vars_defs
+        se.locals
+        (generate_variable ~def_flag:true var_indexes None var)
+        se.def_test
+        (generate_variable var_indexes None var)
+        se.value_comp
   | TableVar (_, IndexTable es) ->
       Format.fprintf oc "%a"
         (fun fmt ->
           IndexMap.iter (fun i v ->
-              let sv, defs = generate_c_expr v var_indexes in
-              Format.fprintf fmt "%a%a = %s;@\n"
-                (format_local_vars_defs var_indexes)
-                defs
-                (generate_variable var_indexes (GetValueConst i))
-                var sv))
+              let sv = generate_c_expr v var_indexes in
+              Format.fprintf fmt "%a%s = %s;@\n%s = %s;@\n"
+                format_local_vars_defs sv.locals
+                (generate_variable ~def_flag:true var_indexes (GetValueConst i)
+                   var)
+                sv.def_test
+                (generate_variable var_indexes (GetValueConst i) var)
+                sv.value_comp))
         es
   | TableVar (size, IndexGeneric e) ->
-      let sv, defs = generate_c_expr e var_indexes in
+      let sv = generate_c_expr e var_indexes in
       Format.fprintf oc
         "for (int generic_index=0; generic_index < %d; generic_index++) {@\n\
-        \ @[<h 4> %a%a = %s;@]@\n\
+        \ @[<h 4> %a%s = %s;@\n\
+         %s = %s;@]@\n\
         \ }@\n"
-        size
-        (format_local_vars_defs var_indexes)
-        defs
-        (generate_variable var_indexes (GetValueVar "generic_index"))
-        var sv
+        size format_local_vars_defs sv.locals
+        (generate_variable ~def_flag:true var_indexes
+           (GetValueVar "generic_index") var)
+        sv.def_test
+        (generate_variable var_indexes (GetValueVar "generic_index") var)
+        sv.value_comp
   | InputVar -> assert false
 
-let generate_var_cond (var_indexes : int Mir.VariableMap.t)
+let generate_var_cond (var_indexes : Dgfip_varid.var_id_map)
     (cond : condition_data) (oc : Format.formatter) =
-  let scond, defs = generate_c_expr cond.cond_expr var_indexes in
+  let scond = generate_c_expr cond.cond_expr var_indexes in
   Format.fprintf oc
-    "@[<hv 0>%acond = %s;@,@[<hv 2>if (m_is_defined_true(cond)){@,%a@]@,}@,@,@]"
-    (format_local_vars_defs var_indexes)
-    defs scond
-    (fun oc () ->
-      let error, _ = cond.cond_error in
-      let error_pos = error.id in
-      Format.fprintf oc
-        "@[<hv 0>m_error_occurrence occurrence = output->errors[%d]; @,\
-         occurrence.error = &m_errors[%d]; @,\
-         occurrence.has_occurred = true;@]@,"
-        error_pos error_pos;
-      if (fst cond.cond_error).Mir.Error.typ = Mast.Anomaly then
-        Format.fprintf oc
-          "output->is_error = true;@,\
-           #ifndef ANOMALY_LIMIT @,\
-           free(TGV); @,\
-           free(LOCAL); @,\
-           return -1; @,\
-           #else /* ANOMALY_LIMIT */ @,\
-           @[<hv 2>if (anomaly_count >= max_anomalies) {@,\
-          \ free(TGV); @,\
-          \ free(LOCAL);@,\
-          \ return -1;@]@,\
-           }@,\
-           #endif /* ANOMALY_LIMIT */")
-    ()
-
-let fresh_cond_counter = ref 0
+    {|
+    %acond_def = %s;
+    cond = %s;
+    if (cond_def)
+    {
+      add_erreur(irdata, &erreur_%s, %s);
+    }
+|}
+    format_local_vars_defs scond.locals scond.def_test scond.value_comp
+    (Pos.unmark (fst cond.cond_error).Mir.Error.name)
+    (match snd cond.cond_error with
+    | None -> "NULL"
+    | Some v -> Pos.unmark v.Mir.Variable.name)
 
 let rec generate_stmt (program : Bir.program)
-    (var_indexes : int Mir.VariableMap.t) (oc : Format.formatter)
+    (var_indexes : Dgfip_varid.var_id_map) (oc : Format.formatter)
     (stmt : Bir.stmt) =
   match Pos.unmark stmt with
   | Bir.SAssign (var, vdata) -> generate_var_def var_indexes var vdata oc
-  | SConditional (cond, tt, ff) ->
-      let pos = Pos.get_position stmt in
-      let fname =
-        String.map
-          (fun c -> if c = '.' then '_' else c)
-          (Filename.basename (Pos.get_file pos))
-      in
-      let cond_name =
-        Format.asprintf "cond_%s_%d_%d_%d_%d_%d" fname (Pos.get_start_line pos)
-          (Pos.get_start_column pos) (Pos.get_end_line pos)
-          (Pos.get_end_column pos) !fresh_cond_counter
-      in
-      fresh_cond_counter := !fresh_cond_counter + 1;
-      let scond, defs =
-        generate_c_expr (Pos.same_pos_as cond stmt) var_indexes
-      in
-      Format.fprintf oc
-        "%am_value %s = %s;@\n\
-         if (m_is_defined_true(%s)) {@\n\
-         @[<h 4>    %a@]@\n\
-         };@\n\
-         if (m_is_defined_false(%s)) {@\n\
-         @[<h 4>    %a@]@\n\n\
-         };@\n"
-        (format_local_vars_defs var_indexes)
-        defs cond_name scond cond_name
-        (generate_stmts program var_indexes)
-        tt cond_name
-        (generate_stmts program var_indexes)
-        ff
+  | SConditional _ -> assert false (* not in dgfip trivial M++ *)
   | SVerif v -> generate_var_cond var_indexes v oc
   | SRuleCall r ->
       let rule = Bir.RuleMap.find r program.rules in
       generate_rule_function_header ~definition:false oc rule
 
-and generate_stmts (program : Bir.program) (var_indexes : int Mir.VariableMap.t)
-    (oc : Format.formatter) (stmts : Bir.stmt list) =
+and generate_stmts (program : Bir.program)
+    (var_indexes : Dgfip_varid.var_id_map) (oc : Format.formatter)
+    (stmts : Bir.stmt list) =
   Format.pp_print_list (generate_stmt program var_indexes) oc stmts
 
 and generate_rule_function_header ~(definition : bool) (oc : Format.formatter)
     (rule : Bir.rule) =
-  let arg_type = if definition then "m_value *" else "" in
-  let ret_type = if definition then "void " else "" in
-  Format.fprintf oc "%sm_rule_%s(%sTGV, %sLOCAL)%s@\n" ret_type rule.rule_name
-    arg_type arg_type
+  let arg_type = if definition then "T_irdata *" else "" in
+  let ret_type = if definition then "int " else "" in
+  Format.fprintf oc "%sm_rule_%s(%sirdata)%s@\n" ret_type rule.rule_name
+    arg_type
     (if definition then "" else ";")
 
 let generate_rule_function (program : Bir.program)
-    (var_indexes : int Mir.VariableMap.t) (oc : Format.formatter)
+    (var_indexes : Dgfip_varid.var_id_map) (oc : Format.formatter)
     (rule : Bir.rule) =
-  Format.fprintf oc "%a@[<v 2>{@ %a@]@;}@\n"
+  Format.fprintf oc "%a@[<v 2>{@ %a@;return 0;@]@;}@\n"
     (generate_rule_function_header ~definition:true)
     rule
     (generate_stmts program var_indexes)
     rule.rule_stmts
 
 let generate_rule_functions (program : Bir.program)
-    (var_indexes : int Mir.VariableMap.t) (oc : Format.formatter)
+    (var_indexes : Dgfip_varid.var_id_map) (oc : Format.formatter)
     (rules : Bir.rule Bir.RuleMap.t) =
   Format.pp_print_list ~pp_sep:Format.pp_print_cut
     (generate_rule_function program var_indexes)
@@ -290,77 +333,13 @@ let generate_rule_functions (program : Bir.program)
 
 let generate_main_function_signature (oc : Format.formatter)
     (add_semicolon : bool) =
-  Format.fprintf oc "int m_extracted(m_output *output, const m_input *input)%s"
+  Format.fprintf oc "int m_extracted(T_irdata* irdata)%s"
     (if add_semicolon then ";" else "")
 
-let get_variables_indexes (p : Bir.program)
-    (function_spec : Bir_interface.bir_function) : int Mir.VariableMap.t * int =
-  let input_vars =
-    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
-  in
-  let assigned_variables =
-    List.map snd (Mir.VariableDict.bindings (Bir.get_assigned_variables p))
-  in
-  let output_vars =
-    List.map fst (VariableMap.bindings function_spec.func_outputs)
-  in
-  let all_relevant_variables =
-    List.fold_left
-      (fun acc var -> Mir.VariableMap.add var () acc)
-      Mir.VariableMap.empty
-      (input_vars @ assigned_variables @ output_vars)
-  in
-  let counter = ref 0 in
-  let var_indexes =
-    VariableMap.mapi
-      (fun var _ ->
-        let id = !counter in
-        let size =
-          match var.Mir.Variable.is_table with None -> 1 | Some size -> size
-        in
-        counter := !counter + size;
-        id)
-      all_relevant_variables
-  in
-  (var_indexes, !counter)
-
-let generate_main_function_signature_and_var_decls (p : Bir.program)
-    (var_indexes : int Mir.VariableMap.t) (var_table_size : int)
-    (oc : Format.formatter) (function_spec : Bir_interface.bir_function) =
-  let input_vars =
-    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
-  in
+let generate_main_function_signature_and_var_decls (oc : Format.formatter) () =
   Format.fprintf oc "%a {@\n@[<h 4>    @\n" generate_main_function_signature
     false;
-  Format.fprintf oc
-    "// First we initialize the table of all the variables used in the program@\n";
-  (* here, we need to generate a table that can host all the local vars. the
-     index inside the table will be the id of the local var so we generate a
-     table big enough so that the highest id is always in bounds *)
-  let size_locals =
-    List.hd
-      (List.rev
-         (List.sort compare
-            (List.map
-               (fun (x, _) -> x.LocalVariable.id)
-               (Mir.LocalVariableMap.bindings (Bir.get_local_variables p)))))
-    + 1
-  in
-  Format.fprintf oc "m_value *LOCAL = malloc(%d * sizeof(m_value));@\n@\n"
-    size_locals;
-  Format.fprintf oc "m_value *TGV = malloc(%d * sizeof(m_value));@\n@\n"
-    var_table_size;
-  Format.fprintf oc
-    "// Then we extract the input variables from the dictionnary:@\n%a@\n@\n"
-    (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
-       (fun fmt var ->
-         Format.fprintf fmt "%a = input->%s;"
-           (generate_variable var_indexes None)
-           var (generate_name var)))
-    input_vars;
-
-  Format.fprintf oc "m_value cond;@\n@\n";
+  Format.fprintf oc "int cond_def;@\ndouble cond;@\n@\n";
   Format.fprintf oc
     {|
   #ifdef ANOMALY_LIMIT
@@ -369,123 +348,44 @@ let generate_main_function_signature_and_var_decls (p : Bir.program)
   #endif /* ANOMALY_LIMIT */
 |}
 
-let generate_return (var_indexes : int Mir.VariableMap.t)
-    (oc : Format.formatter) (function_spec : Bir_interface.bir_function) =
-  let returned_variables =
-    List.map fst (VariableMap.bindings function_spec.func_outputs)
-  in
-  Format.fprintf oc
-    "%a@\n\
-     @\n\
-     free(TGV);@\n\
-     free(LOCAL);@\n\
-     output->is_error = false;@\n\
-     return 0;@]@\n\
-     }"
-    (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
-       (fun fmt var ->
-         Format.fprintf fmt "output->%s = %a;" (generate_name var)
-           (generate_variable var_indexes None)
-           var))
-    returned_variables
+let generate_return (oc : Format.formatter) () =
+  Format.fprintf oc "@\nreturn 0;@]@\n}"
 
 let generate_header (oc : Format.formatter) () : unit =
-  Format.fprintf oc "// %s\n\n" Prelude.message;
-  Format.fprintf oc "#ifndef IR_HEADER_ \n";
-  Format.fprintf oc "#define IR_HEADER_ \n";
-  Format.fprintf oc "#include \"m_value.h\"\n";
-  Format.fprintf oc "#include \"m_error.h\"\n";
-  Format.fprintf oc "#include <stdio.h>\n\n"
+  Format.fprintf oc
+    {|
+// %s
+
+#ifndef IR_HEADER_
+#define IR_HEADER_
+#include <stdio.h>
+#include "irdata.h"
+#include "const.h"
+#include "var.h"
+#include "enchain_static.c"
+
+#ifndef FLG_MULTITHREAD
+#define add_erreur(a,b,c) add_erreur(b,c)
+#endif
+
+// for predef maths
+double my_var1;
+
+|}
+    Prelude.message
 
 let generate_footer (oc : Format.formatter) () : unit =
   Format.fprintf oc "\n#endif /* IR_HEADER_ */"
-
-let generate_empty_input_prototype (oc : Format.formatter)
-    (add_semicolon : bool) =
-  Format.fprintf oc "void m_empty_input(m_input *input)%s"
-    (if add_semicolon then ";\n\n" else "")
-
-let generate_empty_input_func (oc : Format.formatter)
-    (function_spec : Bir_interface.bir_function) =
-  let input_vars =
-    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
-  in
-  Format.fprintf oc "%a {@\n@[<h 4>    %a@]@\n};@\n@\n"
-    generate_empty_input_prototype false
-    (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
-       (fun fmt var ->
-         Format.fprintf fmt "input->%s = m_undefined;" (generate_name var)))
-    input_vars
-
-let generate_input_from_array_prototype (oc : Format.formatter)
-    (add_semicolon : bool) =
-  Format.fprintf oc "void m_input_from_array(m_input* input, m_value *array)%s"
-    (if add_semicolon then ";\n\n" else "")
-
-let generate_input_from_array_func (oc : Format.formatter)
-    (function_spec : Bir_interface.bir_function) =
-  let input_vars =
-    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
-  in
-  Format.fprintf oc "%a {@\n@[<h 4>    %a@]@\n};@\n@\n"
-    generate_input_from_array_prototype false
-    (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
-       (fun fmt (var, i) ->
-         Format.fprintf fmt "input->%s = array[%d];" (generate_name var) i))
-    (List.mapi (fun i x -> (x, i)) input_vars)
 
 let generate_get_input_index_prototype (oc : Format.formatter)
     (add_semicolon : bool) =
   Format.fprintf oc "int m_get_input_index(char *name)%s"
     (if add_semicolon then ";\n\n" else "")
 
-let generate_get_input_index_func (oc : Format.formatter)
-    (function_spec : Bir_interface.bir_function) =
-  let input_vars =
-    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
-  in
-  Format.fprintf oc
-    "%a {@\n\
-     @[<h 4>    %a@\n\
-     printf(\"Input var %%s not found!\\n\", name);@\n\
-     exit(-1);@]@\n\
-     };@\n\
-     @\n"
-    generate_get_input_index_prototype false
-    (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
-       (fun fmt (var, i) ->
-         Format.fprintf fmt "if (strcmp(\"%s\", name) == 0) { return %d; }"
-           (generate_raw_name var) i))
-    (List.mapi (fun i x -> (x, i)) input_vars)
-
 let generate_get_input_name_from_index_prototype (oc : Format.formatter)
     (add_semicolon : bool) =
   Format.fprintf oc "char* m_get_input_name_from_index(int index)%s"
     (if add_semicolon then ";\n" else "")
-
-let generate_get_input_name_from_index_func (oc : Format.formatter)
-    (function_spec : Bir_interface.bir_function) =
-  let input_vars =
-    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
-  in
-  Format.fprintf oc
-    "%a {@\n\
-     @[<h 4>    %a@\n\
-     printf(\"Input int %%d not found!\\n\", index);@\n\
-     exit(-1);@]@\n\
-     };@\n\
-     @\n"
-    generate_get_input_name_from_index_prototype false
-    (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
-       (fun fmt (var, i) ->
-         Format.fprintf fmt "if (%d == index) { return \"%s\"; }" i
-           (generate_raw_name var)))
-    (List.mapi (fun i x -> (x, i)) input_vars)
 
 let generate_get_input_num_prototype (oc : Format.formatter)
     (add_semicolon : bool) =
@@ -499,56 +399,6 @@ let generate_get_input_num_func (oc : Format.formatter)
   in
   Format.fprintf oc "%a {@\n@[<h 4>    return %d;@]@\n};@\n@\n"
     generate_get_input_num_prototype false (List.length input_vars)
-
-let generate_input_type (oc : Format.formatter)
-    (function_spec : Bir_interface.bir_function) =
-  let input_vars =
-    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
-  in
-  Format.fprintf oc "@[<h 2>typedef struct m_input {@,%a@]@\n} m_input;@\n@\n"
-    (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
-       (fun fmt var ->
-         Format.fprintf fmt "m_value %s; // %s" (generate_name var)
-           (Pos.unmark var.Variable.descr)))
-    input_vars
-
-let generate_empty_output_prototype (oc : Format.formatter)
-    (add_semicolon : bool) =
-  Format.fprintf oc "void m_empty_output(m_output* output)%s"
-    (if add_semicolon then ";\n\n" else "")
-
-let generate_empty_output_func (oc : Format.formatter)
-    (function_spec : Bir_interface.bir_function) =
-  let output_vars =
-    List.map fst (VariableMap.bindings function_spec.func_outputs)
-  in
-  Format.fprintf oc
-    "%a {@\n@[<h 4>    @\noutput->is_error = false;@\n%a@]@\n};@\n@\n"
-    generate_empty_output_prototype false
-    (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
-       (fun fmt var ->
-         Format.fprintf fmt "output->%s = m_undefined;" (generate_name var)))
-    output_vars
-
-let generate_output_to_array_prototype (oc : Format.formatter)
-    (add_semicolon : bool) =
-  Format.fprintf oc "void m_output_to_array(m_value *array, m_output* output)%s"
-    (if add_semicolon then ";\n\n" else "")
-
-let generate_output_to_array_func (oc : Format.formatter)
-    (function_spec : Bir_interface.bir_function) =
-  let output_vars =
-    List.map fst (VariableMap.bindings function_spec.func_outputs)
-  in
-  Format.fprintf oc "%a {@\n@[<h 4>    %a@]@\n};@\n@\n"
-    generate_output_to_array_prototype false
-    (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
-       (fun fmt (var, i) ->
-         Format.fprintf fmt "array[%d] = output->%s;" i (generate_name var)))
-    (List.mapi (fun i x -> (x, i)) output_vars)
 
 let generate_get_output_index_prototype (oc : Format.formatter)
     (add_semicolon : bool) =
@@ -614,24 +464,6 @@ let generate_get_output_num_func (oc : Format.formatter)
   Format.fprintf oc "%a {@\n@[<h 4>    return %d;@]@\n};@\n@\n"
     generate_get_output_num_prototype false (List.length output_vars)
 
-let generate_output_type (oc : Format.formatter)
-    (function_spec : Bir_interface.bir_function) =
-  let output_vars =
-    List.map fst (VariableMap.bindings function_spec.func_outputs)
-  in
-  Format.fprintf oc
-    "@[<v 2>typedef struct m_output {@,\
-     m_error_occurrence *errors;@,\
-     bool is_error;@,\
-     %a@.@[<h>}@ m_output;@]@]@\n\
-     @\n"
-    (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
-       (fun fmt var ->
-         Format.fprintf fmt "m_value %s; // %s" (generate_name var)
-           (Pos.unmark var.Variable.descr)))
-    output_vars
-
 let error_table_definitions (oc : Format.formatter) (program : Bir.program) =
   let error_set_size = VariableMap.cardinal program.mir_program.program_conds in
   Format.fprintf oc "typedef m_error_occurrence error_occurrences[%d];\n"
@@ -684,48 +516,33 @@ let generate_implem_header oc header_filename =
 
 let generate_c_program (program : Bir.program)
     (function_spec : Bir_interface.bir_function) (filename : string)
-    (_vm : Dgfip_varid.var_id_map) : unit =
+    (vm : Dgfip_varid.var_id_map) : unit =
   if Filename.extension filename <> ".c" then
     Errors.raise_error
       (Format.asprintf "Output file should have a .c extension (currently %s)"
          filename);
   let header_filename = Filename.remove_extension filename ^ ".h" in
   let _oc = open_out header_filename in
-  let var_indexes, var_table_size =
-    get_variables_indexes program function_spec
-  in
   let oc = Format.formatter_of_out_channel _oc in
-  Format.fprintf oc "%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a" generate_header ()
-    error_table_definitions program generate_input_type function_spec
-    generate_empty_input_prototype true generate_input_from_array_prototype true
-    generate_get_input_index_prototype true generate_get_input_num_prototype
-    true generate_get_input_name_from_index_prototype true generate_output_type
-    function_spec generate_output_to_array_prototype true
+  Format.fprintf oc "%a%a%a%a%a%a%a%a%a%a%a" generate_header ()
+    error_table_definitions program generate_get_input_index_prototype true
+    generate_get_input_num_prototype true
+    generate_get_input_name_from_index_prototype true
     generate_get_output_index_prototype true
     generate_get_output_name_from_index_prototype true
-    generate_get_output_num_prototype true generate_empty_output_prototype true
-    generate_get_error_count_prototype true generate_main_function_signature
-    true generate_footer ();
+    generate_get_output_num_prototype true generate_get_error_count_prototype
+    true generate_main_function_signature true generate_footer ();
   close_out _oc;
   let _oc = open_out filename in
   let oc = Format.formatter_of_out_channel _oc in
-  Format.fprintf oc "%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a" generate_implem_header
+  Format.fprintf oc "%a%a%a%a%a%a%a%a%a%a%a" generate_implem_header
     header_filename generate_errors_table program generate_get_error_count_func
-    program generate_empty_input_func function_spec
-    generate_input_from_array_func function_spec generate_get_input_index_func
-    function_spec generate_get_input_name_from_index_func function_spec
-    generate_get_input_num_func function_spec generate_output_to_array_func
-    function_spec generate_get_output_index_func function_spec
+    program generate_get_input_num_func function_spec
+    generate_get_output_index_func function_spec
     generate_get_output_name_from_index_func function_spec
-    generate_get_output_num_func function_spec generate_empty_output_func
-    function_spec
-    (generate_rule_functions program var_indexes)
-    program.rules
-    (generate_main_function_signature_and_var_decls program var_indexes
-       var_table_size)
-    function_spec
-    (generate_stmts program var_indexes)
-    program.statements
-    (generate_return var_indexes)
-    function_spec;
+    generate_get_output_num_func function_spec
+    (generate_rule_functions program vm)
+    program.rules generate_main_function_signature_and_var_decls ()
+    (generate_stmts program vm)
+    program.statements generate_return ();
   close_out _oc

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.mli
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.mli
@@ -15,4 +15,8 @@
    this program. If not, see <https://www.gnu.org/licenses/>. *)
 
 val generate_c_program :
-  Bir.program -> Bir_interface.bir_function -> (* filename *) string -> Dgfip_varid.var_id_map -> unit
+  Bir.program ->
+  Bir_interface.bir_function ->
+  (* filename *) string ->
+  Dgfip_varid.var_id_map ->
+  unit

--- a/src/mlang/backend_compilers/dgfip_gen_files.ml
+++ b/src/mlang/backend_compilers/dgfip_gen_files.ml
@@ -873,6 +873,9 @@ let gen_var_h fmt flags vars vars_debug rules verifs chainings errors =
   Format.fprintf fmt
     {|/****** LICENCE CECIL *****/
 
+#ifndef _VAR_
+#define _VAR_
+
 #include "irdata.h"
 #include "desc_inv.h"
 #include "const.h"
@@ -957,7 +960,9 @@ let gen_var_h fmt flags vars vars_debug rules verifs chainings errors =
 
   (* TODO function declarations (seems to be no longer used) *)
   if flags.flg_pro then
-    Format.fprintf fmt "extern struct S_erreur *tabErreurs[];\n"
+    Format.fprintf fmt "extern struct S_erreur *tabErreurs[];\n";
+
+  Format.fprintf fmt "#endif /* _VAR_ */\n"
 
 let gen_var_c fmt flags errors =
   let open Mast in
@@ -1067,7 +1072,7 @@ let gen_conf_h fmt flags vars =
 (* Generate a map from variables to array indices *)
 let extract_var_ids (cprog : Bir.program) vars =
   let open Mir in
-  let open Dgfip_varid in
+  (* let open Dgfip_varid in *)
   let pvars = cprog.mir_program.program_vars in
   let add vn v vm =
     let vs =

--- a/src/mlang/backend_compilers/dgfip_gen_files.ml
+++ b/src/mlang/backend_compilers/dgfip_gen_files.ml
@@ -1,15 +1,18 @@
-(* Copyright (C) 2019 Inria, contributor: David Declerck <david.declerck@ocamlpro.com>
+(* Copyright (C) 2019 Inria, contributor: David Declerck
+   <david.declerck@ocamlpro.com>
 
-   This program is free software: you can redistribute it and/or modify it under the terms of the
-   GNU General Public License as published by the Free Software Foundation, either version 3 of the
-   License, or (at your option) any later version.
+   This program is free software: you can redistribute it and/or modify it under
+   the terms of the GNU General Public License as published by the Free Software
+   Foundation, either version 3 of the License, or (at your option) any later
+   version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-   even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-   General Public License for more details.
+   This program is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+   FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+   details.
 
-   You should have received a copy of the GNU General Public License along with this program. If
-   not, see <https://www.gnu.org/licenses/>. *)
+   You should have received a copy of the GNU General Public License along with
+   this program. If not, see <https://www.gnu.org/licenses/>. *)
 
 module StringSet = Set.Make (String)
 module StringMap = Map.Make (String)
@@ -50,7 +53,15 @@ type idx = {
   pen : int ref;
 }
 
-type var_subtype = Context | Family | Income | CorrIncome | Variation | Penality | Base | Computed
+type var_subtype =
+  | Context
+  | Family
+  | Income
+  | CorrIncome
+  | Variation
+  | Penality
+  | Base
+  | Computed
 
 (* Used to specify the type of array to generate *)
 type gen_type =
@@ -61,31 +72,32 @@ type gen_type =
 (* can be of any subtype *)
 
 let default_flags =
-  Dgfip_options.{
-    nom_application = "";
-    annee_revenu = 0;
-    flg_correctif = true;
-    flg_iliad = false;
-    flg_pro = false;
-    flg_cfir = false;
-    flg_gcos = false;
-    flg_tri_ebcdic = false;
-    flg_multithread = false;
-    flg_short = false;
-    flg_register = false;
-    flg_optim_min_max = false;
-    flg_extraction = false;
-    flg_genere_libelle_restituee = false;
-    flg_controle_separe = false;
-    flg_controle_immediat = false;
-    flg_overlays = false;
-    flg_colors = false;
-    flg_ticket = false;
-    flg_trace = false;
-    flg_debug = false;
-    nb_debug_c = 0;
-    xflg = false;
-  }
+  Dgfip_options.
+    {
+      nom_application = "";
+      annee_revenu = 0;
+      flg_correctif = true;
+      flg_iliad = false;
+      flg_pro = false;
+      flg_cfir = false;
+      flg_gcos = false;
+      flg_tri_ebcdic = false;
+      flg_multithread = false;
+      flg_short = false;
+      flg_register = false;
+      flg_optim_min_max = false;
+      flg_extraction = false;
+      flg_genere_libelle_restituee = false;
+      flg_controle_separe = false;
+      flg_controle_immediat = false;
+      flg_overlays = false;
+      flg_colors = false;
+      flg_ticket = false;
+      flg_trace = false;
+      flg_debug = false;
+      nb_debug_c = 0;
+      xflg = false;
+    }
 
 let is_input st = match st with Base | Computed -> false | _ -> true
 
@@ -102,14 +114,16 @@ let input_var_subtype iv : var_subtype =
 let computed_var_subtype cv : var_subtype =
   let is_base =
     List.exists
-      (fun ct -> match Pos.unmark ct with Mast.Base -> true | GivenBack -> false)
+      (fun ct ->
+        match Pos.unmark ct with Mast.Base -> true | GivenBack -> false)
       cv.Mast.comp_subtyp
   in
   if is_base then Base else Computed
 
 let computed_var_is_output cv =
   List.exists
-    (fun st -> match Pos.unmark st with Mast.GivenBack -> true | Base -> false)
+    (fun st ->
+      match Pos.unmark st with Mast.GivenBack -> true | Base -> false)
     cv.Mast.comp_subtyp
 
 (* Used to generated the array names *)
@@ -151,8 +165,9 @@ let new_idx () =
   }
 
 (* Compute the variable indices in the different arrays according to its type *)
-(* Returns 3 indices: 1 - Index in the Computed/Base/Input arrays of the TGV 2 - Index in the
-   Context/Family/Income/... arrays 3 - Index in the Restituee array *)
+(* Returns 3 indices: 1 - Index in the Computed/Base/Input arrays of the TGV 2 -
+   Index in the Context/Family/Income/... arrays 3 - Index in the Restituee
+   array *)
 let next_idx idx kind output size =
   let idxr1, idxr2 =
     match (kind : var_subtype) with
@@ -178,16 +193,21 @@ let next_idx idx kind output size =
   (idx1, idx2, idxo_opt)
 
 let get_attr a attributes =
-  let attr_opt = List.find_opt (fun (an, _al) -> Pos.unmark an = a) attributes in
+  let attr_opt =
+    List.find_opt (fun (an, _al) -> Pos.unmark an = a) attributes
+  in
   match attr_opt with
   | None -> if a = "primrest" then 1 else -1
-  | Some (_an, al) -> ( match Pos.unmark al with Mast.Float f -> int_of_float f | _ -> 0)
+  | Some (_an, al) -> (
+      match Pos.unmark al with Mast.Float f -> int_of_float f | _ -> 0)
 
-let get_name name alias_opt = match alias_opt with Some alias -> alias | _ -> name
+let get_name name alias_opt =
+  match alias_opt with Some alias -> alias | _ -> name
 
 let sort_vars_by_alias vars =
   List.fast_sort
-    (fun (_, _, _, _, name1, alias_opt1, _, _, _, _) (_, _, _, _, name2, alias_opt2, _, _, _, _) ->
+    (fun (_, _, _, _, name1, alias_opt1, _, _, _, _)
+         (_, _, _, _, name2, alias_opt2, _, _, _, _) ->
       let var_name1 = get_name name1 alias_opt1 in
       let var_name2 = get_name name2 alias_opt2 in
       String.compare var_name1 var_name2)
@@ -213,8 +233,12 @@ let get_vars prog =
                 let cv = Pos.unmark cv in
                 let tvar = computed_var_subtype cv in
                 (* Base or Computed *)
-                let size = match cv.comp_table with Some i -> Pos.unmark i | None -> 1 in
-                let idx1, idx2, idxo_opt = next_idx idx tvar (computed_var_is_output cv) size in
+                let size =
+                  match cv.comp_table with Some i -> Pos.unmark i | None -> 1
+                in
+                let idx1, idx2, idxo_opt =
+                  next_idx idx tvar (computed_var_is_output cv) size
+                in
                 let var =
                   ( tvar,
                     idx1,
@@ -231,7 +255,9 @@ let get_vars prog =
             | VariableDecl (InputVar iv) ->
                 let iv = Pos.unmark iv in
                 let tvar = input_var_subtype iv in
-                let idx1, idx2, idxo_opt = next_idx idx tvar iv.input_given_back 1 in
+                let idx1, idx2, idxo_opt =
+                  next_idx idx tvar iv.input_given_back 1
+                in
                 let var =
                   ( tvar,
                     idx1,
@@ -254,22 +280,62 @@ let get_vars prog =
 
   let idx = new_idx () in
 
-  (* Recompute the indices of Context/Family/Income/... vars, as they are sorted by alias *)
+  (* Recompute the indices of Context/Family/Income/... vars, as they are sorted
+     by alias *)
   List.map
-    (fun (tvar, idx1, _idx2, idxo_opt, name, alias_opt, desc, typ_opt, attributes, size) ->
+    (fun ( tvar,
+           idx1,
+           _idx2,
+           idxo_opt,
+           name,
+           alias_opt,
+           desc,
+           typ_opt,
+           attributes,
+           size ) ->
       let _idx1, idx2, _idxo_opt = next_idx idx tvar (idxo_opt <> None) size in
-      (tvar, idx1, idx2, idxo_opt, name, alias_opt, desc, typ_opt, attributes, size))
+      ( tvar,
+        idx1,
+        idx2,
+        idxo_opt,
+        name,
+        alias_opt,
+        desc,
+        typ_opt,
+        attributes,
+        size ))
     vars
 
-(* Retrieve the variables for the debug array; variables with aliases are duplicated *)
+(* Retrieve the variables for the debug array; variables with aliases are
+   duplicated *)
 let get_vars_debug vars =
   sort_vars_by_name
   @@ List.fold_left
        (fun vars var ->
-         let tvar, idx1, idx2, idxo_opt, _name, alias_opt, desc, typ_opt, attributes, size = var in
+         let ( tvar,
+               idx1,
+               idx2,
+               idxo_opt,
+               _name,
+               alias_opt,
+               desc,
+               typ_opt,
+               attributes,
+               size ) =
+           var
+         in
          match alias_opt with
          | Some alias ->
-             (tvar, idx1, idx2, idxo_opt, alias, alias_opt, desc, typ_opt, attributes, size)
+             ( tvar,
+               idx1,
+               idx2,
+               idxo_opt,
+               alias,
+               alias_opt,
+               desc,
+               typ_opt,
+               attributes,
+               size )
              :: var :: vars
          | None -> var :: vars)
        [] vars
@@ -308,7 +374,8 @@ let gen_header fmt =
 |}
 
 (* Print a variable's description *)
-let gen_var fmt req_type opt ~idx ~name ~tvar ~is_output ~typ_opt ~attributes ~desc ~alias_opt =
+let gen_var fmt req_type opt ~idx ~name ~tvar ~is_output ~typ_opt ~attributes
+    ~desc ~alias_opt =
   let open Mast in
   let var_name = if opt.with_alias then get_name name alias_opt else name in
 
@@ -323,29 +390,43 @@ let gen_var fmt req_type opt ~idx ~name ~tvar ~is_output ~typ_opt ~attributes ~d
   let typ = match typ_opt with None -> Real | Some ct -> Pos.unmark ct in
 
   Format.fprintf fmt "    { \"%s\", %s | %d" var_name kind idx;
-  if opt.with_type_donnee then Format.fprintf fmt ", %a" Format_mast.format_value_typ typ;
+  if opt.with_type_donnee then
+    Format.fprintf fmt ", %a" Format_mast.format_value_typ typ;
   if opt.with_verif then
-    if is_input && false then Format.fprintf fmt ", err_%s" name (* Note: no alias *)
+    if is_input && false then Format.fprintf fmt ", err_%s" name
+      (* Note: no alias *)
     else Format.fprintf fmt ", no_error";
   (* does not seem to be used anymore... *)
-  if opt.with_classe then Format.fprintf fmt ", %d" (get_attr "classe" attributes);
-  if opt.with_priorite then Format.fprintf fmt ", %d" (get_attr "priorite" attributes);
-  if opt.with_categorie_TL then Format.fprintf fmt ", %d" (get_attr "categorie_TL" attributes);
-  if opt.with_nat_code then Format.fprintf fmt ", %d" (get_attr "nat_code" attributes);
-  if opt.with_cotsoc then Format.fprintf fmt ", %d" (get_attr "cotsoc" attributes);
-  if opt.with_ind_abat then Format.fprintf fmt ", %d" (get_attr "ind_abat" attributes);
-  if opt.with_acompte then Format.fprintf fmt ", %d" (get_attr "acompte" attributes);
-  if opt.with_avfisc then Format.fprintf fmt ", %d" (get_attr "avfisc" attributes);
-  if opt.with_rapcat then Format.fprintf fmt ", %d" (get_attr "rapcat" attributes);
-  if opt.with_sanction then Format.fprintf fmt ", %d" (get_attr "sanction" attributes);
-  if opt.with_modcat then Format.fprintf fmt ", %d" (get_attr "modcat" attributes);
+  if opt.with_classe then
+    Format.fprintf fmt ", %d" (get_attr "classe" attributes);
+  if opt.with_priorite then
+    Format.fprintf fmt ", %d" (get_attr "priorite" attributes);
+  if opt.with_categorie_TL then
+    Format.fprintf fmt ", %d" (get_attr "categorie_TL" attributes);
+  if opt.with_nat_code then
+    Format.fprintf fmt ", %d" (get_attr "nat_code" attributes);
+  if opt.with_cotsoc then
+    Format.fprintf fmt ", %d" (get_attr "cotsoc" attributes);
+  if opt.with_ind_abat then
+    Format.fprintf fmt ", %d" (get_attr "ind_abat" attributes);
+  if opt.with_acompte then
+    Format.fprintf fmt ", %d" (get_attr "acompte" attributes);
+  if opt.with_avfisc then
+    Format.fprintf fmt ", %d" (get_attr "avfisc" attributes);
+  if opt.with_rapcat then
+    Format.fprintf fmt ", %d" (get_attr "rapcat" attributes);
+  if opt.with_sanction then
+    Format.fprintf fmt ", %d" (get_attr "sanction" attributes);
+  if opt.with_modcat then
+    Format.fprintf fmt ", %d" (get_attr "modcat" attributes);
   if opt.with_liee then
     if true (* no linked var *) then Format.fprintf fmt ", (T_var_irdata)NULL"
     else Format.fprintf fmt ", desc_%s" (assert false);
   (* only REVENU vars may use this, but they don't... *)
   if opt.with_type && is_output then Format.fprintf fmt ", RESTITUEE";
   (* there also exist RESTITUEE_P and RESTITUEE_C, but they are unused *)
-  if opt.with_primrest then Format.fprintf fmt ", %d" (get_attr "primrest" attributes);
+  if opt.with_primrest then
+    Format.fprintf fmt ", %d" (get_attr "primrest" attributes);
   if opt.with_libelle then Format.fprintf fmt ", \"%s\"" desc
   else Format.fprintf fmt " /*\"%s\"*/" desc;
   begin
@@ -372,34 +453,49 @@ let gen_table fmt _flags vars req_type opt =
   (* if opt.with_verif then *)
   Format.fprintf fmt "extern T_discord *no_error(T_irdata *);\n";
 
-  (* TODO there should be individual var verification functions here, but they do not seem to be
-     used (for all kind of input vars as well as output vars and debug tables) *)
+  (* TODO there should be individual var verification functions here, but they
+     do not seem to be used (for all kind of input vars as well as output vars
+     and debug tables) *)
   let vars =
-    if opt.with_alias then vars (* already sorted by alias *) else sort_vars_by_name vars
+    if opt.with_alias then vars (* already sorted by alias *)
+    else sort_vars_by_name vars
   in
 
   let table_name = req_type_name req_type in
   let table_NAME = String.uppercase_ascii table_name in
   begin
     match req_type with
-    | Debug _i -> Format.fprintf fmt "T_desc_debug desc_%s[NB_%s + 1] = {\n" table_name table_NAME
-    | _ -> Format.fprintf fmt "T_desc_%s desc_%s[NB_%s + 1] = {\n" table_name table_name table_NAME
+    | Debug _i ->
+        Format.fprintf fmt "T_desc_debug desc_%s[NB_%s + 1] = {\n" table_name
+          table_NAME
+    | _ ->
+        Format.fprintf fmt "T_desc_%s desc_%s[NB_%s + 1] = {\n" table_name
+          table_name table_NAME
   end;
 
   List.iter
-    (fun (tvar, idx1, _idx2, idxo_opt, name, alias_opt, desc, typ_opt, attributes, _size) ->
+    (fun ( tvar,
+           idx1,
+           _idx2,
+           idxo_opt,
+           name,
+           alias_opt,
+           desc,
+           typ_opt,
+           attributes,
+           _size ) ->
       let is_output = match idxo_opt with Some _ -> true | _ -> false in
       if var_matches req_type tvar is_output then
         match req_type with
         | Debug _i ->
             (* Special case for debug *)
             let opt = { opt with with_alias = false } in
-            gen_var fmt req_type opt ~idx:idx1 ~name ~tvar ~is_output ~typ_opt ~attributes ~desc
-              ~alias_opt
+            gen_var fmt req_type opt ~idx:idx1 ~name ~tvar ~is_output ~typ_opt
+              ~attributes ~desc ~alias_opt
         | _ ->
             (* General case*)
-            gen_var fmt req_type opt ~idx:idx1 ~name ~tvar ~is_output ~typ_opt ~attributes ~desc
-              ~alias_opt)
+            gen_var fmt req_type opt ~idx:idx1 ~name ~tvar ~is_output ~typ_opt
+              ~attributes ~desc ~alias_opt)
     vars;
 
   Format.fprintf fmt "};\n"
@@ -407,36 +503,51 @@ let gen_table fmt _flags vars req_type opt =
 let gen_desc fmt vars ~alias_only =
   let vars = sort_vars_by_name vars in
 
-  Format.fprintf fmt {|/****** LICENCE CECIL *****/
+  Format.fprintf fmt
+    {|/****** LICENCE CECIL *****/
 
 #include "desc_static.h"
 
 |};
 
   List.iter
-    (fun (tvar, _idx1, idx2, idxo_opt, name, alias_opt, _desc, _typ_opt, _attributes, _size) ->
+    (fun ( tvar,
+           _idx1,
+           idx2,
+           idxo_opt,
+           name,
+           alias_opt,
+           _desc,
+           _typ_opt,
+           _attributes,
+           _size ) ->
       if (not alias_only) || alias_opt <> None then
         let data_opt =
           match (tvar : var_subtype) with
           | Base | Computed -> begin
               (* computed var: only output *)
-              match idxo_opt with Some idx -> Some ("restituee", idx) | None -> None
+              match idxo_opt with
+              | Some idx -> Some ("restituee", idx)
+              | None -> None
             end
           | _ -> Some (subtype_name tvar, idx2)
         in
         match data_opt with
         | Some (type_name, idx) ->
             let var_name =
-              match (alias_only, alias_opt) with true, Some alias -> alias | _ -> name
+              match (alias_only, alias_opt) with
+              | true, Some alias -> alias
+              | _ -> name
             in
-            (* TODO special handling for debug vars (though it does not seem to happen) *)
-            Format.fprintf fmt "#define desc_%s (T_var_irdata)(desc_%s + %d)\n" var_name type_name
-              idx
+            (* TODO special handling for debug vars (though it does not seem to
+               happen) *)
+            Format.fprintf fmt "#define desc_%s (T_var_irdata)(desc_%s + %d)\n"
+              var_name type_name idx
         | None -> ())
     vars
 
-(* TODO when flg_controle_immediat, add per variable verifications (add #define desc_verif) although
-   it does not seem to be used anymore *)
+(* TODO when flg_controle_immediat, add per variable verifications (add #define
+   desc_verif) although it does not seem to be used anymore *)
 
 let gen_table_output fmt flags vars =
   let opt =
@@ -646,7 +757,8 @@ let gen_table_debug fmt flags vars i =
 
   gen_table fmt flags vars (Debug i) opt
 
-let is_valid_app al = List.exists (fun a -> String.equal (Pos.unmark a) "iliad") al
+let is_valid_app al =
+  List.exists (fun a -> String.equal (Pos.unmark a) "iliad") al
 
 (* Retrieve rules, verifications, errors and chainings from a program *)
 let get_rules_verif_etc prog =
@@ -679,11 +791,13 @@ let get_rules_verif_etc prog =
                 in
                 (rules, verifs, errors, chainings)
             | Error e -> (rules, verifs, e :: errors, chainings)
-            (* | Chaining (cn, _anl) -> rules, verifs, errors, cn :: chainings *)
+            (* | Chaining (cn, _anl) -> rules, verifs, errors, cn ::
+               chainings *)
             | _ -> (rules, verifs, errors, chainings))
           (rules, verifs, errors, chainings)
           file)
-      ([], [], [], StringSet.empty) prog
+      ([], [], [], StringSet.empty)
+      prog
   in
 
   let rules = List.fast_sort compare rules in
@@ -704,7 +818,9 @@ let gen_table_call fmt flags vars_debug rules chainings errors =
     List.iter (fun rn -> Format.fprintf fmt "extern int regle_%d();\n" rn) rules;
 
     Format.fprintf fmt "T_desc_call desc_call[NB_CALL + 1] = {\n";
-    List.iter (fun rn -> Format.fprintf fmt "    { %d, regle_%d },\n" rn rn) rules;
+    List.iter
+      (fun rn -> Format.fprintf fmt "    { %d, regle_%d },\n" rn rn)
+      rules;
     Format.fprintf fmt "};\n\n";
 
     Format.fprintf fmt "T_desc_err desc_err[NB_ERR + 1] = {\n";
@@ -716,10 +832,14 @@ let gen_table_call fmt flags vars_debug rules chainings errors =
     Format.fprintf fmt "};\n\n"
   end;
 
-  StringSet.iter (fun cn -> Format.fprintf fmt "extern void %s();\n" cn) chainings;
+  StringSet.iter
+    (fun cn -> Format.fprintf fmt "extern void %s();\n" cn)
+    chainings;
 
   Format.fprintf fmt "T_desc_ench desc_ench[NB_ENCH + 1] = {\n";
-  StringSet.iter (fun cn -> Format.fprintf fmt "    { \"%s\", %s },\n" cn cn) chainings;
+  StringSet.iter
+    (fun cn -> Format.fprintf fmt "    { \"%s\", %s },\n" cn cn)
+    chainings;
   Format.fprintf fmt "};\n"
 
 (* Print the table of verification functions (tablev.c) *)
@@ -728,10 +848,14 @@ let gen_table_verif fmt flags verifs =
 
   if flags.Dgfip_options.flg_debug || flags.flg_controle_immediat then begin
     (* TODO: when control_immediat, don' put everything (but what ?) *)
-    List.iter (fun vn -> Format.fprintf fmt "extern void verif_%d();\n" vn) verifs;
+    List.iter
+      (fun vn -> Format.fprintf fmt "extern void verif_%d();\n" vn)
+      verifs;
 
     Format.fprintf fmt "T_desc_verif desc_verif[NB_VERIF + 1] = {\n";
-    List.iter (fun vn -> Format.fprintf fmt "    { %d, verif_%d },\n" vn vn) verifs;
+    List.iter
+      (fun vn -> Format.fprintf fmt "    { %d, verif_%d },\n" vn vn)
+      verifs;
     Format.fprintf fmt "};\n\n"
   end
 
@@ -788,8 +912,9 @@ let gen_var_h fmt flags vars vars_debug rules verifs chainings errors =
 #define NB_RESTITUEE %d
 #define NB_ENCH %d
 |}
-    taille_saisie taille_calculee taille_base taille_totale nb_contexte nb_famille nb_revenu
-    nb_revenu_correc nb_variation nb_penalite nb_restituee nb_ench;
+    taille_saisie taille_calculee taille_base taille_totale nb_contexte
+    nb_famille nb_revenu nb_revenu_correc nb_variation nb_penalite nb_restituee
+    nb_ench;
 
   if flags.Dgfip_options.flg_debug then begin
     Format.fprintf fmt "#define NB_ERR %d\n" nb_err;
@@ -812,14 +937,18 @@ let gen_var_h fmt flags vars vars_debug rules verifs chainings errors =
     Format.fprintf fmt "#define NB_VERIF %d\n" nb_verif;
 
   List.iter
-    (fun rn -> Format.fprintf fmt "extern int regle_%d _PROTS((struct S_irdata *));\n" rn)
+    (fun rn ->
+      Format.fprintf fmt "extern int regle_%d _PROTS((struct S_irdata *));\n" rn)
     rules;
 
   List.iter
-    (fun vn -> Format.fprintf fmt "extern void verif_%d _PROTS((struct S_irdata *));\n" vn)
+    (fun vn ->
+      Format.fprintf fmt "extern void verif_%d _PROTS((struct S_irdata *));\n"
+        vn)
     verifs;
 
-  (* TODO external declaration of individual control rules (seems to be no longer used) *)
+  (* TODO external declaration of individual control rules (seems to be no
+     longer used) *)
   List.iter
     (fun e ->
       let en = Pos.unmark e.error_name in
@@ -827,7 +956,8 @@ let gen_var_h fmt flags vars vars_debug rules verifs chainings errors =
     errors;
 
   (* TODO function declarations (seems to be no longer used) *)
-  if flags.flg_pro then Format.fprintf fmt "extern struct S_erreur *tabErreurs[];\n"
+  if flags.flg_pro then
+    Format.fprintf fmt "extern struct S_erreur *tabErreurs[];\n"
 
 let gen_var_c fmt flags errors =
   let open Mast in
@@ -847,29 +977,37 @@ let gen_var_c fmt flags errors =
             | Information -> 4
           in
           let sous_code_suffix =
-            if String.equal (Pos.unmark sous_code) "00" then "" else "-" ^ Pos.unmark sous_code
+            if String.equal (Pos.unmark sous_code) "00" then ""
+            else "-" ^ Pos.unmark sous_code
           in
           Format.fprintf fmt
-            "T_erreur erreur_%s = { \"%s%s%s / %s\", \"%s\", \"%s\", \"%s\", \"%s\", %d };\n"
-            (Pos.unmark e.error_name) (Pos.unmark famille) (Pos.unmark code_bo) sous_code_suffix
-            (Pos.unmark libelle) (Pos.unmark code_bo) (Pos.unmark sous_code) (Pos.unmark is_isf)
-            (Pos.unmark e.error_name) terr
+            "T_erreur erreur_%s = { \"%s%s%s / %s\", \"%s\", \"%s\", \"%s\", \
+             \"%s\", %d };\n"
+            (Pos.unmark e.error_name) (Pos.unmark famille) (Pos.unmark code_bo)
+            sous_code_suffix (Pos.unmark libelle) (Pos.unmark code_bo)
+            (Pos.unmark sous_code) (Pos.unmark is_isf) (Pos.unmark e.error_name)
+            terr
       | _ -> failwith "Invalid error description")
     errors;
 
   if flags.Dgfip_options.flg_pro || flags.flg_iliad then begin
     Format.fprintf fmt "T_erreur *tabErreurs[] = {\n";
 
-    List.iter (fun e -> Format.fprintf fmt "    &erreur_%s,\n" (Pos.unmark e.error_name)) errors;
+    List.iter
+      (fun e ->
+        Format.fprintf fmt "    &erreur_%s,\n" (Pos.unmark e.error_name))
+      errors;
 
     Format.fprintf fmt "    NULL\n};\n"
   end
 
 let gen_annee_h fmt flags =
-  Format.fprintf fmt {|/****** LICENCE CECIL *****/
+  Format.fprintf fmt
+    {|/****** LICENCE CECIL *****/
 
 #define ANNEE_REVENU %04d
-|} flags.Dgfip_options.annee_revenu;
+|}
+    flags.Dgfip_options.annee_revenu;
 
   Format.pp_print_flush fmt ()
 
@@ -898,19 +1036,23 @@ let gen_conf_h fmt flags vars =
   if flags.flg_short then Format.fprintf fmt "#define FLG_SHORT\n";
   if flags.flg_register then Format.fprintf fmt "#define FLG_REGISTER\n";
   (* flag is not used *)
-  (*if flags.flg_optim_min_max then Format.fprintf fmt "#define FLG_OPTIM_MIN_MAX\n"; *)
+  (*if flags.flg_optim_min_max then Format.fprintf fmt "#define
+    FLG_OPTIM_MIN_MAX\n"; *)
   if flags.flg_extraction then Format.fprintf fmt "#define FLG_EXTRACTION\n";
   if flags.flg_genere_libelle_restituee then
     Format.fprintf fmt "#define FLG_GENERE_LIBELLE_RESTITUEE\n";
-  if flags.flg_controle_separe then Format.fprintf fmt "#define FLG_CONTROLE_SEPARE\n";
-  if flags.flg_controle_immediat then Format.fprintf fmt "#define FLG_CONTROLE_IMMEDIAT\n";
+  if flags.flg_controle_separe then
+    Format.fprintf fmt "#define FLG_CONTROLE_SEPARE\n";
+  if flags.flg_controle_immediat then
+    Format.fprintf fmt "#define FLG_CONTROLE_IMMEDIAT\n";
   (* does not need to be printed *)
   (*if flags.flg_overlays then Format.fprintf fmt "#define FLG_OVERLAYS\n"; *)
   if flags.flg_colors then Format.fprintf fmt "#define FLG_COLORS\n";
   if flags.flg_ticket then Format.fprintf fmt "#define FLG_TICKET\n";
   if flags.flg_trace then Format.fprintf fmt "#define FLG_TRACE\n";
   (* flag is not used *)
-  (*if flags.flg_trace_irdata then Format.fprintf fmt "#define FLG_TRACE_IRDATA\n"; *)
+  (*if flags.flg_trace_irdata then Format.fprintf fmt "#define
+    FLG_TRACE_IRDATA\n"; *)
   if flags.flg_debug then Format.fprintf fmt "#define FLG_DEBUG\n";
   Format.fprintf fmt "#define NB_DEBUG_C  %d\n" flags.nb_debug_c;
 
@@ -928,10 +1070,15 @@ let extract_var_ids (cprog : Bir.program) vars =
   let open Dgfip_varid in
   let pvars = cprog.mir_program.program_vars in
   let add vn v vm =
-    let vs = match StringMap.find_opt vn vm with None -> VariableSet.empty | Some vs -> vs in
+    let vs =
+      match StringMap.find_opt vn vm with
+      | None -> VariableSet.empty
+      | Some vs -> vs
+    in
     StringMap.add (Pos.unmark v.Variable.name) (VariableSet.add v vs) vm
   in
-  (* Build a map from variable names to all their definitions (with different ids) *)
+  (* Build a map from variable names to all their definitions (with different
+     ids) *)
   let vars_map =
     VariableDict.fold
       (fun v vm ->
@@ -940,23 +1087,37 @@ let extract_var_ids (cprog : Bir.program) vars =
       pvars StringMap.empty
   in
   let process_var ~alias
-      (tvar, idx1, _idx2, _idxo_opt, name, alias_opt, _desc, _typ_opt, _attributes, _size) =
+      ( tvar,
+        idx1,
+        _idx2,
+        _idxo_opt,
+        name,
+        alias_opt,
+        _desc,
+        _typ_opt,
+        _attributes,
+        _size ) =
     let vid =
       match (tvar : var_subtype) with
       | Computed -> Dgfip_varid.VarComputed idx1
       | Base -> VarBase idx1
       | _ -> VarInput idx1
     in
-    let name = if alias then match alias_opt with Some alias -> alias | None -> name else name in
+    let name =
+      if alias then match alias_opt with Some alias -> alias | None -> name
+      else name
+    in
     (name, vid)
   in
-  (* Build a map from variable definitions (with different ids) to their array indices *)
+  (* Build a map from variable definitions (with different ids) to their array
+     indices *)
   List.fold_left
     (fun vm vd ->
       let name, vid = process_var ~alias:false vd in
       let vs =
         try StringMap.find name vars_map
-        with Not_found -> Errors.raise_error (Format.asprintf "Variable %s is undeclared" name)
+        with Not_found ->
+          Errors.raise_error (Format.asprintf "Variable %s is undeclared" name)
       in
       VariableSet.fold (fun v vm -> VariableMap.add v vid vm) vs vm)
     VariableMap.empty vars
@@ -966,9 +1127,9 @@ let open_file filename =
   let fmt = Format.formatter_of_out_channel oc in
   (oc, fmt)
 
-(* Generate the auxiliary files AND return the map of variables names to TGV ids *)
+(* Generate the auxiliary files AND return the map of variables names to TGV
+   ids *)
 let generate_auxiliary_files flags prog cprog : Dgfip_varid.var_id_map =
-
   let folder = Filename.dirname !Cli.output_file in
 
   let vars = get_vars prog in
@@ -1009,7 +1170,8 @@ let generate_auxiliary_files flags prog cprog : Dgfip_varid.var_id_map =
         (fun i vars ->
           let file = Printf.sprintf "tableg%02d.c" i in
           let oc, fmt = open_file (Filename.concat folder file) in
-          if flags.flg_debug then gen_table_debug fmt flags vars i else gen_header fmt;
+          if flags.flg_debug then gen_table_debug fmt flags vars i
+          else gen_header fmt;
           close_out oc;
           i + 1)
         1 vars_debug_split

--- a/src/mlang/backend_compilers/dgfip_varid.ml
+++ b/src/mlang/backend_compilers/dgfip_varid.ml
@@ -1,15 +1,18 @@
-(* Copyright (C) 2019 Inria, contributor: David Declerck <david.declerck@ocamlpro.com>
+(* Copyright (C) 2019 Inria, contributor: David Declerck
+   <david.declerck@ocamlpro.com>
 
-   This program is free software: you can redistribute it and/or modify it under the terms of the
-   GNU General Public License as published by the Free Software Foundation, either version 3 of the
-   License, or (at your option) any later version.
+   This program is free software: you can redistribute it and/or modify it under
+   the terms of the GNU General Public License as published by the Free Software
+   Foundation, either version 3 of the License, or (at your option) any later
+   version.
 
-   This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-   even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-   General Public License for more details.
+   This program is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+   FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+   details.
 
-   You should have received a copy of the GNU General Public License along with this program. If
-   not, see <https://www.gnu.org/licenses/>. *)
+   You should have received a copy of the GNU General Public License along with
+   this program. If not, see <https://www.gnu.org/licenses/>. *)
 
 (* ID of a variable in its sub-array of the TGV *)
 type var_id = VarInput of int | VarBase of int | VarComputed of int

--- a/src/mlang/backend_compilers/dgfip_varid.ml
+++ b/src/mlang/backend_compilers/dgfip_varid.ml
@@ -20,16 +20,23 @@ type var_id = VarInput of int | VarBase of int | VarComputed of int
 (* Map from variables to their TGV ID *)
 type var_id_map = var_id Mir.VariableMap.t
 
-let gen_access_def vm v =
+let gen_access_def vm v offset =
   let vn = Pos.unmark v.Mir.Variable.name in
   match Mir.VariableMap.find v vm with
-  | VarInput i -> Printf.sprintf "DS_[%d /*%s*/]" i vn
-  | VarBase i -> Printf.sprintf "DB_[%d /*%s*/]" i vn
-  | VarComputed i -> Printf.sprintf "DC_[%d /*%s*/]" i vn
+  | VarInput i -> Printf.sprintf "DS_[%d/*%s*/%s]" i vn offset
+  | VarBase i -> Printf.sprintf "DB_[%d/*%s*/%s]" i vn offset
+  | VarComputed i -> Printf.sprintf "DC_[%d/*%s*/%s]" i vn offset
 
-let gen_access_val vm v =
+let gen_access_val vm v offset =
   let vn = Pos.unmark v.Mir.Variable.name in
   match Mir.VariableMap.find v vm with
-  | VarInput i -> Printf.sprintf "S_[%d /*%s*/]" i vn
-  | VarBase i -> Printf.sprintf "B_[%d /*%s*/]" i vn
-  | VarComputed i -> Printf.sprintf "C_[%d /*%s*/]" i vn
+  | VarInput i -> Printf.sprintf "S_[%d/*%s*/%s]" i vn offset
+  | VarBase i -> Printf.sprintf "B_[%d/*%s*/%s]" i vn offset
+  | VarComputed i -> Printf.sprintf "C_[%d/*%s*/%s]" i vn offset
+
+let gen_access_pointer vm v =
+  let vn = Pos.unmark v.Mir.Variable.name in
+  match Mir.VariableMap.find v vm with
+  | VarInput i -> Printf.sprintf "(S_ + %d/*%s*/)" i vn
+  | VarBase i -> Printf.sprintf "(B_ + %d/*%s*/)" i vn
+  | VarComputed i -> Printf.sprintf "(C_ + %d/*%s*/)" i vn

--- a/src/mlang/driver.ml
+++ b/src/mlang/driver.ml
@@ -216,8 +216,10 @@ let driver (files : string list) (debug : bool) (var_info_debug : string list)
             Cli.debug_print "Compiling the codebase to DGFiP C...";
             if !Cli.output_file = "" then
               Errors.raise_error "an output file must be defined with --output";
-            let vm = Dgfip_gen_files.generate_auxiliary_files dgfip_flags
-                source_m_program combined_program in
+            let vm =
+              Dgfip_gen_files.generate_auxiliary_files dgfip_flags
+                source_m_program combined_program
+            in
             Bir_to_dgfip_c.generate_c_program combined_program function_spec
               !Cli.output_file vm;
             Cli.debug_print "Result written to %s" !Cli.output_file

--- a/src/mlang/m_frontend/format_mast.mli
+++ b/src/mlang/m_frontend/format_mast.mli
@@ -20,11 +20,11 @@ val format_binop : Format.formatter -> Mast.binop -> unit
 
 val format_unop : Format.formatter -> Mast.unop -> unit
 
+val format_value_typ : Format.formatter -> Mast.value_typ -> unit
+
 val format_variable : Format.formatter -> Mast.variable -> unit
 
 val format_rule_name : Format.formatter -> Mast.rule_name -> unit
-
-val format_value_typ : Format.formatter -> Mast.value_typ -> unit
 
 val format_source_file : Format.formatter -> Mast.source_file -> unit
 

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -244,11 +244,7 @@ let rec translate_mpp_function (mpp_program : Mpp_ir.mpp_compute list)
     (m_program : Mir_interface.full_program) (compute_decl : Mpp_ir.mpp_compute)
     (args : Mpp_ir.scoped_var list) (ctx : translation_ctx) :
     translation_ctx * Bir.stmt list =
-  List.fold_left
-    (fun (ctx, stmts) stmt ->
-      let ctx, stmt' = translate_mpp_stmt mpp_program m_program args ctx stmt in
-      (ctx, stmts @ stmt'))
-    (ctx, []) compute_decl.Mpp_ir.body
+  translate_mpp_stmts mpp_program m_program args ctx compute_decl.Mpp_ir.body
 
 and translate_mpp_expr (p : Mir_interface.full_program) (ctx : translation_ctx)
     (expr : Mpp_ir.mpp_expr_kind Pos.marked) : Mir.expression =
@@ -299,7 +295,7 @@ and translate_mpp_expr (p : Mir_interface.full_program) (ctx : translation_ctx)
 
 and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
     (m_program : Mir_interface.full_program) func_args (ctx : translation_ctx)
-    stmt : translation_ctx * Bir.stmt list =
+    (stmt : Mpp_ir.mpp_stmt) : translation_ctx * Bir.stmt list =
   let pos = Pos.get_position stmt in
   match Pos.unmark stmt with
   | Mpp_ir.Assign (Local l, expr) ->


### PR DESCRIPTION
From #59, [relevant diff](https://github.com/MLanguage/mlang/pull/84/commits/6c6f2f84694edf41f1aace2a74e5ce02917ac56c).

This patch makes the dgfip backend produce code closer to the original compirateur. With this we should be able to build a calculette by fitting mlang in the current workflow.

Closes #22 