### PR TITLE
Update Cmdliner to v1.1.0

### DIFF
--- a/.github/workflows/check_correctness.yml
+++ b/.github/workflows/check_correctness.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt install m4 perl python3 clang git build-essential lzip libgmp-dev libmpfr-dev
+          opam update
           make deps-without-ocaml
 
       - name: Build Mlang

--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,7 @@
   (ANSITerminal
    (= 0.8.2))
   (cmdliner
-    (= 1.0.4))
+    (= 1.1.0))
   (re
    (= 1.9.0))
   (ocamlgraph

--- a/mlang.opam
+++ b/mlang.opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.11.2"}
   "dune" {build}
   "ANSITerminal" {= "0.8.2"}
-  "cmdliner" {= "1.0.4"}
+  "cmdliner" {= "1.1.0"}
   "re" {= "1.9.0"}
   "ocamlgraph" {= "1.8.8"}
   "odoc" {= "1.5.3"}

--- a/src/mlang/driver.ml
+++ b/src/mlang/driver.ml
@@ -234,4 +234,4 @@ let driver (files : string list) (debug : bool) (var_info_debug : string list)
     exit (-1)
 
 let main () =
-  Cmdliner.Term.exit @@ Cmdliner.Term.eval (Cli.mlang_t driver, Cli.info)
+  exit @@ Cmdliner.Cmd.eval @@ Cmdliner.Cmd.v Cli.info (Cli.mlang_t driver)

--- a/src/mlang/utils/cli.ml
+++ b/src/mlang/utils/cli.ml
@@ -208,13 +208,13 @@ let info =
     ]
   in
   let exits =
-    Term.default_exits
+    Cmd.Exit.defaults
     @ [
-        Term.exit_info ~doc:"on M parsing error." 1;
-        Term.exit_info ~doc:"on M typechecking error." 2;
+        Cmd.Exit.info ~doc:"on M parsing error." 1;
+        Cmd.Exit.info ~doc:"on M typechecking error." 2;
       ]
   in
-  Term.info "mlang"
+  Cmd.info "mlang"
     ~version:
       (match Build_info.V1.version () with
       | None -> "n/a"

--- a/src/mlang/utils/cli.mli
+++ b/src/mlang/utils/cli.mli
@@ -43,7 +43,7 @@ val mlang_t :
   'a Cmdliner.Term.t
 (** Mlang binary command-line arguments parsing function *)
 
-val info : Cmdliner.Term.info
+val info : Cmdliner.Cmd.info
 (** Command-line man page for --help *)
 
 (**{2 Flags and parameters}*)

--- a/src/mlang/utils/dgfip_options.ml
+++ b/src/mlang/utils/dgfip_options.ml
@@ -101,9 +101,9 @@ let info =
       `P "Please file bug reports at https://github.com/MLanguage/mlang/issues";
     ]
   in
-  Term.info "mlang --dgfip_options" ~doc ~man
+  Cmd.info "mlang --dgfip_options" ~doc ~man
 
-(* Flags inherited from the old comiler *)
+(* Flags inherited from the old compiler *)
 type flags = {
   (* -A *) nom_application : string;
   (* iliad, pro, oceans, bareme, batch *)
@@ -213,5 +213,8 @@ let handler (income_year : int) (application_name : string) (iliad_pro : bool)
 
 let process_dgfip_options options =
   let options = Array.of_list ("mlang" :: options) in
-  let res = Cmdliner.Term.eval ~argv:options (dgfip_t handler, info) in
-  match res with `Ok res -> Some res | _ -> None
+  let cmd = Cmd.v info (dgfip_t handler) in
+  let res = Cmd.eval_value ~argv:options cmd in
+  match res with
+  | Ok res -> ( match res with `Ok res -> Some res | _ -> None)
+  | _ -> None


### PR DESCRIPTION
Cmdliner have release a new version 1.1.0 which has breaking changes,
this PR aims to update the version and change all the deprecated
function and module uses.

Closes issue #119