### PR TITLE
Unify SSA duplicated variables of Mir in Bir

### DIFF
--- a/src/mlang/backend_compilers/bir_to_c.ml
+++ b/src/mlang/backend_compilers/bir_to_c.ml
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License along with
    this program. If not, see <https://www.gnu.org/licenses/>. *)
 
-open Mir
+open Bir
 
 let none_value = "m_undefined"
 
@@ -45,39 +45,39 @@ type offset =
   | PassPointer
   | None
 
-let generate_variable (var_indexes : int Mir.VariableMap.t) (offset : offset)
-    (fmt : Format.formatter) (var : Bir.variable) : unit =
-  let var = Bir.var_to_mir var in
+let generate_variable (var_indexes : int VariableMap.t) (offset : offset)
+    (fmt : Format.formatter) (var : variable) : unit =
+  let mvar = var_to_mir var in
   let var_index =
-    match Mir.VariableMap.find_opt var var_indexes with
+    match VariableMap.find_opt var var_indexes with
     | Some i -> i
     | None ->
         Errors.raise_error
           (Format.asprintf "Variable %s not found in TGV"
-             (Pos.unmark var.Mir.Variable.name))
+             (Pos.unmark mvar.Mir.Variable.name))
   in
   match offset with
   | PassPointer ->
       Format.fprintf fmt "(TGV + %d/*%s*/)" var_index
-        (Pos.unmark var.Mir.Variable.name)
+        (Pos.unmark mvar.Mir.Variable.name)
   | _ ->
       Format.fprintf fmt "TGV[%d/*%s*/%s]" var_index
-        (Pos.unmark var.Mir.Variable.name)
+        (Pos.unmark mvar.Mir.Variable.name)
         (match offset with
         | None -> ""
         | GetValueVar offset -> " + " ^ offset
         | GetValueConst offset -> " + " ^ string_of_int offset
         | PassPointer -> assert false)
 
-let generate_raw_name (v : Bir.variable) : string =
-  let v = Bir.var_to_mir v in
-  match v.alias with Some v -> v | None -> Pos.unmark v.Variable.name
+let generate_raw_name (v : variable) : string =
+  let v = var_to_mir v in
+  match v.alias with Some v -> v | None -> Pos.unmark v.Mir.Variable.name
 
-let generate_name (v : Bir.variable) : string = "v_" ^ generate_raw_name v
+let generate_name (v : variable) : string = "v_" ^ generate_raw_name v
 
 let rec generate_c_expr (e : expression Pos.marked)
-    (var_indexes : int Mir.VariableMap.t) :
-    string * (LocalVariable.t * expression Pos.marked) list =
+    (var_indexes : int VariableMap.t) :
+    string * (Mir.LocalVariable.t * expression Pos.marked) list =
   match Pos.unmark e with
   | Comparison (op, e1, e2) ->
       let se1, s1 = generate_c_expr e1 var_indexes in
@@ -94,11 +94,12 @@ let rec generate_c_expr (e : expression Pos.marked)
       (Format.asprintf "%s(%s)" (generate_unop op) se, s)
   | Index (var, e) ->
       let se, s = generate_c_expr e var_indexes in
-      let size = Option.get (Pos.unmark var).Mir.Variable.is_table in
+      let size =
+        Option.get (var_to_mir (Pos.unmark var)).Mir.Variable.is_table
+      in
       ( Format.asprintf "m_array_index(%a, %s, %d)"
           (generate_variable var_indexes PassPointer)
-          (Bir.var_from_mir (Pos.unmark var))
-          se size,
+          (Pos.unmark var) se size,
         s )
   | Conditional (e1, e2, e3) ->
       let se1, s1 = generate_c_expr e1 var_indexes in
@@ -129,18 +130,15 @@ let rec generate_c_expr (e : expression Pos.marked)
       let se1, s1 = generate_c_expr e1 var_indexes in
       ( Format.asprintf "m_multimax(%s, %a)" se1
           (generate_variable var_indexes PassPointer)
-          (Bir.var_from_mir v2),
+          v2,
         s1 )
   | FunctionCall _ -> assert false (* should not happen *)
   | Literal (Float f) ->
       (Format.asprintf "m_literal(%s)" (string_of_float f), [])
   | Literal Undefined -> (Format.asprintf "%s" none_value, [])
   | Var var ->
-      ( Format.asprintf "%a"
-          (generate_variable var_indexes None)
-          (Bir.var_from_mir var),
-        [] )
-  | LocalVar lvar -> (Format.asprintf "LOCAL[%d]" lvar.LocalVariable.id, [])
+      (Format.asprintf "%a" (generate_variable var_indexes None) var, [])
+  | LocalVar lvar -> (Format.asprintf "LOCAL[%d]" lvar.Mir.LocalVariable.id, [])
   | GenericTableIndex -> (Format.asprintf "m_literal(generic_index)", [])
   | Error -> assert false (* should not happen *)
   | LocalLet (lvar, e1, e2) ->
@@ -148,17 +146,17 @@ let rec generate_c_expr (e : expression Pos.marked)
       let se2, s2 = generate_c_expr e2 var_indexes in
       (Format.asprintf "%s" se2, s1 @ ((lvar, e1) :: s2))
 
-let format_local_vars_defs (var_indexes : int Mir.VariableMap.t)
+let format_local_vars_defs (var_indexes : int VariableMap.t)
     (fmt : Format.formatter)
-    (defs : (LocalVariable.t * expression Pos.marked) list) =
+    (defs : (Mir.LocalVariable.t * expression Pos.marked) list) =
   List.iter
     (fun (lvar, e) ->
       let se, _ = generate_c_expr e var_indexes in
-      Format.fprintf fmt "LOCAL[%d] = %s;@\n" lvar.LocalVariable.id se)
+      Format.fprintf fmt "LOCAL[%d] = %s;@\n" lvar.Mir.LocalVariable.id se)
     defs
 
-let generate_var_def (var_indexes : int Mir.VariableMap.t) (var : Bir.variable)
-    (data : Mir.variable_data) (oc : Format.formatter) : unit =
+let generate_var_def (var_indexes : int VariableMap.t) (var : variable)
+    (data : variable_data) (oc : Format.formatter) : unit =
   match data.var_definition with
   | SimpleVar e ->
       let se, defs = generate_c_expr e var_indexes in
@@ -170,7 +168,7 @@ let generate_var_def (var_indexes : int Mir.VariableMap.t) (var : Bir.variable)
   | TableVar (_, IndexTable es) ->
       Format.fprintf oc "%a"
         (fun fmt ->
-          IndexMap.iter (fun i v ->
+          Mir.IndexMap.iter (fun i v ->
               let sv, defs = generate_c_expr v var_indexes in
               Format.fprintf fmt "%a%a = %s;@\n"
                 (format_local_vars_defs var_indexes)
@@ -193,8 +191,8 @@ let generate_var_def (var_indexes : int Mir.VariableMap.t) (var : Bir.variable)
        *   (Pos.get_position e) *)
   | InputVar -> assert false
 
-let generate_var_cond (var_indexes : int Mir.VariableMap.t)
-    (cond : condition_data) (oc : Format.formatter) =
+let generate_var_cond (var_indexes : int VariableMap.t) (cond : condition_data)
+    (oc : Format.formatter) =
   if (fst cond.cond_error).typ = Mast.Anomaly then
     let scond, defs = generate_c_expr cond.cond_expr var_indexes in
     let percent = Re.Pcre.regexp "%" in
@@ -216,16 +214,15 @@ let generate_var_cond (var_indexes : int Mir.VariableMap.t)
         let error_descr =
           Re.Pcre.substitute ~rex:percent ~subst:(fun _ -> "%%") error_descr
         in
-        Format.fprintf fmt "%s: %s" (Pos.unmark err.Error.name) error_descr)
+        Format.fprintf fmt "%s: %s" (Pos.unmark err.Mir.Error.name) error_descr)
       (fst cond.cond_error)
 
 let fresh_cond_counter = ref 0
 
-let rec generate_stmt (program : Bir.program)
-    (var_indexes : int Mir.VariableMap.t) (oc : Format.formatter)
-    (stmt : Bir.stmt) =
+let rec generate_stmt (program : program) (var_indexes : int VariableMap.t)
+    (oc : Format.formatter) (stmt : stmt) =
   match Pos.unmark stmt with
-  | Bir.SAssign (var, vdata) -> generate_var_def var_indexes var vdata oc
+  | SAssign (var, vdata) -> generate_var_def var_indexes var vdata oc
   | SConditional (cond, tt, ff) ->
       let pos = Pos.get_position stmt in
       let fname =
@@ -258,44 +255,42 @@ let rec generate_stmt (program : Bir.program)
         ff
   | SVerif v -> generate_var_cond var_indexes v oc
   | SRuleCall r ->
-      let rule = Bir.RuleMap.find r program.rules in
+      let rule = RuleMap.find r program.rules in
       generate_rule_function_header ~definition:false oc rule
   | SFunctionCall (f, _) ->
       Format.fprintf oc "if(%s(output, TGV, LOCAL)) {return -1;};\n" f
 
-and generate_stmts (program : Bir.program) (var_indexes : int Mir.VariableMap.t)
-    (oc : Format.formatter) (stmts : Bir.stmt list) =
+and generate_stmts (program : program) (var_indexes : int VariableMap.t)
+    (oc : Format.formatter) (stmts : stmt list) =
   Format.pp_print_list (generate_stmt program var_indexes) oc stmts
 
 and generate_rule_function_header ~(definition : bool) (oc : Format.formatter)
-    (rule : Bir.rule) =
+    (rule : rule) =
   let arg_type = if definition then "m_value *" else "" in
   let ret_type = if definition then "void " else "" in
   Format.fprintf oc "%sm_rule_%s(%sTGV, %sLOCAL)%s@\n" ret_type rule.rule_name
     arg_type arg_type
     (if definition then "" else ";")
 
-let generate_rule_function (program : Bir.program)
-    (var_indexes : int Mir.VariableMap.t) (oc : Format.formatter)
-    (rule : Bir.rule) =
+let generate_rule_function (program : program) (var_indexes : int VariableMap.t)
+    (oc : Format.formatter) (rule : rule) =
   Format.fprintf oc "%a@[<v 2>{@ %a@]@;}@\n"
     (generate_rule_function_header ~definition:true)
     rule
     (generate_stmts program var_indexes)
     rule.rule_stmts
 
-let generate_rule_functions (program : Bir.program)
-    (var_indexes : int Mir.VariableMap.t) (oc : Format.formatter)
-    (rules : Bir.rule Bir.RuleMap.t) =
+let generate_rule_functions (program : program)
+    (var_indexes : int VariableMap.t) (oc : Format.formatter)
+    (rules : rule RuleMap.t) =
   Format.pp_print_list ~pp_sep:Format.pp_print_cut
     (generate_rule_function program var_indexes)
     oc
-    (Bir.RuleMap.bindings rules |> List.map snd)
+    (RuleMap.bindings rules |> List.map snd)
 
-let generate_mpp_function (program : Bir.program)
-    (var_indexes : int Mir.VariableMap.t) (oc : Format.formatter)
-    (f : Bir.function_name) =
-  let stmts = Bir.FunctionMap.find f program.mpp_functions in
+let generate_mpp_function (program : program) (var_indexes : int VariableMap.t)
+    (oc : Format.formatter) (f : function_name) =
+  let stmts = FunctionMap.find f program.mpp_functions in
   Format.fprintf oc
     "@[<hv 4>int %s(m_output*output, m_value* TGV, m_value* LOCAL) {@,\
      m_value cond;@,\
@@ -306,7 +301,7 @@ let generate_mpp_function (program : Bir.program)
     stmts
 
 let generate_mpp_functions (program : Bir.program) (oc : Format.formatter)
-    (var_indexes : int Mir.VariableMap.t) =
+    (var_indexes : int VariableMap.t) =
   Bir.FunctionMap.iter
     (fun fname _ -> generate_mpp_function program var_indexes oc fname)
     (Bir_interface.context_agnostic_mpp_functions program)
@@ -316,13 +311,11 @@ let generate_main_function_signature (oc : Format.formatter)
   Format.fprintf oc "int m_extracted(m_output *output, const m_input *input)%s"
     (if add_semicolon then ";" else "")
 
-let generate_main_function_signature_and_var_decls (p : Bir.program)
-    (var_indexes : int Mir.VariableMap.t) (var_table_size : int)
+let generate_main_function_signature_and_var_decls (p : program)
+    (var_indexes : int VariableMap.t) (var_table_size : int)
     (oc : Format.formatter) (function_spec : Bir_interface.bir_function) =
   let input_vars =
-    List.map
-      (fun b -> fst b |> Bir.var_from_mir)
-      (VariableMap.bindings function_spec.func_variable_inputs)
+    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
   in
   Format.fprintf oc "%a {@\n@[<h 4>    @\n" generate_main_function_signature
     false;
@@ -331,7 +324,7 @@ let generate_main_function_signature_and_var_decls (p : Bir.program)
   (* here, we need to generate a table that can host all the local vars. the
      index inside the table will be the id of the local var so we generate a
      table big enough so that the highest id is always in bounds *)
-  let size_locals = Bir.get_locals_size p + 1 in
+  let size_locals = get_locals_size p + 1 in
   Format.fprintf oc "m_value *LOCAL = malloc(%d * sizeof(m_value));@\n@\n"
     size_locals;
   Format.fprintf oc "m_value *TGV = malloc(%d * sizeof(m_value));@\n@\n"
@@ -348,12 +341,10 @@ let generate_main_function_signature_and_var_decls (p : Bir.program)
 
   Format.fprintf oc "m_value cond;@\n@\n"
 
-let generate_return (var_indexes : int Mir.VariableMap.t)
-    (oc : Format.formatter) (function_spec : Bir_interface.bir_function) =
+let generate_return (var_indexes : int VariableMap.t) (oc : Format.formatter)
+    (function_spec : Bir_interface.bir_function) =
   let returned_variables =
-    List.map
-      (fun b -> fst b |> Bir.var_from_mir)
-      (VariableMap.bindings function_spec.func_outputs)
+    List.map fst (VariableMap.bindings function_spec.func_outputs)
   in
   Format.fprintf oc
     "%a@\n\
@@ -389,9 +380,7 @@ let generate_empty_input_prototype (oc : Format.formatter)
 let generate_empty_input_func (oc : Format.formatter)
     (function_spec : Bir_interface.bir_function) =
   let input_vars =
-    List.map
-      (fun b -> fst b |> Bir.var_from_mir)
-      (VariableMap.bindings function_spec.func_variable_inputs)
+    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
   in
   Format.fprintf oc "%a {@\n@[<h 4>    %a@]@\n};@\n@\n"
     generate_empty_input_prototype false
@@ -409,9 +398,7 @@ let generate_input_from_array_prototype (oc : Format.formatter)
 let generate_input_from_array_func (oc : Format.formatter)
     (function_spec : Bir_interface.bir_function) =
   let input_vars =
-    List.map
-      (fun b -> fst b |> Bir.var_from_mir)
-      (VariableMap.bindings function_spec.func_variable_inputs)
+    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
   in
   Format.fprintf oc "%a {@\n@[<h 4>    %a@]@\n};@\n@\n"
     generate_input_from_array_prototype false
@@ -429,9 +416,7 @@ let generate_get_input_index_prototype (oc : Format.formatter)
 let generate_get_input_index_func (oc : Format.formatter)
     (function_spec : Bir_interface.bir_function) =
   let input_vars =
-    List.map
-      (fun b -> fst b |> Bir.var_from_mir)
-      (VariableMap.bindings function_spec.func_variable_inputs)
+    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
   in
   Format.fprintf oc
     "%a {@\n\
@@ -456,9 +441,7 @@ let generate_get_input_name_from_index_prototype (oc : Format.formatter)
 let generate_get_input_name_from_index_func (oc : Format.formatter)
     (function_spec : Bir_interface.bir_function) =
   let input_vars =
-    List.map
-      (fun b -> fst b |> Bir.var_from_mir)
-      (VariableMap.bindings function_spec.func_variable_inputs)
+    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
   in
   Format.fprintf oc
     "%a {@\n\
@@ -491,16 +474,14 @@ let generate_get_input_num_func (oc : Format.formatter)
 let generate_input_type (oc : Format.formatter)
     (function_spec : Bir_interface.bir_function) =
   let input_vars =
-    List.map
-      (fun b -> fst b |> Bir.var_from_mir)
-      (VariableMap.bindings function_spec.func_variable_inputs)
+    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
   in
   Format.fprintf oc "typedef struct m_input {@[<h 4>    %a@]@\n} m_input;@\n@\n"
     (Format.pp_print_list
        ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
        (fun fmt var ->
          Format.fprintf fmt "m_value %s; // %s" (generate_name var)
-           (Pos.unmark (Bir.var_to_mir var).Variable.descr)))
+           (Pos.unmark (var_to_mir var).Mir.Variable.descr)))
     input_vars
 
 let generate_empty_output_prototype (oc : Format.formatter)
@@ -511,9 +492,7 @@ let generate_empty_output_prototype (oc : Format.formatter)
 let generate_empty_output_func (oc : Format.formatter)
     (function_spec : Bir_interface.bir_function) =
   let output_vars =
-    List.map
-      (fun b -> fst b |> Bir.var_from_mir)
-      (VariableMap.bindings function_spec.func_outputs)
+    List.map fst (VariableMap.bindings function_spec.func_outputs)
   in
   Format.fprintf oc
     "%a {@\n@[<h 4>    @\noutput->is_error = false;@\n%a@]@\n};@\n@\n"
@@ -532,9 +511,7 @@ let generate_output_to_array_prototype (oc : Format.formatter)
 let generate_output_to_array_func (oc : Format.formatter)
     (function_spec : Bir_interface.bir_function) =
   let output_vars =
-    List.map
-      (fun b -> fst b |> Bir.var_from_mir)
-      (VariableMap.bindings function_spec.func_outputs)
+    List.map fst (VariableMap.bindings function_spec.func_outputs)
   in
   Format.fprintf oc "%a {@\n@[<h 4>    %a@]@\n};@\n@\n"
     generate_output_to_array_prototype false
@@ -566,7 +543,7 @@ let generate_get_output_index_func (oc : Format.formatter)
        ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
        (fun fmt (var, i) ->
          Format.fprintf fmt "if (strcmp(\"%s\", name) == 0) { return %d; }"
-           (Pos.unmark var.Mir.Variable.name)
+           (Pos.unmark (var_to_mir var).Mir.Variable.name)
            i))
     (List.mapi (fun i x -> (x, i)) output_vars)
 
@@ -592,7 +569,7 @@ let generate_get_output_name_from_index_func (oc : Format.formatter)
        ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
        (fun fmt (var, i) ->
          Format.fprintf fmt "if (index == %d) { return \"%s\"; }" i
-           (Pos.unmark var.Mir.Variable.name)))
+           (Pos.unmark (var_to_mir var).Mir.Variable.name)))
     (List.mapi (fun i x -> (x, i)) output_vars)
 
 let generate_get_output_num_prototype (oc : Format.formatter)
@@ -611,9 +588,7 @@ let generate_get_output_num_func (oc : Format.formatter)
 let generate_output_type (oc : Format.formatter)
     (function_spec : Bir_interface.bir_function) =
   let output_vars =
-    List.map
-      (fun b -> fst b |> Bir.var_from_mir)
-      (VariableMap.bindings function_spec.func_outputs)
+    List.map fst (VariableMap.bindings function_spec.func_outputs)
   in
   Format.fprintf oc
     "typedef struct m_output {@\n\
@@ -625,7 +600,7 @@ let generate_output_type (oc : Format.formatter)
        ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
        (fun fmt var ->
          Format.fprintf fmt "m_value %s; // %s" (generate_name var)
-           (Pos.unmark (Bir.var_to_mir var).Variable.descr)))
+           (Pos.unmark (var_to_mir var).Mir.Variable.descr)))
     output_vars
 
 let generate_implem_header oc header_filename =
@@ -633,7 +608,7 @@ let generate_implem_header oc header_filename =
   Format.fprintf oc "#include <string.h>\n";
   Format.fprintf oc "#include \"%s\"\n\n" header_filename
 
-let generate_c_program (program : Bir.program)
+let generate_c_program (program : program)
     (function_spec : Bir_interface.bir_function) (filename : string) : unit =
   if Filename.extension filename <> ".c" then
     Errors.raise_error
@@ -658,17 +633,17 @@ let generate_c_program (program : Bir.program)
   close_out _oc;
   let _oc = open_out filename in
   let oc = Format.formatter_of_out_channel _oc in
-  Format.fprintf oc "%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a" 
-    generate_implem_header header_filename 
+  Format.fprintf oc "%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a%a"
+    generate_implem_header header_filename
     generate_empty_input_func function_spec
-    generate_input_from_array_func function_spec 
-    generate_get_input_index_func function_spec 
+    generate_input_from_array_func function_spec
+    generate_get_input_index_func function_spec
     generate_get_input_name_from_index_func function_spec
-    generate_get_input_num_func function_spec 
-    generate_output_to_array_func function_spec 
+    generate_get_input_num_func function_spec
+    generate_output_to_array_func function_spec
     generate_get_output_index_func function_spec
     generate_get_output_name_from_index_func function_spec
-    generate_get_output_num_func function_spec 
+    generate_get_output_num_func function_spec
     generate_empty_output_func function_spec
     (generate_rule_functions program var_indexes)
       program.rules
@@ -676,7 +651,7 @@ let generate_c_program (program : Bir.program)
       var_indexes
     (generate_main_function_signature_and_var_decls program var_indexes
        var_table_size) function_spec
-    (generate_stmts program var_indexes) 
+    (generate_stmts program var_indexes)
       (Bir.main_statements program)
     (generate_return var_indexes) function_spec;
   close_out _oc[@@ocamlformat "disable"]

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -294,7 +294,8 @@ let rec generate_stmt (program : Bir.program)
     (var_indexes : Dgfip_varid.var_id_map) (oc : Format.formatter)
     (stmt : Bir.stmt) =
   match Pos.unmark stmt with
-  | Bir.SAssign (var, vdata) -> generate_var_def var_indexes var vdata oc
+  | Bir.SAssign (var, vdata) ->
+      generate_var_def var_indexes (Bir.var_to_mir var) vdata oc
   | SConditional _ -> assert false (* not in dgfip trivial M++ *)
   | SVerif v -> generate_var_cond var_indexes v oc
   | SRuleCall r ->

--- a/src/mlang/backend_compilers/bir_to_java.ml
+++ b/src/mlang/backend_compilers/bir_to_java.ml
@@ -316,7 +316,8 @@ and generate_stmt (program : Bir.program) (var_indexes : int Mir.VariableMap.t)
   | SRuleCall r ->
       let rule = Bir.RuleMap.find r program.rules in
       generate_rule_header oc rule
-  | Bir.SAssign (var, vdata) -> generate_var_def var_indexes var vdata oc
+  | Bir.SAssign (var, vdata) ->
+      generate_var_def var_indexes (Bir.var_to_mir var) vdata oc
   | SConditional (cond, tt, ff) ->
       let pos = Pos.get_position stmt in
       let fname =

--- a/src/mlang/backend_compilers/bir_to_python.ml
+++ b/src/mlang/backend_compilers/bir_to_python.ml
@@ -370,7 +370,7 @@ let rec generate_stmts (program : Bir.program) oc stmts =
 
 and generate_stmt program oc stmt =
   match Pos.unmark stmt with
-  | Bir.SAssign (var, vdata) -> generate_var_def var vdata oc
+  | Bir.SAssign (var, vdata) -> generate_var_def (Bir.var_to_mir var) vdata oc
   | SConditional (cond, tt, []) ->
       let pos = Pos.get_position stmt in
       let fname =

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -18,6 +18,29 @@ type rule_id = Mir.rule_id
 
 module RuleMap = Mir.RuleMap
 
+type variable = Mir.Variable.t
+
+type variable_id = Mir.variable_id
+
+module VariableMap = Mir.VariableMap
+module VariableDict = Mir.VariableDict
+
+(* unify SSA variables *)
+let var_from_mir (v : Mir.Variable.t) : variable =
+  match v.origin with Some v -> v | None -> v
+
+let var_to_mir v = v
+
+let map_from_mir_map map =
+  Mir.VariableMap.fold
+    (fun var -> VariableMap.add (var_from_mir var))
+    map VariableMap.empty
+
+let dict_from_mir_dict dict =
+  Mir.VariableDict.fold
+    (fun var -> VariableDict.add (var_from_mir var))
+    dict VariableDict.empty
+
 type function_name = string
 
 type rule = { rule_id : rule_id; rule_name : string; rule_stmts : stmt list }
@@ -25,7 +48,7 @@ type rule = { rule_id : rule_id; rule_name : string; rule_stmts : stmt list }
 and stmt = stmt_kind Pos.marked
 
 and stmt_kind =
-  | SAssign of Mir.Variable.t * Mir.variable_data
+  | SAssign of variable * Mir.variable_data
   | SConditional of Mir.expression * stmt list * stmt list
   | SVerif of Mir.condition_data
   | SRuleCall of rule_id

--- a/src/mlang/backend_ir/bir.mli
+++ b/src/mlang/backend_ir/bir.mli
@@ -18,6 +18,38 @@ type rule_id = Mir.rule_id
 
 module RuleMap = Mir.RuleMap
 
+type variable
+
+type variable_id
+
+module VariableMap : Map.S with type key = variable
+
+module VariableDict : sig
+  type t
+
+  val bindings : t -> (variable_id * variable) list
+
+  val add : variable -> t -> t
+
+  val empty : t
+
+  val find : variable_id -> t -> variable
+
+  val mem : variable -> t -> bool
+
+  val union : t -> t -> t
+
+  val inter : t -> t -> t
+
+  val fold : (variable -> 'b -> 'b) -> t -> 'b -> 'b
+
+  val singleton : variable -> t
+
+  val filter : (variable_id -> variable -> bool) -> t -> t
+
+  val for_all : (variable -> bool) -> t -> bool
+end
+
 type function_name = string
 
 type rule = { rule_id : rule_id; rule_name : string; rule_stmts : stmt list }
@@ -25,7 +57,7 @@ type rule = { rule_id : rule_id; rule_name : string; rule_stmts : stmt list }
 and stmt = stmt_kind Pos.marked
 
 and stmt_kind =
-  | SAssign of Mir.Variable.t * Mir.variable_data
+  | SAssign of variable * Mir.variable_data
   | SConditional of Mir.expression * stmt list * stmt list
   | SVerif of Mir.condition_data
   | SRuleCall of rule_id
@@ -43,6 +75,14 @@ type program = {
   mir_program : Mir.program;
   outputs : unit Mir.VariableMap.t;
 }
+
+val var_from_mir : Mir.Variable.t -> variable
+
+val var_to_mir : variable -> Mir.Variable.t
+
+val map_from_mir_map : 'a Mir.VariableMap.t -> 'a VariableMap.t
+
+val dict_from_mir_dict : Mir.VariableDict.t -> VariableDict.t
 
 val main_statements : program -> stmt list
 

--- a/src/mlang/backend_ir/bir.mli
+++ b/src/mlang/backend_ir/bir.mli
@@ -20,7 +20,7 @@ module RuleMap = Mir.RuleMap
 
 type variable
 
-type variable_id
+type variable_id = int
 
 module VariableMap : Map.S with type key = variable
 
@@ -50,6 +50,14 @@ module VariableDict : sig
   val for_all : (variable -> bool) -> t -> bool
 end
 
+type expression = variable Mir.expression_
+
+type condition_data = variable Mir.condition_data_
+
+type variable_def = variable Mir.variable_def_
+
+type variable_data = variable Mir.variable_data_
+
 type function_name = string
 
 type rule = { rule_id : rule_id; rule_name : string; rule_stmts : stmt list }
@@ -57,9 +65,9 @@ type rule = { rule_id : rule_id; rule_name : string; rule_stmts : stmt list }
 and stmt = stmt_kind Pos.marked
 
 and stmt_kind =
-  | SAssign of variable * Mir.variable_data
-  | SConditional of Mir.expression * stmt list * stmt list
-  | SVerif of Mir.condition_data
+  | SAssign of variable * variable_data
+  | SConditional of expression * stmt list * stmt list
+  | SVerif of condition_data
   | SRuleCall of rule_id
   | SFunctionCall of function_name * Mir.Variable.t list
 
@@ -73,12 +81,14 @@ type program = {
   main_function : function_name;
   idmap : Mir.idmap;
   mir_program : Mir.program;
-  outputs : unit Mir.VariableMap.t;
+  outputs : unit VariableMap.t;
 }
 
 val var_from_mir : Mir.Variable.t -> variable
 
 val var_to_mir : variable -> Mir.Variable.t
+
+val compare_variable : variable -> variable -> int
 
 val map_from_mir_map : 'a Mir.VariableMap.t -> 'a VariableMap.t
 
@@ -96,10 +106,15 @@ val squish_statements : program -> int -> string -> program
     existing rules semantics, with these chunks being rule definitions and
     inserting rule calls in their place*)
 
-val get_assigned_variables : program -> Mir.VariableDict.t
+val get_assigned_variables : program -> VariableDict.t
 
 val get_local_variables : program -> unit Mir.LocalVariableMap.t
 
 val get_locals_size : program -> int
 
 val remove_empty_conditionals : stmt list -> stmt list
+
+val get_used_variables_ :
+  expression Pos.marked -> VariableDict.t -> VariableDict.t
+
+val get_used_variables : expression Pos.marked -> VariableDict.t

--- a/src/mlang/backend_ir/bir_instrumentation.ml
+++ b/src/mlang/backend_ir/bir_instrumentation.ml
@@ -21,12 +21,12 @@ module CodeLocationMap = Map.Make (struct
 end)
 
 type code_coverage_result =
-  Bir_interpreter.var_literal CodeLocationMap.t Mir.VariableMap.t
+  Bir_interpreter.var_literal CodeLocationMap.t Bir.VariableMap.t
 (** The result of the code coverage measurement is a map of the successive
     definitions of all the non-array variables during interpretation of the
     program *)
 
-let empty_code_coverage_result : code_coverage_result = Mir.VariableMap.empty
+let empty_code_coverage_result : code_coverage_result = Bir.VariableMap.empty
 
 let code_coverage_acc : code_coverage_result ref =
   ref empty_code_coverage_result
@@ -36,7 +36,7 @@ let code_coverage_init () : unit =
   Bir_interpreter.assign_hook :=
     fun var literal code_loc ->
       code_coverage_acc :=
-        Mir.VariableMap.update var
+        Bir.VariableMap.update var
           (fun old_defs ->
             match old_defs with
             | None -> Some (CodeLocationMap.singleton code_loc (literal ()))
@@ -69,19 +69,19 @@ end)
 type code_coverage_map_value = VarLiteralSet.t
 
 type code_coverage_acc =
-  code_coverage_map_value CodeLocationMap.t Mir.VariableMap.t
+  code_coverage_map_value CodeLocationMap.t Bir.VariableMap.t
 
 let merge_code_coverage_single_results_with_acc (results : code_coverage_result)
     (acc : code_coverage_acc) : code_coverage_acc =
-  Mir.VariableMap.fold
+  Bir.VariableMap.fold
     (fun var (new_defs : Bir_interpreter.var_literal CodeLocationMap.t) acc ->
-      match Mir.VariableMap.find_opt var acc with
+      match Bir.VariableMap.find_opt var acc with
       | None ->
-          Mir.VariableMap.add var
+          Bir.VariableMap.add var
             (CodeLocationMap.map (fun x -> VarLiteralSet.singleton x) new_defs)
             acc
       | Some old_defs ->
-          Mir.VariableMap.add var
+          Bir.VariableMap.add var
             (CodeLocationMap.fold
                (fun code_loc new_def defs ->
                  match CodeLocationMap.find_opt code_loc defs with
@@ -99,7 +99,7 @@ let merge_code_coverage_single_results_with_acc (results : code_coverage_result)
 
 let merge_code_coverage_acc (acc1 : code_coverage_acc)
     (acc2 : code_coverage_acc) : code_coverage_acc =
-  Mir.VariableMap.union
+  Bir.VariableMap.union
     (fun _ defs1 defs2 ->
       Some
         (CodeLocationMap.union
@@ -107,7 +107,7 @@ let merge_code_coverage_acc (acc1 : code_coverage_acc)
            defs1 defs2))
     acc1 acc2
 
-type code_locs = Mir.Variable.t CodeLocationMap.t
+type code_locs = Bir.variable CodeLocationMap.t
 
 let rec get_code_locs_stmt (p : Bir.program) (stmt : Bir.stmt)
     (loc : Bir_interpreter.code_location) : code_locs =

--- a/src/mlang/backend_ir/bir_instrumentation.mli
+++ b/src/mlang/backend_ir/bir_instrumentation.mli
@@ -21,7 +21,7 @@
 module CodeLocationMap : Map.S with type key = Bir_interpreter.code_location
 
 type code_coverage_result =
-  Bir_interpreter.var_literal CodeLocationMap.t Mir.VariableMap.t
+  Bir_interpreter.var_literal CodeLocationMap.t Bir.VariableMap.t
 (** For each variable, and for each code location where it is assigned, we
     record the value it has been assigned to during an interpreter run *)
 
@@ -45,7 +45,7 @@ module VarLiteralSet : Set.S with type elt = Bir_interpreter.var_literal
 type code_coverage_map_value = VarLiteralSet.t
 
 type code_coverage_acc =
-  code_coverage_map_value CodeLocationMap.t Mir.VariableMap.t
+  code_coverage_map_value CodeLocationMap.t Bir.VariableMap.t
 (** The accumulated coverage is the set of distinct values a particular variable
     assignment has received in the tests runs so far *)
 
@@ -61,7 +61,7 @@ val merge_code_coverage_acc :
 
 (** {1 Code locations}*)
 
-type code_locs = Mir.Variable.t CodeLocationMap.t
+type code_locs = Bir.variable CodeLocationMap.t
 
 val get_code_locs : Bir.program -> code_locs
 (** Returns all code locations in a program *)

--- a/src/mlang/backend_ir/bir_interface.ml
+++ b/src/mlang/backend_ir/bir_interface.ml
@@ -277,7 +277,7 @@ let adapt_program_to_function (p : Bir.program) (f : bir_function) :
       (fun var e acc ->
         Pos.same_pos_as
           (Bir.SAssign
-             ( var,
+             ( Bir.var_from_mir var,
                {
                  Mir.var_typ = None;
                  Mir.var_io = Regular;
@@ -296,7 +296,7 @@ let adapt_program_to_function (p : Bir.program) (f : bir_function) :
             else
               let pos = Pos.no_pos in
               ( Bir.SAssign
-                  ( var,
+                  ( Bir.var_from_mir var,
                     {
                       Mir.var_typ = None;
                       Mir.var_io = Regular;

--- a/src/mlang/backend_ir/bir_interface.ml
+++ b/src/mlang/backend_ir/bir_interface.ml
@@ -15,37 +15,38 @@
    this program. If not, see <https://www.gnu.org/licenses/>. *)
 
 type bir_function = {
-  func_variable_inputs : unit Mir.VariableMap.t;
-  func_constant_inputs : Mir.expression Pos.marked Mir.VariableMap.t;
-  func_outputs : unit Mir.VariableMap.t;
-  func_conds : Mir.condition_data Mir.VariableMap.t;
+  func_variable_inputs : unit Bir.VariableMap.t;
+  func_constant_inputs : Bir.expression Pos.marked Bir.VariableMap.t;
+  func_outputs : unit Bir.VariableMap.t;
+  func_conds : Bir.condition_data Bir.VariableMap.t;
 }
 
 let get_variables_indexes (p : Bir.program) (function_spec : bir_function) :
-    int Mir.VariableMap.t * int =
-  let open Mir in
+    int Bir.VariableMap.t * int =
   let input_vars =
-    List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
+    List.map fst (Bir.VariableMap.bindings function_spec.func_variable_inputs)
   in
   let assigned_variables =
-    List.map snd (Mir.VariableDict.bindings (Bir.get_assigned_variables p))
+    List.map snd (Bir.VariableDict.bindings (Bir.get_assigned_variables p))
   in
   let output_vars =
-    List.map fst (VariableMap.bindings function_spec.func_outputs)
+    List.map fst (Bir.VariableMap.bindings function_spec.func_outputs)
   in
   let all_relevant_variables =
     List.fold_left
-      (fun acc var -> Mir.VariableMap.add var () acc)
-      Mir.VariableMap.empty
+      (fun acc var -> Bir.VariableMap.add var () acc)
+      Bir.VariableMap.empty
       (input_vars @ assigned_variables @ output_vars)
   in
   let counter = ref 0 in
   let var_indexes =
-    VariableMap.mapi
+    Bir.VariableMap.mapi
       (fun var _ ->
         let id = !counter in
         let size =
-          match var.Mir.Variable.is_table with None -> 1 | Some size -> size
+          match (Bir.var_to_mir var).Mir.Variable.is_table with
+          | None -> 1
+          | Some size -> size
         in
         counter := !counter + size;
         id)
@@ -54,12 +55,12 @@ let get_variables_indexes (p : Bir.program) (function_spec : bir_function) :
   (var_indexes, !counter)
 
 let var_set_from_variable_name_list (p : Bir.program)
-    (names : string Pos.marked list) : unit Mir.VariableMap.t =
+    (names : string Pos.marked list) : unit Bir.VariableMap.t =
   List.fold_left
     (fun acc name ->
       let var = Mir.find_var_by_name p.mir_program name in
-      Mir.VariableMap.add var () acc)
-    Mir.VariableMap.empty names
+      Bir.VariableMap.add (Bir.var_from_mir var) () acc)
+    Bir.VariableMap.empty names
 
 let check_const_expression_is_really_const (e : Mir.expression Pos.marked) :
     unit =
@@ -73,7 +74,7 @@ let check_const_expression_is_really_const (e : Mir.expression Pos.marked) :
 
 let const_var_set_from_list (p : Bir.program)
     (names : (string Pos.marked * Mast.expression Pos.marked) list) :
-    Mir.expression Pos.marked Mir.VariableMap.t =
+    Bir.expression Pos.marked Bir.VariableMap.t =
   List.fold_left
     (fun acc ((name, e) : string Pos.marked * Mast.expression Pos.marked) ->
       let var =
@@ -84,6 +85,7 @@ let const_var_set_from_list (p : Bir.program)
                  compare v1.Mir.Variable.execution_number
                    v2.Mir.Variable.execution_number)
                (Pos.VarNameToID.find (Pos.unmark name) p.idmap))
+          |> Bir.var_from_mir
         with Not_found -> (
           try
             let name = Mir.find_var_name_by_alias p.mir_program name in
@@ -93,6 +95,7 @@ let const_var_set_from_list (p : Bir.program)
                    compare v1.Mir.Variable.execution_number
                      v2.Mir.Variable.execution_number)
                  (Pos.VarNameToID.find name p.idmap))
+            |> Bir.var_from_mir
           with Errors.StructuredError _ ->
             Errors.raise_spanned_error
               (Format.asprintf "unknown variable %s" (Pos.unmark name))
@@ -110,12 +113,14 @@ let const_var_set_from_list (p : Bir.program)
           e
       in
       check_const_expression_is_really_const new_e;
-      Mir.VariableMap.add var new_e acc)
-    Mir.VariableMap.empty names
+      Bir.VariableMap.add var
+        (Pos.map_under_mark (Mir.map_expr_var Bir.var_from_mir) new_e)
+        acc)
+    Bir.VariableMap.empty names
 
 let translate_external_conditions idmap
     (conds : Mast.expression Pos.marked list) :
-    Mir.condition_data Mir.VariableMap.t =
+    Bir.condition_data Bir.VariableMap.t =
   let check_boolean (mexpr : Mast.expression Pos.marked) =
     match Pos.unmark mexpr with
     | Binop (((And | Or), _), _, _) -> true
@@ -168,41 +173,52 @@ let translate_external_conditions idmap
         verif_conditions = verif_conds;
       }
   in
-  (* Leave a constant map empty is risky, it will fail if we allow tests to
-     refer to M constants in their expressions *)
-  Mast_to_mir.get_conds [ test_error ] Mast_to_mir.ConstMap.empty idmap
-    [ [ (program, Pos.no_pos) ] ]
+  let conds =
+    (* Leave a constant map empty is risky, it will fail if we allow tests to
+       refer to M constants in their expressions *)
+    Mast_to_mir.get_conds [ test_error ] Mast_to_mir.ConstMap.empty idmap
+      [ [ (program, Pos.no_pos) ] ]
+  in
+  Mir.VariableMap.fold
+    (fun v data acc ->
+      Bir.VariableMap.add (Bir.var_from_mir v)
+        (Mir.map_cond_data_var Bir.var_from_mir data)
+        acc)
+    conds Bir.VariableMap.empty
 
 let generate_function_all_vars (p : Bir.program) : bir_function =
-  let open Mir in
   let output_vars =
-    VariableDict.fold
-      (fun k acc -> VariableMap.add k () acc)
-      (find_vars_by_io p.mir_program Output)
-      VariableMap.empty
+    Mir.VariableDict.fold
+      (fun k acc -> Bir.VariableMap.add (Bir.var_from_mir k) () acc)
+      (Mir.find_vars_by_io p.mir_program Output)
+      Bir.VariableMap.empty
   in
   let input_vars =
-    let program_input_vars = find_vars_by_io p.mir_program Input in
+    let program_input_vars =
+      Mir.find_vars_by_io p.mir_program Input |> Bir.dict_from_mir_dict
+    in
     let max_exec_vars =
       Pos.VarNameToID.fold
         (fun _ v acc ->
-          let max_exec_var = Mast_to_mir.list_max_execution_number v in
-          Mir.VariableDict.add max_exec_var acc)
-        p.idmap VariableDict.empty
+          let max_exec_var =
+            Mast_to_mir.list_max_execution_number v |> Bir.var_from_mir
+          in
+          Bir.VariableDict.add max_exec_var acc)
+        p.idmap Bir.VariableDict.empty
     in
-    VariableDict.fold
-      (fun k acc -> VariableMap.add k () acc)
-      (VariableDict.inter program_input_vars max_exec_vars)
-      VariableMap.empty
+    Bir.VariableDict.fold
+      (fun k acc -> Bir.VariableMap.add k () acc)
+      (Bir.VariableDict.inter program_input_vars max_exec_vars)
+      Bir.VariableMap.empty
   in
   Cli.debug_print "Using all %d outputs and %d inputs from m sources"
-    (VariableMap.cardinal output_vars)
-    (VariableMap.cardinal input_vars);
+    (Bir.VariableMap.cardinal output_vars)
+    (Bir.VariableMap.cardinal input_vars);
   {
     func_variable_inputs = input_vars;
-    func_constant_inputs = VariableMap.empty;
+    func_constant_inputs = Bir.VariableMap.empty;
     func_outputs = output_vars;
-    func_conds = VariableMap.empty;
+    func_conds = Bir.VariableMap.empty;
   }
 
 let read_function_from_spec (p : Bir.program) (spec_file : string) :
@@ -241,16 +257,17 @@ let read_function_from_spec (p : Bir.program) (spec_file : string) :
       Errors.raise_spanned_error "Error while parsing the m_spec file"
         (Parse_utils.mk_position (filebuf.lex_start_p, filebuf.lex_curr_p))
 
-let read_inputs_from_stdin (f : bir_function) : Mir.literal Mir.VariableMap.t =
-  if Mir.VariableMap.cardinal f.func_variable_inputs > 0 then
+let read_inputs_from_stdin (f : bir_function) : Mir.literal Bir.VariableMap.t =
+  if Bir.VariableMap.cardinal f.func_variable_inputs > 0 then
     Cli.result_print "Enter the input values of the program:";
-  Mir.VariableMap.mapi
+  Bir.VariableMap.mapi
     (fun var _ ->
+      let mvar = Bir.var_to_mir var in
       Format.printf "%s (%s) = @?"
-        (match var.Mir.Variable.alias with
+        (match mvar.Mir.Variable.alias with
         | Some s -> s
-        | None -> Pos.unmark var.Mir.Variable.name)
-        (Pos.unmark var.Mir.Variable.descr);
+        | None -> Pos.unmark mvar.Mir.Variable.name)
+        (Pos.unmark mvar.Mir.Variable.descr);
       let value = read_line () in
       try
         let value_ast =
@@ -273,11 +290,11 @@ let context_agnostic_mpp_functions (p : Bir.program) :
 let adapt_program_to_function (p : Bir.program) (f : bir_function) :
     Bir.program * int =
   let const_input_stmts =
-    Mir.VariableMap.fold
+    Bir.VariableMap.fold
       (fun var e acc ->
         Pos.same_pos_as
           (Bir.SAssign
-             ( Bir.var_from_mir var,
+             ( var,
                {
                  Mir.var_typ = None;
                  Mir.var_io = Regular;
@@ -292,7 +309,8 @@ let adapt_program_to_function (p : Bir.program) (f : bir_function) :
       (fun var def acc ->
         match def.Mir.var_definition with
         | Mir.InputVar ->
-            if Mir.VariableMap.mem var f.func_variable_inputs then acc
+            if Bir.VariableMap.mem (Bir.var_from_mir var) f.func_variable_inputs
+            then acc
             else
               let pos = Pos.no_pos in
               ( Bir.SAssign
@@ -319,7 +337,7 @@ let adapt_program_to_function (p : Bir.program) (f : bir_function) :
       p.mir_program []
   in
   let conds_stmts =
-    Mir.VariableMap.fold
+    Bir.VariableMap.fold
       (fun _ cond acc ->
         Pos.same_pos_as (Bir.SVerif cond) cond.cond_expr :: acc)
       f.func_conds []

--- a/src/mlang/backend_ir/bir_interface.mli
+++ b/src/mlang/backend_ir/bir_interface.mli
@@ -17,20 +17,20 @@
 (** Input-output management for BIR programs interpretation *)
 
 type bir_function = {
-  func_variable_inputs : unit Mir.VariableMap.t;
-  func_constant_inputs : Mir.expression Pos.marked Mir.VariableMap.t;
-  func_outputs : unit Mir.VariableMap.t;
-  func_conds : Mir.condition_data Mir.VariableMap.t;
+  func_variable_inputs : unit Bir.VariableMap.t;
+  func_constant_inputs : Bir.expression Pos.marked Bir.VariableMap.t;
+  func_outputs : unit Bir.VariableMap.t;
+  func_conds : Bir.condition_data Bir.VariableMap.t;
 }
 (** Input-output data necessary to interpret a BIR program*)
 
 val get_variables_indexes :
-  Bir.program -> bir_function -> int Mir.VariableMap.t * int
+  Bir.program -> bir_function -> int Bir.VariableMap.t * int
 
 val translate_external_conditions :
   Mir.idmap ->
   Mast.expression Pos.marked list ->
-  Mir.condition_data Mir.VariableMap.t
+  Bir.condition_data Bir.VariableMap.t
 (** [translate_external_conditions idmap conditions] translates a series of
     boolean expressions [conditions] into M verification conditions ready to be
     added to a BIR program *)
@@ -43,7 +43,7 @@ val read_function_from_spec : Bir.program -> string -> bir_function
 (** [read_function_from_spec program spec_file] reads and parses [spec_file] and
     extracts all the inputs, outputs and conditions from it. *)
 
-val read_inputs_from_stdin : bir_function -> Mir.literal Mir.VariableMap.t
+val read_inputs_from_stdin : bir_function -> Mir.literal Bir.VariableMap.t
 (** Given an input-output specification, prompts the user on [stdin] for the
     values of the inputs and returns them as a map *)
 

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -14,9 +14,9 @@
    You should have received a copy of the GNU General Public License along with
    this program. If not, see <https://www.gnu.org/licenses/>. *)
 
-open Mir
-
-type var_literal = SimpleVar of literal | TableVar of int * literal array
+type var_literal =
+  | SimpleVar of Mir.literal
+  | TableVar of int * Mir.literal array
 
 type code_location_segment =
   | InsideBlock of int
@@ -85,9 +85,9 @@ module type S = sig
     | UnknownInputVariable of string * Pos.t
     | ConditionViolated of
         Mir.Error.t
-        * Mir.expression Pos.marked
+        * Bir.expression Pos.marked
         * (Bir.variable * var_value) list
-    | NanOrInf of string * Mir.expression Pos.marked
+    | NanOrInf of string * Bir.expression Pos.marked
     | StructuredError of
         (string * (string option * Pos.t) list * (unit -> unit) option)
 
@@ -144,13 +144,13 @@ module Make (N : Bir_number.NumberInterface) = struct
     match vl with
     | SimpleVar value ->
         Format.fprintf fmt "%s (%s): %a"
-          (Pos.unmark var.Variable.name)
-          (Pos.unmark var.Variable.descr)
+          (Pos.unmark var.Mir.Variable.name)
+          (Pos.unmark var.Mir.Variable.descr)
           format_value value
     | TableVar (size, values) ->
         Format.fprintf fmt "%s (%s): Table (%d values)@\n"
-          (Pos.unmark var.Variable.name)
-          (Pos.unmark var.Variable.descr)
+          (Pos.unmark var.Mir.Variable.name)
+          (Pos.unmark var.Mir.Variable.descr)
           size;
         List.iteri
           (fun idx value ->
@@ -158,14 +158,14 @@ module Make (N : Bir_number.NumberInterface) = struct
           (Array.to_list values)
 
   type ctx = {
-    ctx_local_vars : value Pos.marked LocalVariableMap.t;
+    ctx_local_vars : value Pos.marked Mir.LocalVariableMap.t;
     ctx_vars : var_value Bir.VariableMap.t;
     ctx_generic_index : int option;
   }
 
   let empty_ctx : ctx =
     {
-      ctx_local_vars = LocalVariableMap.empty;
+      ctx_local_vars = Mir.LocalVariableMap.empty;
       ctx_vars = Bir.VariableMap.empty;
       ctx_generic_index = None;
     }
@@ -195,8 +195,8 @@ module Make (N : Bir_number.NumberInterface) = struct
     in
     l
 
-  let update_ctx_with_inputs (ctx : ctx) (inputs : literal Bir.VariableMap.t) :
-      ctx =
+  let update_ctx_with_inputs (ctx : ctx)
+      (inputs : Mir.literal Bir.VariableMap.t) : ctx =
     {
       ctx with
       ctx_vars =
@@ -219,8 +219,10 @@ module Make (N : Bir_number.NumberInterface) = struct
     | IncorrectOutputVariable of string * Pos.t
     | UnknownInputVariable of string * Pos.t
     | ConditionViolated of
-        Error.t * expression Pos.marked * (Bir.variable * var_value) list
-    | NanOrInf of string * expression Pos.marked
+        Mir.Error.t
+        * Bir.expression Pos.marked
+        * (Bir.variable * var_value) list
+    | NanOrInf of string * Bir.expression Pos.marked
     | StructuredError of
         (string * (string option * Pos.t) list * (unit -> unit) option)
 
@@ -233,11 +235,11 @@ module Make (N : Bir_number.NumberInterface) = struct
      it set the I/O flag properly for execution. Not that such a change to the
      program does not require to recompute the dependency graph and the
      execution order. *)
-  let replace_undefined_with_input_variables (p : program)
-      (input_values : VariableDict.t) : program =
+  let replace_undefined_with_input_variables (p : Mir.program)
+      (input_values : Mir.VariableDict.t) : Mir.program =
     Mir.map_vars
       (fun var def ->
-        match VariableDict.find var.id input_values with
+        match Mir.VariableDict.find var.id input_values with
         | _input -> { def with var_definition = InputVar; var_io = Input }
         | exception Not_found -> def)
       p
@@ -245,7 +247,7 @@ module Make (N : Bir_number.NumberInterface) = struct
   let print_output (f : Bir_interface.bir_function) (results : ctx) : unit =
     Bir.VariableMap.iter
       (fun var value ->
-        if Mir.VariableMap.mem (Bir.var_to_mir var) f.func_outputs then
+        if Bir.VariableMap.mem var f.func_outputs then
           Cli.result_print "%a" format_var_value_with_var (var, value))
       results.ctx_vars
 
@@ -266,24 +268,26 @@ module Make (N : Bir_number.NumberInterface) = struct
           let vars =
             List.sort
               (fun var1 var2 ->
-                compare_execution_number var1.Variable.execution_number
-                  var2.Variable.execution_number)
+                Mir.(
+                  compare_execution_number var1.Variable.execution_number
+                    var2.Variable.execution_number))
               vars
           in
           List.iter
-            (fun var ->
-              Format.printf "[%a %a] -> %a@\n"
-                Format_mir.format_execution_number_short
-                var.Variable.execution_number Pos.format_position
-                var.Variable.execution_number.pos
-                (fun fmt () ->
-                  try
-                    let rule, def = Mir.find_var_definition p var in
-                    Format.fprintf fmt "rule %d, %a"
-                      (Pos.unmark rule.rule_number)
-                      Format_mir.format_variable_def def.var_definition
-                  with Not_found -> Format.fprintf fmt "unused definition")
-                ())
+            Mir.(
+              fun var ->
+                Format.printf "[%a %a] -> %a@\n"
+                  Format_mir.format_execution_number_short
+                  var.Variable.execution_number Pos.format_position
+                  var.Variable.execution_number.pos
+                  (fun fmt () ->
+                    try
+                      let rule, def = Mir.find_var_definition p var in
+                      Format.fprintf fmt "rule %d, %a"
+                        (Pos.unmark rule.rule_number)
+                        Format_mir.format_variable_def def.var_definition
+                    with Not_found -> Format.fprintf fmt "unused definition")
+                  ())
             vars
         with Not_found -> Format.printf "Inexisting variable@\n"
       end
@@ -293,30 +297,33 @@ module Make (N : Bir_number.NumberInterface) = struct
           let vars =
             List.sort
               (fun var1 var2 ->
-                compare_execution_number var1.Variable.execution_number
-                  var2.Variable.execution_number)
+                Mir.(
+                  compare_execution_number var1.Variable.execution_number
+                    var2.Variable.execution_number))
               vars
           in
           List.iter
-            (fun var ->
-              let bvar = Bir.var_from_mir var in
-              try
-                let var_l = Bir.VariableMap.find bvar ctx.ctx_vars in
-                Format.printf "[%a %a] -> %a@\n"
-                  Format_mir.format_execution_number_short
-                  var.Variable.execution_number Pos.format_position
-                  var.Variable.execution_number.pos format_var_value_with_var
-                  (bvar, var_l)
-              with Not_found ->
-                Format.printf "[%a %a] -> not computed@\n"
-                  Format_mir.format_execution_number_short
-                  var.Variable.execution_number Pos.format_position
-                  var.Variable.execution_number.pos)
+            Mir.(
+              fun var ->
+                let bvar = Bir.var_from_mir var in
+                try
+                  let var_l = Bir.VariableMap.find bvar ctx.ctx_vars in
+                  Format.printf "[%a %a] -> %a@\n"
+                    Format_mir.format_execution_number_short
+                    var.Variable.execution_number Pos.format_position
+                    var.Variable.execution_number.pos format_var_value_with_var
+                    (bvar, var_l)
+                with Not_found ->
+                  Format.printf "[%a %a] -> not computed@\n"
+                    Format_mir.format_execution_number_short
+                    var.Variable.execution_number Pos.format_position
+                    var.Variable.execution_number.pos)
             vars
         with Not_found -> Format.printf "Inexisting variable@\n"
     done
 
-  let raise_runtime_as_structured (e : run_error) (ctx : ctx) (p : program) =
+  let raise_runtime_as_structured (e : run_error) (ctx : ctx) (p : Mir.program)
+      =
     match e with
     | ErrorValue (s, pos) ->
         Errors.raise_spanned_error
@@ -333,7 +340,7 @@ module Make (N : Bir_number.NumberInterface) = struct
     | NanOrInf (v, e) ->
         Errors.raise_spanned_error_with_continuation
           (Format.asprintf "Expression evaluated to %s: %a" v
-             Format_mir.format_expression (Pos.unmark e))
+             Format_bir.format_expression (Pos.unmark e))
           (Pos.get_position e)
           (fun _ -> repl_debugguer ctx p)
     | UnknownInputVariable (s, pos) ->
@@ -355,9 +362,9 @@ module Make (N : Bir_number.NumberInterface) = struct
               %a"
              (fun fmt err ->
                Format.fprintf fmt "Error %s [%s]"
-                 (Pos.unmark err.Error.name)
-                 (Pos.unmark @@ Error.err_descr_string err))
-             error Format_mir.format_expression (Pos.unmark condition)
+                 (Pos.unmark err.Mir.Error.name)
+                 (Pos.unmark @@ Mir.Error.err_descr_string err))
+             error Format_bir.format_expression (Pos.unmark condition)
              (Format_mast.pp_print_list_endline (fun fmt v ->
                   Format.fprintf fmt "  * %a" format_var_value_with_var v))
              bindings)
@@ -385,7 +392,7 @@ module Make (N : Bir_number.NumberInterface) = struct
     else values.(Int64.to_int (N.to_int idx))
 
   let rec evaluate_expr (ctx : ctx) (p : Mir.program)
-      (e : expression Pos.marked) : value =
+      (e : Bir.expression Pos.marked) : value =
     let out =
       try
         match Pos.unmark e with
@@ -457,30 +464,24 @@ module Make (N : Bir_number.NumberInterface) = struct
             let new_e1 = evaluate_expr ctx p e1 in
             if new_e1 = Undefined then Undefined
             else
-              match
-                Bir.VariableMap.find
-                  (Bir.var_from_mir (Pos.unmark var))
-                  ctx.ctx_vars
-              with
+              match Bir.VariableMap.find (Pos.unmark var) ctx.ctx_vars with
               | SimpleVar _ -> assert false (* should not happen *)
               | TableVar (size, values) ->
                   evaluate_array_index new_e1 size values)
         | LocalVar lvar -> (
-            try Pos.unmark (LocalVariableMap.find lvar ctx.ctx_local_vars)
+            try Pos.unmark (Mir.LocalVariableMap.find lvar ctx.ctx_local_vars)
             with Not_found -> assert false (* should not happen*))
         | Var var ->
             let r =
               try
-                match
-                  Bir.VariableMap.find (Bir.var_from_mir var) ctx.ctx_vars
-                with
+                match Bir.VariableMap.find var ctx.ctx_vars with
                 | SimpleVar l -> l
                 | TableVar _ -> assert false
                 (* should not happen *)
               with Not_found ->
                 Errors.raise_spanned_error
                   ("Var not found (should not happen): "
-                  ^ Pos.unmark var.Variable.name)
+                  ^ Pos.unmark (Bir.var_to_mir var).Mir.Variable.name)
                   (Pos.get_position e)
             in
             r
@@ -503,7 +504,7 @@ module Make (N : Bir_number.NumberInterface) = struct
                 {
                   ctx with
                   ctx_local_vars =
-                    LocalVariableMap.add lvar
+                    Mir.LocalVariableMap.add lvar
                       (Pos.same_pos_as new_e1 e1)
                       ctx.ctx_local_vars;
                 }
@@ -548,7 +549,7 @@ module Make (N : Bir_number.NumberInterface) = struct
                        ( ErrorValue
                            ( Format.asprintf
                                "evaluation of %a should be an integer, not %a"
-                               Format_mir.format_expression (Pos.unmark arg1)
+                               Format_bir.format_expression (Pos.unmark arg1)
                                format_value e,
                              Pos.get_position arg1 ),
                          ctx ))
@@ -612,9 +613,9 @@ module Make (N : Bir_number.NumberInterface) = struct
       else raise (RuntimeError (e, ctx))
     else out
 
-  let report_violatedcondition (cond : condition_data) (ctx : ctx) : 'a =
+  let report_violatedcondition (cond : Bir.condition_data) (ctx : ctx) : 'a =
     let err = fst cond.cond_error in
-    match err.Error.typ with
+    match err.Mir.Error.typ with
     | Mast.Anomaly ->
         raise
           (RuntimeError
@@ -630,19 +631,21 @@ module Make (N : Bir_number.NumberInterface) = struct
                            (fun (_, x) -> Bir.var_from_mir x)
                            (Mir.VariableDict.bindings
                               (Mir_dependency_graph.get_used_variables
-                                 cond.cond_expr))) ),
+                                 (Pos.map_under_mark
+                                    (Mir.map_expr_var Bir.var_to_mir)
+                                    cond.cond_expr)))) ),
                ctx ))
     | Mast.Discordance ->
         Cli.warning_print "Anomaly: %s"
-          (Pos.unmark (Error.err_descr_string err));
+          (Pos.unmark (Mir.Error.err_descr_string err));
         ctx
     | Mast.Information ->
         Cli.debug_print "Information: %s"
-          (Pos.unmark (Error.err_descr_string err));
+          (Pos.unmark (Mir.Error.err_descr_string err));
         ctx
 
-  let evaluate_variable (p : Bir.program) (ctx : ctx) (vdef : variable_def) :
-      var_value =
+  let evaluate_variable (p : Bir.program) (ctx : ctx)
+      (vdef : Bir.variable Mir.variable_def_) : var_value =
     match vdef with
     | Mir.SimpleVar e -> SimpleVar (evaluate_expr ctx p.mir_program e)
     | Mir.TableVar (size, es) ->
@@ -655,7 +658,7 @@ module Make (N : Bir_number.NumberInterface) = struct
                       { ctx with ctx_generic_index = Some idx }
                       p.mir_program e
                 | IndexTable es ->
-                    let e = IndexMap.find idx es in
+                    let e = Mir.IndexMap.find idx es in
                     evaluate_expr ctx p.mir_program e) )
     | Mir.InputVar -> assert false
 
@@ -728,9 +731,8 @@ type value_sort =
   | Rational
 
 let evaluate_program (bir_func : Bir_interface.bir_function) (p : Bir.program)
-    (inputs : literal VariableMap.t) (code_loc_start_value : int)
+    (inputs : Mir.literal Bir.VariableMap.t) (code_loc_start_value : int)
     (sort : value_sort) : unit -> unit =
-  let inputs = Bir.map_from_mir_map inputs in
   match sort with
   | RegularFloat ->
       let ctx =
@@ -776,8 +778,8 @@ let evaluate_program (bir_func : Bir_interface.bir_function) (p : Bir.program)
       in
       fun () -> RationalInterpreter.print_output bir_func ctx
 
-let evaluate_expr (p : Mir.program) (e : expression Pos.marked)
-    (sort : value_sort) : literal =
+let evaluate_expr (p : Mir.program) (e : Bir.expression Pos.marked)
+    (sort : value_sort) : Mir.literal =
   let f p e =
     match sort with
     | RegularFloat ->

--- a/src/mlang/backend_ir/bir_interpreter.mli
+++ b/src/mlang/backend_ir/bir_interpreter.mli
@@ -106,9 +106,9 @@ module type S = sig
     | UnknownInputVariable of string * Pos.t
     | ConditionViolated of
         Mir.Error.t
-        * Mir.expression Pos.marked
+        * Bir.expression Pos.marked
         * (Bir.variable * var_value) list
-    | NanOrInf of string * Mir.expression Pos.marked
+    | NanOrInf of string * Bir.expression Pos.marked
     | StructuredError of
         (string * (string option * Pos.t) list * (unit -> unit) option)
 
@@ -147,7 +147,7 @@ type value_sort =
 val evaluate_program :
   Bir_interface.bir_function ->
   Bir.program ->
-  Mir.literal Mir.VariableMap.t ->
+  Mir.literal Bir.VariableMap.t ->
   int ->
   value_sort ->
   unit ->
@@ -155,5 +155,5 @@ val evaluate_program :
 (** Main interpreter function *)
 
 val evaluate_expr :
-  Mir.program -> Mir.expression Pos.marked -> value_sort -> Mir.literal
+  Mir.program -> Bir.expression Pos.marked -> value_sort -> Mir.literal
 (** Interprets only an expression *)

--- a/src/mlang/backend_ir/bir_interpreter.mli
+++ b/src/mlang/backend_ir/bir_interpreter.mli
@@ -44,7 +44,7 @@ type code_location = code_location_segment list
 val format_code_location : Format.formatter -> code_location -> unit
 
 val assign_hook :
-  (Mir.Variable.t -> (unit -> var_literal) -> code_location -> unit) ref
+  (Bir.variable -> (unit -> var_literal) -> code_location -> unit) ref
 (** The instrumentation of the interpreter is done through this reference. The
     function that you assign to this reference will be called each time a
     variable assignment is executed *)
@@ -78,11 +78,11 @@ module type S = sig
   val format_var_value : Format.formatter -> var_value -> unit
 
   val format_var_value_with_var :
-    Format.formatter -> Mir.Variable.t * var_value -> unit
+    Format.formatter -> Bir.variable * var_value -> unit
 
   type ctx = {
     ctx_local_vars : value Pos.marked Mir.LocalVariableMap.t;
-    ctx_vars : var_value Mir.VariableMap.t;
+    ctx_vars : var_value Bir.VariableMap.t;
     ctx_generic_index : int option;
   }
   (** Interpretation context *)
@@ -107,7 +107,7 @@ module type S = sig
     | ConditionViolated of
         Mir.Error.t
         * Mir.expression Pos.marked
-        * (Mir.Variable.t * var_value) list
+        * (Bir.variable * var_value) list
     | NanOrInf of string * Mir.expression Pos.marked
     | StructuredError of
         (string * (string option * Pos.t) list * (unit -> unit) option)

--- a/src/mlang/backend_ir/format_bir.ml
+++ b/src/mlang/backend_ir/format_bir.ml
@@ -20,7 +20,7 @@ let rec format_stmt fmt (stmt : stmt) =
   match Pos.unmark stmt with
   | SAssign (v, vdata) ->
       Format.fprintf fmt "%s = %a"
-        (Pos.unmark v.Mir.Variable.name)
+        (Pos.unmark (var_to_mir v).Mir.Variable.name)
         Format_mir.format_variable_def vdata.var_definition
   | SConditional (cond, t, []) ->
       Format.fprintf fmt "if(%a):@\n@[<h 2>  %a@]@\n"

--- a/src/mlang/backend_ir/format_bir.ml
+++ b/src/mlang/backend_ir/format_bir.ml
@@ -16,26 +16,34 @@
 
 open Bir
 
+let format_expression fmt (e : expression) =
+  Format_mir.format_expression fmt (Mir.map_expr_var Bir.var_to_mir e)
+
+let format_variable_def fmt (vdef : variable_def) =
+  Format_mir.format_variable_def fmt (Mir.map_var_def_var Bir.var_to_mir vdef)
+
 let rec format_stmt fmt (stmt : stmt) =
   match Pos.unmark stmt with
   | SAssign (v, vdata) ->
       Format.fprintf fmt "%s = %a"
         (Pos.unmark (var_to_mir v).Mir.Variable.name)
-        Format_mir.format_variable_def vdata.var_definition
+        format_variable_def vdata.var_definition
   | SConditional (cond, t, []) ->
-      Format.fprintf fmt "if(%a):@\n@[<h 2>  %a@]@\n"
-        Format_mir.format_expression cond format_stmts t
+      Format.fprintf fmt "if(%a):@\n@[<h 2>  %a@]@\n" format_expression cond
+        format_stmts t
   | SConditional (cond, t, f) ->
       Format.fprintf fmt "if(%a):@\n@[<h 2>  %a@]else:@\n@[<h 2>  %a@]@\n"
-        Format_mir.format_expression cond format_stmts t format_stmts f
+        format_expression cond format_stmts t format_stmts f
   | SVerif cond_data ->
-      Format.fprintf fmt "assert (%a) or raise %a%a"
-        Format_mir.format_expression
+      let cond_error_opt_var =
+        Option.map var_to_mir (snd cond_data.cond_error)
+      in
+      Format.fprintf fmt "assert (%a) or raise %a%a" format_expression
         (Pos.unmark cond_data.cond_expr)
         Format_mir.format_error (fst cond_data.cond_error)
         (Format.pp_print_option (fun fmt v ->
              Format.fprintf fmt " (%s)" (Pos.unmark v.Mir.Variable.name)))
-        (snd cond_data.cond_error)
+        cond_error_opt_var
   | SRuleCall r -> Format.fprintf fmt "call_rule(%d)@\n" r
   | SFunctionCall (func, args) ->
       Format.fprintf fmt "call_function: %s with args %a@," func

--- a/src/mlang/backend_ir/format_bir.mli
+++ b/src/mlang/backend_ir/format_bir.mli
@@ -14,6 +14,10 @@
    You should have received a copy of the GNU General Public License along with
    this program. If not, see <https://www.gnu.org/licenses/>. *)
 
+val format_expression : Format.formatter -> Bir.expression -> unit
+
+val format_variable_def : Format.formatter -> Bir.variable_def -> unit
+
 val format_stmt : Format.formatter -> Bir.stmt -> unit
 
 val format_stmts : Format.formatter -> Bir.stmt list -> unit

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -84,6 +84,9 @@ type variable = {
       (** Description taken from the variable declaration *)
   attributes :
     (Mast.input_variable_attribute Pos.marked * Mast.literal Pos.marked) list;
+  origin : variable option;
+      (** If the variable is an SSA duplication, refers to the original
+          (declared) variable *)
   is_income : bool;
   is_table : int option;
 }
@@ -102,6 +105,9 @@ module Variable = struct
         (** Description taken from the variable declaration *)
     attributes :
       (Mast.input_variable_attribute Pos.marked * Mast.literal Pos.marked) list;
+    origin : variable option;
+        (** If the variable is an SSA duplication, refers to the original
+            (declared) variable *)
     is_income : bool;
     is_table : int option;
   }
@@ -117,7 +123,8 @@ module Variable = struct
       (descr : string Pos.marked) (execution_number : execution_number)
       ~(attributes :
          (Mast.input_variable_attribute Pos.marked * Mast.literal Pos.marked)
-         list) ~(is_income : bool) ~(is_table : int option) : t =
+         list) ~(origin : t option) ~(is_income : bool) ~(is_table : int option)
+      : t =
     {
       name;
       id = fresh_id ();
@@ -125,6 +132,7 @@ module Variable = struct
       alias;
       execution_number;
       attributes;
+      origin;
       is_income;
       is_table;
     }

--- a/src/mlang/m_ir/mir.mli
+++ b/src/mlang/m_ir/mir.mli
@@ -76,26 +76,33 @@ type func =
     Because translating to MIR requires a lot of unrolling and expansion, we
     introduce a [LocalLet] construct to avoid code duplication. *)
 
-type expression =
-  | Unop of (Mast.unop[@opaque]) * expression Pos.marked
+type 'variable expression_ =
+  | Unop of (Mast.unop[@opaque]) * 'variable expression_ Pos.marked
   | Comparison of
       (Mast.comp_op[@opaque]) Pos.marked
-      * expression Pos.marked
-      * expression Pos.marked
+      * 'variable expression_ Pos.marked
+      * 'variable expression_ Pos.marked
   | Binop of
       (Mast.binop[@opaque]) Pos.marked
-      * expression Pos.marked
-      * expression Pos.marked
-  | Index of variable Pos.marked * expression Pos.marked
+      * 'variable expression_ Pos.marked
+      * 'variable expression_ Pos.marked
+  | Index of 'variable Pos.marked * 'variable expression_ Pos.marked
   | Conditional of
-      expression Pos.marked * expression Pos.marked * expression Pos.marked
-  | FunctionCall of (func[@opaque]) * expression Pos.marked list
+      'variable expression_ Pos.marked
+      * 'variable expression_ Pos.marked
+      * 'variable expression_ Pos.marked
+  | FunctionCall of (func[@opaque]) * 'variable expression_ Pos.marked list
   | Literal of (literal[@opaque])
-  | Var of variable
+  | Var of 'variable
   | LocalVar of local_variable
   | GenericTableIndex
   | Error
-  | LocalLet of local_variable * expression Pos.marked * expression Pos.marked
+  | LocalLet of
+      local_variable
+      * 'variable expression_ Pos.marked
+      * 'variable expression_ Pos.marked
+
+type expression = variable expression_
 
 (** MIR programs are just mapping from variables to their definitions, and make
     a massive use of [VariableMap]. *)
@@ -130,24 +137,29 @@ module IndexMap : sig
     (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
 end
 
-type index_def =
-  | IndexTable of (expression Pos.marked IndexMap.t[@name "index_map"])
-  | IndexGeneric of expression Pos.marked
+type 'variable index_def =
+  | IndexTable of
+      ('variable expression_ Pos.marked IndexMap.t[@name "index_map"])
+  | IndexGeneric of 'variable expression_ Pos.marked
 
-type variable_def =
-  | SimpleVar of expression Pos.marked
-  | TableVar of int * index_def
+type 'variable variable_def_ =
+  | SimpleVar of 'variable expression_ Pos.marked
+  | TableVar of int * 'variable index_def
   | InputVar
+
+type variable_def = variable variable_def_
 
 type io = Input | Output | Regular
 
-type variable_data = {
-  var_definition : variable_def;
+type 'variable variable_data_ = {
+  var_definition : 'variable variable_def_;
   var_typ : typ option;
       (** The typing info here comes from the variable declaration in the source
           program *)
   var_io : io;
 }
+
+type variable_data = variable variable_data_
 
 type rule_tag =
   | Primitif
@@ -205,10 +217,12 @@ type error = {
   typ : Mast.error_typ;
 }
 
-type condition_data = {
-  cond_expr : expression Pos.marked;
-  cond_error : error * variable option;
+type 'variable condition_data_ = {
+  cond_expr : 'variable expression_ Pos.marked;
+  cond_error : error * 'variable option;
 }
+
+type condition_data = variable condition_data_
 
 type idmap = variable list Pos.VarNameToID.t
 (** We translate string variables into first-class unique {!type: Mir.variable},
@@ -335,6 +349,12 @@ val true_literal : literal
 val same_execution_number : execution_number -> execution_number -> bool
 
 val find_var_name_by_alias : program -> string Pos.marked -> string
+
+val map_expr_var : ('v -> 'v2) -> 'v expression_ -> 'v2 expression_
+
+val map_var_def_var : ('v -> 'v2) -> 'v variable_def_ -> 'v2 variable_def_
+
+val map_cond_data_var : ('v -> 'v2) -> 'v condition_data_ -> 'v2 condition_data_
 
 val fold_vars : (variable -> variable_data -> 'a -> 'a) -> program -> 'a -> 'a
 

--- a/src/mlang/m_ir/mir.mli
+++ b/src/mlang/m_ir/mir.mli
@@ -39,6 +39,9 @@ type variable = {
       (** Description taken from the variable declaration *)
   attributes :
     (Mast.input_variable_attribute Pos.marked * Mast.literal Pos.marked) list;
+  origin : variable option;
+      (** If the variable is an SSA duplication, refers to the original
+          (declared) variable *)
   is_income : bool;
   is_table : int option;
 }
@@ -241,6 +244,9 @@ module Variable : sig
         (** Description taken from the variable declaration *)
     attributes :
       (Mast.input_variable_attribute Pos.marked * Mast.literal Pos.marked) list;
+    origin : variable option;
+        (** If the variable is an SSA duplication, refers to the original
+            (declared) variable *)
     is_income : bool;
     is_table : int option;
   }
@@ -253,6 +259,7 @@ module Variable : sig
     string Pos.marked ->
     execution_number ->
     attributes:(string Pos.marked * Mast.literal Pos.marked) list ->
+    origin:variable option ->
     is_income:bool ->
     is_table:rule_id option ->
     variable

--- a/src/mlang/m_ir/mir_typechecker.ml
+++ b/src/mlang/m_ir/mir_typechecker.ml
@@ -231,8 +231,8 @@ let typecheck (p : Mir_interface.full_program) : Mir_interface.full_program =
   (* the typechecking modifications do not change the dependency graph *)
   { p with program }
 
-let rec expand_functions_expr (e : expression Pos.marked) :
-    expression Pos.marked =
+let rec expand_functions_expr (e : 'var expression_ Pos.marked) :
+    'var expression_ Pos.marked =
   match Pos.unmark e with
   | Comparison (op, e1, e2) ->
       let new_e1 = expand_functions_expr e1 in

--- a/src/mlang/m_ir/mir_typechecker.mli
+++ b/src/mlang/m_ir/mir_typechecker.mli
@@ -22,7 +22,7 @@
 val typecheck : Mir_interface.full_program -> Mir_interface.full_program
 
 val expand_functions_expr :
-  Mir.expression Pos.marked -> Mir.expression Pos.marked
+  'var Mir.expression_ Pos.marked -> 'var Mir.expression_ Pos.marked
 (** Most functions are just syntactic sugar for operations expressible with the
     rest of the language, so we expand these. *)
 

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -150,7 +150,9 @@ let translate_m_code (m_program : Mir_interface.full_program)
         | InputVar -> None
         | _ ->
             (* variables used in the context should not be reassigned *)
-            Some (Bir.SAssign (var, vdef), var.Mir.Variable.execution_number.pos)
+            Some
+              ( Bir.SAssign (Bir.var_from_mir var, vdef),
+                var.Mir.Variable.execution_number.pos )
       with Not_found -> None)
     vars
 
@@ -258,7 +260,7 @@ and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
         [
           Pos.same_pos_as
             (Bir.SAssign
-               ( new_l,
+               ( Bir.var_from_mir new_l,
                  {
                    var_definition =
                      SimpleVar (translate_mpp_expr m_program ctx expr, pos);
@@ -276,7 +278,7 @@ and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
         [
           Pos.same_pos_as
             (Bir.SAssign
-               ( var,
+               ( Bir.var_from_mir var,
                  {
                    var_definition =
                      SimpleVar (translate_mpp_expr m_program ctx expr, pos);
@@ -302,7 +304,7 @@ and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
         [
           Pos.same_pos_as
             (Bir.SAssign
-               ( var,
+               ( Bir.var_from_mir var,
                  {
                    var_definition = SimpleVar (Mir.Literal Undefined, pos);
                    var_typ = None;
@@ -318,7 +320,7 @@ and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
         [
           Pos.same_pos_as
             (Bir.SAssign
-               ( var,
+               ( Bir.var_from_mir var,
                  {
                    var_definition = SimpleVar (Mir.Literal Undefined, pos);
                    var_typ = None;

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -21,7 +21,7 @@ module StringMap = Map.Make (struct
 end)
 
 type translation_ctx = {
-  new_variables : Mir.Variable.t StringMap.t;
+  new_variables : Bir.variable StringMap.t;
   variables_used_as_inputs : Mir.VariableDict.t;
 }
 
@@ -36,7 +36,7 @@ let ctx_join ctx1 ctx2 =
     new_variables =
       StringMap.union
         (fun _ v1 v2 ->
-          assert (Mir.Variable.compare v1 v2 = 0);
+          assert (Bir.compare_variable v1 v2 = 0);
           Some v2)
         ctx1.new_variables ctx2.new_variables;
     variables_used_as_inputs =
@@ -68,14 +68,15 @@ let rec list_map_opt (f : 'a -> 'b option) (l : 'a list) : 'b list =
 let generate_input_condition (crit : Mir.Variable.t -> bool)
     (p : Mir_interface.full_program) (pos : Pos.t) =
   let variables_to_check =
-    Mir.VariableDict.filter (fun _ var -> crit var) p.program.program_vars
+    Bir.dict_from_mir_dict
+    @@ Mir.VariableDict.filter (fun _ var -> crit var) p.program.program_vars
   in
   let mk_call_present x =
     (Mir.FunctionCall (PresentFunc, [ (Mir.Var x, pos) ]), pos)
   in
   let mk_or e1 e2 = (Mir.Binop ((Or, pos), e1, e2), pos) in
   let mk_false = (Mir.Literal (Float 0.), pos) in
-  Mir.VariableDict.fold
+  Bir.VariableDict.fold
     (fun var acc -> mk_or (mk_call_present var) acc)
     variables_to_check mk_false
 
@@ -86,15 +87,15 @@ let var_is_ (attr : string) (v : Mir.Variable.t) : bool =
     v.Mir.Variable.attributes
 
 let cond_DepositDefinedVariables :
-    Mir_interface.full_program -> Pos.t -> Mir.expression Pos.marked =
+    Mir_interface.full_program -> Pos.t -> Bir.expression Pos.marked =
   generate_input_condition (var_is_ "acompte")
 
 let cond_TaxbenefitDefinedVariables :
-    Mir_interface.full_program -> Pos.t -> Mir.expression Pos.marked =
+    Mir_interface.full_program -> Pos.t -> Bir.expression Pos.marked =
   generate_input_condition (var_is_ "avfisc")
 
 let cond_TaxbenefitCeiledVariables (p : Mir_interface.full_program)
-    (pos : Pos.t) : Mir.expression Pos.marked =
+    (pos : Pos.t) : Bir.expression Pos.marked =
   (* commented aliases do not exist in the 2018 version *)
   (* double-commented aliases do not exist in the 2019 version *)
   (* triple-commented aliases do not exist in the 2020 version *)
@@ -148,8 +149,41 @@ let translate_m_code (m_program : Mir_interface.full_program)
         let var = Mir.VariableDict.find vid m_program.program.program_vars in
         match vdef.var_definition with
         | InputVar -> None
-        | _ ->
+        | TableVar (i, idx_def) ->
             (* variables used in the context should not be reassigned *)
+            let idx_def =
+              match idx_def with
+              | IndexTable es ->
+                  Mir.IndexTable
+                    (Mir.IndexMap.map
+                       (Pos.map_under_mark (Mir.map_expr_var Bir.var_from_mir))
+                       es)
+              | IndexGeneric e ->
+                  Mir.IndexGeneric
+                    (Pos.map_under_mark (Mir.map_expr_var Bir.var_from_mir) e)
+            in
+            let vdef =
+              Mir.
+                {
+                  var_definition = Mir.TableVar (i, idx_def);
+                  var_typ = vdef.var_typ;
+                  var_io = vdef.var_io;
+                }
+            in
+            Some
+              ( Bir.SAssign (Bir.var_from_mir var, vdef),
+                var.Mir.Variable.execution_number.pos )
+        | SimpleVar e ->
+            let vdef =
+              Mir.
+                {
+                  var_definition =
+                    Mir.SimpleVar
+                      (Pos.map_under_mark (Mir.map_expr_var Bir.var_from_mir) e);
+                  var_typ = vdef.var_typ;
+                  var_io = vdef.var_io;
+                }
+            in
             Some
               ( Bir.SAssign (Bir.var_from_mir var, vdef),
                 var.Mir.Variable.execution_number.pos )
@@ -185,11 +219,11 @@ let rec translate_mpp_function (mpp_program : Mpp_ir.mpp_compute list)
   translate_mpp_stmts mpp_program m_program args ctx compute_decl.Mpp_ir.body
 
 and translate_mpp_expr (p : Mir_interface.full_program) (ctx : translation_ctx)
-    (expr : Mpp_ir.mpp_expr_kind Pos.marked) : Mir.expression =
+    (expr : Mpp_ir.mpp_expr_kind Pos.marked) : Bir.expression =
   let pos = Pos.get_position expr in
   match Pos.unmark expr with
   | Mpp_ir.Constant i -> Mir.Literal (Float (float_of_int i))
-  | Variable (Mbased (var, _)) -> Var var
+  | Variable (Mbased (var, _)) -> Var (Bir.var_from_mir var)
   | Variable (Local l) -> (
       try Var (StringMap.find l ctx.new_variables)
       with Not_found ->
@@ -246,6 +280,7 @@ and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
                 None ("", pos)
                 (Mast_to_mir.dummy_exec_number pos)
                 ~attributes:[] ~origin:None ~is_income:false ~is_table:None
+              |> Bir.var_from_mir
             in
             let ctx =
               {
@@ -260,7 +295,7 @@ and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
         [
           Pos.same_pos_as
             (Bir.SAssign
-               ( Bir.var_from_mir new_l,
+               ( new_l,
                  {
                    var_definition =
                      SimpleVar (translate_mpp_expr m_program ctx expr, pos);
@@ -320,7 +355,7 @@ and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
         [
           Pos.same_pos_as
             (Bir.SAssign
-               ( Bir.var_from_mir var,
+               ( var,
                  {
                    var_definition = SimpleVar (Mir.Literal Undefined, pos);
                    var_typ = None;
@@ -405,6 +440,7 @@ let generate_verif_conds (conds : Mir.condition_data Mir.VariableMap.t) :
     Bir.stmt list =
   Mir.VariableMap.fold
     (fun _var data acc ->
+      let data = Mir.map_cond_data_var Bir.var_from_mir data in
       (Bir.SVerif data, Pos.get_position data.cond_expr) :: acc)
     conds []
 
@@ -456,7 +492,7 @@ let create_combined_program (m_program : Mir_interface.full_program)
       main_function = mpp_function_to_extract;
       idmap = m_program.program.program_idmap;
       mir_program = m_program.program;
-      outputs = Mir.VariableMap.empty;
+      outputs = Bir.VariableMap.empty;
     }
   with Bir_interpreter.RegularFloatInterpreter.RuntimeError (r, ctx) ->
     Bir_interpreter.RegularFloatInterpreter.raise_runtime_as_structured r ctx

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -243,7 +243,7 @@ and translate_mpp_stmt (mpp_program : Mpp_ir.mpp_compute list)
                 ("mpp_" ^ l, pos)
                 None ("", pos)
                 (Mast_to_mir.dummy_exec_number pos)
-                ~attributes:[] ~is_income:false ~is_table:None
+                ~attributes:[] ~origin:None ~is_income:false ~is_table:None
             in
             let ctx =
               {

--- a/src/mlang/optimizing_ir/format_oir.ml
+++ b/src/mlang/optimizing_ir/format_oir.ml
@@ -21,18 +21,21 @@ let rec format_stmt fmt (stmt : stmt) =
   | SAssign (v, vdata) ->
       Format.fprintf fmt "%s = %a@,"
         (Pos.unmark (Bir.var_to_mir v).Mir.Variable.name)
-        Format_mir.format_variable_def vdata.var_definition
+        Format_bir.format_variable_def vdata.var_definition
   | SConditional (cond, b1, b2, _) ->
       Format.fprintf fmt "if(%a) then goto %d else goto %d@,"
-        Format_mir.format_expression cond b1 b2
+        Format_bir.format_expression cond b1 b2
   | SVerif cond_data ->
+      let cond_error_opt_var =
+        Option.map Bir.var_to_mir (snd cond_data.cond_error)
+      in
       Format.fprintf fmt "assert (%a) or raise %a%a@,"
-        Format_mir.format_expression
+        Format_bir.format_expression
         (Pos.unmark cond_data.cond_expr)
         Format_mir.format_error (fst cond_data.cond_error)
         (Format.pp_print_option (fun fmt v ->
              Format.fprintf fmt " (%s)" (Pos.unmark v.Mir.Variable.name)))
-        (snd cond_data.cond_error)
+        cond_error_opt_var
   | SGoto b -> Format.fprintf fmt "goto %d@," b
   | SRuleCall (_rid, name, stmts) ->
       Format.fprintf fmt "call(%s)@[<v 3>{@,%a@]}@," name format_stmts stmts

--- a/src/mlang/optimizing_ir/format_oir.ml
+++ b/src/mlang/optimizing_ir/format_oir.ml
@@ -20,7 +20,7 @@ let rec format_stmt fmt (stmt : stmt) =
   match Pos.unmark stmt with
   | SAssign (v, vdata) ->
       Format.fprintf fmt "%s = %a@,"
-        (Pos.unmark v.Mir.Variable.name)
+        (Pos.unmark (Bir.var_to_mir v).Mir.Variable.name)
         Format_mir.format_variable_def vdata.var_definition
   | SConditional (cond, b1, b2, _) ->
       Format.fprintf fmt "if(%a) then goto %d else goto %d@,"

--- a/src/mlang/optimizing_ir/oir.ml
+++ b/src/mlang/optimizing_ir/oir.ml
@@ -21,7 +21,7 @@ module BlockMap = Map.Make (Int)
 type stmt = stmt_kind Pos.marked
 
 and stmt_kind =
-  | SAssign of Mir.Variable.t * Mir.variable_data
+  | SAssign of Bir.variable * Mir.variable_data
   | SConditional of Mir.expression * block_id * block_id * block_id
       (** The first two block ids are the true and false branch, the third is
           the join point after *)

--- a/src/mlang/optimizing_ir/oir.ml
+++ b/src/mlang/optimizing_ir/oir.ml
@@ -21,11 +21,11 @@ module BlockMap = Map.Make (Int)
 type stmt = stmt_kind Pos.marked
 
 and stmt_kind =
-  | SAssign of Bir.variable * Mir.variable_data
-  | SConditional of Mir.expression * block_id * block_id * block_id
+  | SAssign of Bir.variable * Bir.variable_data
+  | SConditional of Bir.expression * block_id * block_id * block_id
       (** The first two block ids are the true and false branch, the third is
           the join point after *)
-  | SVerif of Mir.condition_data
+  | SVerif of Bir.condition_data
   | SGoto of block_id
   | SRuleCall of Bir.rule_id * string * stmt list
   | SFunctionCall of Bir.function_name * Mir.variable list
@@ -38,7 +38,7 @@ type program = {
   exit_block : block_id;
   idmap : Mir.idmap;
   mir_program : Mir.program;
-  outputs : unit Mir.VariableMap.t;
+  outputs : unit Bir.VariableMap.t;
   main_function : Bir.function_name;
 }
 

--- a/src/mlang/optimizing_ir/oir.mli
+++ b/src/mlang/optimizing_ir/oir.mli
@@ -21,7 +21,7 @@ module BlockMap : Map.S with type key = block_id
 type stmt = stmt_kind Pos.marked
 
 and stmt_kind =
-  | SAssign of Mir.Variable.t * Mir.variable_data
+  | SAssign of Bir.variable * Mir.variable_data
   | SConditional of Mir.expression * block_id * block_id * block_id
   | SVerif of Mir.condition_data
   | SGoto of block_id

--- a/src/mlang/optimizing_ir/oir.mli
+++ b/src/mlang/optimizing_ir/oir.mli
@@ -21,9 +21,9 @@ module BlockMap : Map.S with type key = block_id
 type stmt = stmt_kind Pos.marked
 
 and stmt_kind =
-  | SAssign of Bir.variable * Mir.variable_data
-  | SConditional of Mir.expression * block_id * block_id * block_id
-  | SVerif of Mir.condition_data
+  | SAssign of Bir.variable * Bir.variable_data
+  | SConditional of Bir.expression * block_id * block_id * block_id
+  | SVerif of Bir.condition_data
   | SGoto of block_id
   | SRuleCall of Bir.rule_id * string * stmt list
   | SFunctionCall of Bir.function_name * Mir.variable list
@@ -36,7 +36,7 @@ type program = {
   exit_block : block_id;
   idmap : Mir.idmap;
   mir_program : Mir.program;
-  outputs : unit Mir.VariableMap.t;
+  outputs : unit Bir.VariableMap.t;
   main_function : Bir.function_name;
 }
 

--- a/src/mlang/optimizing_ir/partial_evaluation.ml
+++ b/src/mlang/optimizing_ir/partial_evaluation.ml
@@ -214,6 +214,28 @@ let get_closest_dominating_def (var : Bir.variable) (ctx : partial_ev_ctx) :
                         | UnknownFloat, UnknownFloat ->
                             Some (SimpleVar UnknownFloat)
                         | _ -> None)
+                    | Some (TableVar (ai, aa)), Some (TableVar (di, da)) -> (
+                        assert (ai = di);
+                        let partials =
+                          List.fold_left2
+                            (fun acc a d ->
+                              match acc with
+                              | None -> None
+                              | Some acc -> (
+                                  match (a, d) with
+                                  | ( PartialLiteral (Float _),
+                                      PartialLiteral (Float _) )
+                                  | PartialLiteral (Float _), UnknownFloat
+                                  | UnknownFloat, PartialLiteral (Float _)
+                                  | UnknownFloat, UnknownFloat ->
+                                      Some (UnknownFloat :: acc)
+                                  | _ -> None))
+                            (Some []) (Array.to_list aa) (Array.to_list da)
+                        in
+                        match partials with
+                        | None -> None
+                        | Some ps ->
+                            Some (TableVar (ai, Array.of_list (List.rev ps))))
                     | Some (TableVar _), _ | _, Some (TableVar _) ->
                         assert false)
                   (Some def) defs


### PR DESCRIPTION
This ought to straighten a bit the re-affectations semantics of Bir programs.

It needs more work to get rid of bugs and performance issues (and even more to smooth the whole thing up), drafting for now. 