### PR TITLE
Improve anomaly handling

### DIFF
--- a/examples/dgfip_c/Makefile
+++ b/examples/dgfip_c/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.include
 
-MPP_FILE=../../../mpp_specs/dgfip_base.mpp
+MPP_FILE=../../mpp_specs/dgfip_base.mpp
 
 OPTIMIZE_FLAG=-O
 

--- a/examples/dgfip_c/backend_tests/test_harness.c
+++ b/examples/dgfip_c/backend_tests/test_harness.c
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
                         // Here we move to controlling the outputs, so we
                         // have to run the computation!
                         m_input_from_array(input_for_m, input_array_for_m);
-                        errors = malloc(sizeof(Errors));
+                        errors = malloc(sizeof(error_occurrences));
                         output_for_m->errors = errors;
                         m_extracted(output_for_m, input_for_m);
                         free(output_for_m->errors);

--- a/examples/dgfip_c/backend_tests/test_harness.c
+++ b/examples/dgfip_c/backend_tests/test_harness.c
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
     int num_outputs = m_num_inputs();
     m_value *outputs_array_for_m = malloc(num_outputs * sizeof(m_value));
     m_output *output_for_m = malloc(sizeof(m_input));
-    m_error *errors;
+    m_error_occurrence *errors;
 
     char *name;
     char *value_s;

--- a/examples/dgfip_c/m_error.c
+++ b/examples/dgfip_c/m_error.c
@@ -1,3 +1,16 @@
+/* Copyright (C) 2021 Inria, contributor: James Barnes <bureau.si-part-ircalcul@dgfip.finances.gouv.fr>
+
+   This program is free software: you can redistribute it and/or modify it under the terms of the
+   GNU General Public License as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+   even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with this program. If
+   not, see <https://www.gnu.org/licenses/>. */
+
 #include "m_error.h"
 
 int get_occurred_errors_count(m_error_occurrence* errors, int size) {

--- a/examples/dgfip_c/m_error.c
+++ b/examples/dgfip_c/m_error.c
@@ -1,6 +1,6 @@
 #include "m_error.h"
 
-int get_occurred_errors_count(m_error *errors, int size) {
+int get_occurred_errors_count(m_error_occurrence* errors, int size) {
   int count = 0;
 
   for (int i = 0; i < size; i++) {
@@ -12,8 +12,8 @@ int get_occurred_errors_count(m_error *errors, int size) {
   return count;
 }
 
-m_error *get_occurred_errors_items(int full_list_count, m_error *full_list,
-                                   m_error *filtered_errors) {
+m_error_occurrence* get_occurred_errors_items(int full_list_count, m_error_occurrence* full_list,
+                                   m_error_occurrence* filtered_errors) {
   int count = 0;
 
   for (int i = 0; i < full_list_count; i++) {

--- a/examples/dgfip_c/m_error.h
+++ b/examples/dgfip_c/m_error.h
@@ -14,12 +14,16 @@ typedef struct m_error {
   char minor_code[7];
   char description[81];
   char isisf[2];
-  bool has_occurred;
 } m_error;
 
-int get_occurred_errors(m_error *errors, int size);
+typedef struct m_error_occurrence {
+  m_error *error;
+  bool has_occurred; 
+} m_error_occurrence;
 
-m_error *get_occurred_errors_items(int full_list_count, m_error *full_list,
-                                   m_error *filtered_errors);
+int get_occurred_errors(m_error_occurrence *errors, int size);
+
+m_error_occurrence* get_occurred_errors_items(int full_list_count, m_error_occurrence *full_list,
+                                   m_error_occurrence *filtered_errors);
 
 #endif /* M_ERROR_ */

--- a/examples/dgfip_c/m_error.h
+++ b/examples/dgfip_c/m_error.h
@@ -14,10 +14,11 @@ typedef struct m_error {
   char minor_code[7];
   char description[81];
   char isisf[2];
+  char code_information[10];
 } m_error;
 
 typedef struct m_error_occurrence {
-  m_error *error;
+  const m_error *error;
   bool has_occurred; 
 } m_error_occurrence;
 

--- a/examples/dgfip_c/m_error.h
+++ b/examples/dgfip_c/m_error.h
@@ -1,3 +1,16 @@
+/* Copyright (C) 2021 Inria, contributor: James Barnes <bureau.si-part-ircalcul@dgfip.finances.gouv.fr>
+
+   This program is free software: you can redistribute it and/or modify it under the terms of the
+   GNU General Public License as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+   even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with this program. If
+   not, see <https://www.gnu.org/licenses/>. */
+
 #ifndef M_ERROR_
 #define M_ERROR_
 

--- a/examples/dgfip_c/m_error.h
+++ b/examples/dgfip_c/m_error.h
@@ -22,12 +22,12 @@
 typedef enum error_kind { Anomaly, Discordance, Information } error_kind;
 
 typedef struct m_error {
-  char kind[2];
-  char major_code[4];
-  char minor_code[7];
-  char description[81];
-  char isisf[2];
-  char code_information[10];
+  const char* kind;
+  const char* major_code;
+  const char* minor_code;
+  const char* description;
+  const char* isisf;
+  const char* code_information;
 } m_error;
 
 typedef struct m_error_occurrence {

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -265,6 +265,17 @@ let generate_main_function_signature (oc : Format.formatter) (add_semicolon : bo
   Format.fprintf oc "int m_extracted(m_output *output, const m_input *input)%s"
     (if add_semicolon then ";" else "")
 
+let get_anomaly_indexes (p : Bir.program) : (Error.t * Variable.t option) ErrorIndex.t =
+  let _, index =
+    VariableMap.fold
+      (fun _ v acc ->
+        let count, err = acc in
+        let count = count + 1 in
+        count, ErrorIndex.add count v.cond_error err)
+      p.mir_program.program_conds (0, ErrorIndex.empty)
+  in
+  index
+
 let get_variables_indexes (p : Bir.program) (function_spec : Bir_interface.bir_function) :
     int Mir.VariableMap.t * int =
   let input_vars = List.map fst (VariableMap.bindings function_spec.func_variable_inputs) in

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -170,30 +170,29 @@ let generate_var_def (var_indexes : int Mir.VariableMap.t) (var : Mir.Variable.t
 let generate_var_cond (var_indexes : int Mir.VariableMap.t) (cond : condition_data)
     (oc : Format.formatter) =
   let scond, defs = generate_c_expr cond.cond_expr var_indexes in
-  Format.fprintf oc "@[<hv 0>%acond = %s;@,\
-  @[<hv 2>if (m_is_defined_true(cond)){@,\
-  %a@]@,\
-  }@,@,@]"
+  Format.fprintf oc "@[<hv 0>%acond = %s;@,@[<hv 2>if (m_is_defined_true(cond)){@,%a@]@,}@,@,@]"
     (format_local_vars_defs var_indexes)
     defs scond
     (fun oc () ->
-        let error, _ = cond.cond_error in
-        let error_pos = error.id in
-        Format.fprintf oc "@[<hv 0>m_error_occurrence occurrence = output->errors[%d]; @,\
-           occurrence.error = &m_errors[%d]; @,\
-           occurrence.has_occurred = true;@]@," error_pos error_pos;
+      let error, _ = cond.cond_error in
+      let error_pos = error.id in
+      Format.fprintf oc
+        "@[<hv 0>m_error_occurrence occurrence = output->errors[%d]; @,\
+         occurrence.error = &m_errors[%d]; @,\
+         occurrence.has_occurred = true;@]@,"
+        error_pos error_pos;
       if (fst cond.cond_error).Mir.Error.typ = Mast.Anomaly then
-               Format.fprintf oc
+        Format.fprintf oc
           "output->is_error = true;@,\
            #ifndef ANOMALY_LIMIT @,\
            free(TGV); @,\
            free(LOCAL); @,\
            return -1; @,\
            #else /* ANOMALY_LIMIT */ @,\
-           @[<hv 2>if (anomaly_count >= max_anomalies) {@, \
-           free(TGV); @, \
-           free(LOCAL);@, \
-           return -1;@]@,\
+           @[<hv 2>if (anomaly_count >= max_anomalies) {@,\
+          \ free(TGV); @,\
+          \ free(LOCAL);@,\
+          \ return -1;@]@,\
            }@,\
            #endif /* ANOMALY_LIMIT */")
     ()

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -170,34 +170,32 @@ let generate_var_def (var_indexes : int Mir.VariableMap.t) (var : Mir.Variable.t
 let generate_var_cond (var_indexes : int Mir.VariableMap.t) (cond : condition_data)
     (oc : Format.formatter) =
   let scond, defs = generate_c_expr cond.cond_expr var_indexes in
-  Format.fprintf oc {|
-  %acond = %s;
-  if (m_is_defined_true(cond))
-  {%a
-  }
-|}
+  Format.fprintf oc "@[<hv 0>%acond = %s;@,\
+  @[<hv 2>if (m_is_defined_true(cond)){@,\
+  %a@]@,\
+  }@,@,@]"
     (format_local_vars_defs var_indexes)
     defs scond
     (fun oc () ->
-      if (fst cond.cond_error).Mir.Error.typ = Mast.Anomaly then
         let error, _ = cond.cond_error in
         let error_pos = error.id in
-        Format.fprintf oc
-          " @[<hv 0>output->is_error = true;@,\
-           m_error_occurrence occurrence = output->errors[%d]; @,\
+        Format.fprintf oc "@[<hv 0>m_error_occurrence occurrence = output->errors[%d]; @,\
            occurrence.error = &m_errors[%d]; @,\
-          \ occurrence.has_occurred = true;@,\
-          \ #ifndef ANOMALY_LIMIT @,\
+           occurrence.has_occurred = true;@]@," error_pos error_pos;
+      if (fst cond.cond_error).Mir.Error.typ = Mast.Anomaly then
+               Format.fprintf oc
+          "output->is_error = true;@,\
+           #ifndef ANOMALY_LIMIT @,\
            free(TGV); @,\
            free(LOCAL); @,\
            return -1; @,\
            #else /* ANOMALY_LIMIT */ @,\
-           if (anomaly_count >= max_anomalies) {@,\
-          \ free(TGV); @,\
-           free(LOCAL);@,\
-          \ return -1;@,\
+           @[<hv 2>if (anomaly_count >= max_anomalies) {@, \
+           free(TGV); @, \
+           free(LOCAL);@, \
+           return -1;@]@,\
            }@,\
-          \ #endif /* ANOMALY_LIMIT */" error_pos error_pos)
+           #endif /* ANOMALY_LIMIT */")
     ()
 
 let fresh_cond_counter = ref 0

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -174,7 +174,6 @@ let generate_var_def (var_indexes : int Mir.VariableMap.t) (var : Mir.Variable.t
 let generate_var_cond (var_indexes : int Mir.VariableMap.t) (cond : condition_data)
     (oc : Format.formatter) =
   let scond, defs = generate_c_expr cond.cond_expr var_indexes in
-  let percent = Re.Pcre.regexp "%" in
   Format.fprintf oc
     {|
     %acond = %s;
@@ -191,7 +190,6 @@ let generate_var_cond (var_indexes : int Mir.VariableMap.t) (cond : condition_da
         ^ (Pos.unmark @@ err.Mir.Error.descr.major_code)
         ^ Pos.unmark @@ err.Mir.Error.descr.minor_code
       in
-      let error_descr = Re.Pcre.substitute ~rex:percent ~subst:(fun _ -> "%%") error_descr in
       Format.fprintf fmt
         {|
         output->errors[m_get_error_index("%s")].has_occurred = true;|}


### PR DESCRIPTION
The DGFiP backend doesn't currently return any information about the errors that occurred during calculation, just that an anomaly occurred. This PR aims to improve on that by returning information for all calculation error categories. 

Relates to #24 