### PR TITLE
Set Cmdliner version to 1.0.4

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -33,6 +33,8 @@
    (and :build))
   (ANSITerminal
    (= 0.8.2))
+  (cmdliner
+    (= 1.0.4))
   (re
    (= 1.9.0))
   (ocamlgraph

--- a/mlang.opam
+++ b/mlang.opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml" {>= "4.11.2"}
   "dune" {build}
   "ANSITerminal" {= "0.8.2"}
+  "cmdliner" {= "1.0.4"}
   "re" {= "1.9.0"}
   "ocamlgraph" {= "1.8.8"}
   "odoc" {= "1.5.3"}


### PR DESCRIPTION
Following an update to Cmdliner v1.1.0, deprecation warnings now break
the macOS CI build.

Also Cmdliner is a direct dependancy of the project and should therefore be
explicitly mentionned in dune-project and mlang.opam files.