### PR TITLE
Fix generic variables name computation

### DIFF
--- a/src/mlang/m_frontend/format_mast.ml
+++ b/src/mlang/m_frontend/format_mast.ml
@@ -85,9 +85,12 @@ let format_set_value fmt (sv : set_value) =
 
 let format_set_value_loop fmt (sv : set_value_loop) =
   match sv with
-  | VarParam v -> Format.fprintf fmt "%s" (Pos.unmark v)
-  | IntervalLoop (i1, i2) ->
+  | Single l -> Format.fprintf fmt "%a" format_literal (Pos.unmark l)
+  | Range (i1, i2) ->
       Format.fprintf fmt "%a..%a" format_literal (Pos.unmark i1) format_literal
+        (Pos.unmark i2)
+  | NumRange (i1, i2) ->
+      Format.fprintf fmt "%a-%a" format_literal (Pos.unmark i1) format_literal
         (Pos.unmark i2)
 
 let format_comp_op fmt (op : comp_op) =

--- a/src/mlang/m_frontend/mast.ml
+++ b/src/mlang/m_frontend/mast.ml
@@ -98,8 +98,9 @@ type set_value =
 
 (** Values that can be substituted for loop parameters *)
 type set_value_loop =
-  | VarParam of variable_name Pos.marked
-  | IntervalLoop of literal Pos.marked * literal Pos.marked
+  | Single of literal Pos.marked
+  | Range of literal Pos.marked * literal Pos.marked
+  | NumRange of literal Pos.marked * literal Pos.marked
 
 type loop_variable = char Pos.marked * set_value_loop list
 (** A loop variable is the character that should be substituted in variable

--- a/src/mlang/m_frontend/mast_to_mir.mli
+++ b/src/mlang/m_frontend/mast_to_mir.mli
@@ -32,7 +32,7 @@ module ConstMap : Map.S with type key = Mast.variable_name
 module ParamsMap : Map.S with type key = Char.t
 (** Map whose keys are loop parameters *)
 
-type loop_context = loop_param_value ParamsMap.t
+type loop_context = (loop_param_value * int) ParamsMap.t
 (** This is the context when iterating a loop : for each loop parameter, we have
     access to the current value of this loop parameter in this iteration. *)
 

--- a/src/mlang/m_frontend/mparser.mly
+++ b/src/mlang/m_frontend/mparser.mly
@@ -25,6 +25,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  | CompSubTyp of computed_typ Pos.marked
  | Attr of input_variable_attribute Pos.marked * literal Pos.marked
 
+ let parse_to_literal (v: parse_val) : literal = match v with
+ | ParseVar v -> Variable v
+ | ParseInt v -> Float (float_of_int v)
+
  (** Module generated automaticcaly by Menhir, the parser generator *)
 %}
 
@@ -350,21 +354,21 @@ loop_variables_range:
 
  enumeration_loop_item:
  | bounds = interval_loop { bounds  }
- | s = SYMBOL { VarParam (parse_variable_name $sloc s, mk_position $sloc) }
+ | s = SYMBOL { Single (parse_to_literal (parse_variable_or_int $sloc s),
+                        mk_position $sloc) }
 
 range_or_minus:
-| RANGE {}
-| MINUS {}
+| RANGE { `Range }
+| MINUS { `Minus }
 
 interval_loop:
- | i1 = SYMBOL range_or_minus i2 = SYMBOL
-  {
-      let parse_to_literal (v: parse_val) : literal = match v with
-      | ParseVar v -> Variable v
-      | ParseInt v -> Float (float_of_int v)
-      in
-      IntervalLoop ((parse_to_literal (parse_variable_or_int $sloc i1), mk_position $sloc),
-    (parse_to_literal (parse_variable_or_int $sloc i2), mk_position $sloc)) }
+| i1 = SYMBOL rm = range_or_minus i2 = SYMBOL {
+    let l1 = parse_to_literal (parse_variable_or_int $sloc i1), mk_position $sloc in
+    let l2 = parse_to_literal (parse_variable_or_int $sloc i2), mk_position $sloc in
+    match rm with
+    | `Range -> Range (l1, l2)
+    | `Minus -> NumRange (l1, l2)
+  }
 
 enumeration:
 | i = enumeration_item { [i] }


### PR DESCRIPTION
This makes generic names computation behave as in the original compiler (fixes potential bugs).

Generic names may be specified using ranges, with the following syntax :
x..y can be used both for integer ranges or **single** character ranges (integers and characters can not be mixed in a range)
x-y is a range whose lower bound is an integer and its upper bound is a **constant**

For instance, one can write such construct :
```
V=somme(i=0..2,4-T,X..Z:Ni)
```

Here, T must be a constant, and X, Y, Z are substituted characters (it does not matter if they also exist as variables or constants).
If T = 6, then we get: N0, N1, N2, N4, N5, N6, NX, NY and NZ.

It is also possible to specify individual substitution strings along with integer ranges.

In any case, the length of the string representation of integers and of the substituted characters/strings must be equal. If necessary, integers are zero-padded on the left so that all lengths become equal. If only integers are present, the reference length is the length of the largest integer's representation.

So, if we write :
```
VARTMP1=somme(i=1..3,XX,YY:NBi);
```

Then we get : NB01, NB02, NB03, NBXX, NBYY

However, if we remove XX and YY, then we get : NB1, NB2, NB3
