### PR TITLE
Refactor dune files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ dune:
 	dune build $(DUNE_OPTIONS)
 
 # Run only in an opam switch with musl and static options activated
-build-static: DUNE_OPTIONS+=--profile=static --profile=release
+build-static: DUNE_OPTIONS+=--profile=static 
 build-static: build
 
 ##################################################

--- a/src/dune
+++ b/src/dune
@@ -1,12 +1,10 @@
 (env
  (static
   (flags
-   (-cclib -lstdc++ -ccopt -static))))
+   (-ccopt -static -O3))))
 
 (executable
  (name main)
  (package mlang)
  (public_name mlang)
- (ocamlopt_flags
-  (-cclib -lstdc++))
  (libraries mlang))

--- a/src/mlang/dune
+++ b/src/mlang/dune
@@ -1,9 +1,12 @@
+(env
+  (static
+    (flags
+      (-O3 -ccopt -static))))
+
 (include_subdirs unqualified)
 
 (library
  (public_name mlang)
- (ocamlopt_flags
-  (-cclib -lstdc++))
  (libraries ocamlgraph re ANSITerminal parmap cmdliner threads
    dune-build-info num gmp))
 


### PR DESCRIPTION
The release profile currently active in the makefile for the
build-static target appears to override the static build thus breaking
the pre-built linux binary. This PR reverts that change.

It also removes the inclusion of the stdc++ library with appears to be
unused by MLang.

Finally this PR adds O3 level optimizations when the static profile is
active, increasing performance.

closes #91 