### PR TITLE
Register tags on rules in Mir

### DIFF
--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -242,7 +242,7 @@ module Make (N : Bir_number.NumberInterface) = struct
                 (fun fmt () ->
                   try
                     let rule, def = Mir.find_var_definition p var in
-                    Format.fprintf fmt "rule %a, %a" Format_mast.format_rule_name rule.rule_name
+                    Format.fprintf fmt "rule %d, %a" (Pos.unmark rule.rule_number)
                       Format_mir.format_variable_def def.var_definition
                   with Not_found -> Format.fprintf fmt "unused definition")
                 ())

--- a/src/mlang/m_frontend/mast_to_mir.ml
+++ b/src/mlang/m_frontend/mast_to_mir.ml
@@ -1353,7 +1353,8 @@ let translate (p : Mast.program) : Mir.program =
                 Mir.VariableDict.add var vars ))
             ([], vars) (List.rev rule_vars)
         in
-        (Mir.RuleMap.add rule_id Mir.{ rule_vars; rule_name } rules, vars))
+        let rule_number, rule_tags = Mir.rule_number_and_tags_of_rule_name rule_name in
+        (Mir.RuleMap.add rule_id Mir.{ rule_vars; rule_number; rule_tags } rules, vars))
       rule_data
       (Mir.RuleMap.empty, Mir.VariableDict.empty)
   in
@@ -1369,7 +1370,7 @@ let translate (p : Mast.program) : Mir.program =
   in
   let rules =
     Mir.RuleMap.add Mir.initial_undef_rule_id
-      Mir.{ rule_vars = orphans; rule_name = [ ("var_init", Pos.no_pos) ] }
+      Mir.{ rule_vars = orphans; rule_number = (0, Pos.no_pos); rule_tags = [] }
       rules
   in
   let conds = get_conds error_decls idmap p in

--- a/src/mlang/m_ir/format_mir.ml
+++ b/src/mlang/m_ir/format_mir.ml
@@ -113,7 +113,7 @@ let format_precondition fmt (precond : condition_data) =
 
 let format_program_rules fmt (vars : VariableDict.t) (rules : rule_data RuleMap.t) =
   RuleMap.iter
-    (fun _ { rule_vars; rule_name } ->
+    (fun _ { rule_vars; rule_number; _ } ->
       let var_defs =
         List.fold_left
           (fun var_defs (vid, def) ->
@@ -121,8 +121,7 @@ let format_program_rules fmt (vars : VariableDict.t) (rules : rule_data RuleMap.
             VariableMap.add var def var_defs)
           VariableMap.empty rule_vars
       in
-      Format.fprintf fmt "Regle %a\n%a\n" Format_mast.format_rule_name rule_name format_variables
-        var_defs)
+      Format.fprintf fmt "Regle %d\n%a\n" (Pos.unmark rule_number) format_variables var_defs)
     rules
 
 let format_program_conds fmt (conds : condition_data VariableMap.t) =

--- a/src/mlang/m_ir/mir_dependency_graph.ml
+++ b/src/mlang/m_ir/mir_dependency_graph.ml
@@ -127,7 +127,7 @@ let check_for_cycle (g : RG.t) (p : Mir.program) (print_debug : bool) : bool =
                  (List.map
                     (fun (rule_id, edge) ->
                       let rule = Mir.RuleMap.find rule_id p.Mir.program_rules in
-                      Format.asprintf "%a with vars: %s" Format_mast.format_rule_name rule.rule_name
+                      Format.asprintf "%d with vars: %s" (Pos.unmark rule.rule_number)
                         (RG.E.label edge))
                     edges))
             :: !cycles_strings)

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -175,8 +175,8 @@ let generate_rule_instance (m_program : Mir_interface.full_program) (rule_id : M
   let rule = Mir.RuleMap.find rule_id m_program.program.program_rules in
   let rule_stmts = translate_m_code m_program rule.rule_vars in
   let pos, rule_name =
-    let pos = List.hd rule.Mir.rule_name |> Pos.get_position in
-    let name = List.map Pos.unmark rule.Mir.rule_name |> String.concat "_" in
+    let pos = Pos.get_position rule.Mir.rule_number in
+    let name = string_of_int (Pos.unmark rule.Mir.rule_number) in
     (pos, name ^ "_i" ^ string_of_int instance_id)
   in
   let instance = Bir.{ rule_id = instance_id; rule_name; rule_stmts } in


### PR DESCRIPTION
This creates a proper list of tags for rules, denoting its membership to the diverse "enchaineurs".
Based on the tags seen in 2020 sources.