### PR TITLE
Distinguish M code in separate chains

### DIFF
--- a/mpp_specs/2018_6_7.mpp
+++ b/mpp_specs/2018_6_7.mpp
@@ -9,7 +9,7 @@ compute_benefits():
     V_INDTEO = 1
     V_CALCUL_NAPS = 1
     partition with var_is_taxbenefit:
-      IAD11, INE, IRE <- call_m(calcul_primitif)
+      IAD11, INE, IRE <- call_m(primitif)
     V_CALCUL_NAPS = 0
     iad11 = cast(IAD11)
     ire = cast(IRE)
@@ -41,9 +41,9 @@ compute_double_liquidation3(outputs):
   8ZG = v_8ZG
   V_ACO_MTAP = 0
   V_NEGACO = 0
-  outputs <- call_m(calcul_primitif_isf)
-  outputs <- call_m(calcul_primitif)
-  outputs <- call_m(calcul_primitif_taux)
+  outputs <- call_m(isf)
+  outputs <- call_m(primitif)
+  outputs <- call_m(taux)
 
 compute_double_liquidation_exit_taxe(outputs):
   annee = 2018 # FIXME

--- a/mpp_specs/2019_8_0.mpp
+++ b/mpp_specs/2019_8_0.mpp
@@ -9,7 +9,7 @@ compute_benefits():
     partition with var_is_taxbenefit:
       V_INDTEO = 1
       V_CALCUL_NAPS = 1
-      IAD11, INE, IRE <- call_m(calcul_primitif)
+      IAD11, INE, IRE <- call_m(primitif)
       V_CALCUL_NAPS = 0
       iad11 = cast(IAD11)
       ire = cast(IRE)
@@ -41,9 +41,9 @@ compute_double_liquidation3(outputs):
   8ZG = v_8ZG
   V_ACO_MTAP = 0
   V_NEGACO = 0
-  outputs <- call_m(calcul_primitif_isf)
-  outputs <- call_m(calcul_primitif)
-  outputs <- call_m(calcul_primitif_taux)
+  outputs <- call_m(isf)
+  outputs <- call_m(primitif)
+  outputs <- call_m(taux)
 
 compute_double_liquidation_exit_taxe(outputs):
   annee = 2018 # FIXME

--- a/mpp_specs/2020_6_5.mpp
+++ b/mpp_specs/2020_6_5.mpp
@@ -5,13 +5,13 @@ compute_article1731bis():
     PREM8_11 = 1
 
 calcul_primitif_isf(outputs):
-  outputs <- call_m(calcul_primitif_isf)
- 
+  outputs <- call_m(isf)
+
 calcul_primitif(outputs):
-  outputs <- call_m(calcul_primitif)
+  outputs <- call_m(primitif)
 
 calcul_primitif_taux(outputs):
-  outputs <- call_m(calcul_primitif_taux)
+  outputs <- call_m(taux)
 
 compute_benefits():
  if exists_deposit_defined_variables() or exists_taxbenefit_ceiled_variables():

--- a/mpp_specs/dgfip_base.mpp
+++ b/mpp_specs/dgfip_base.mpp
@@ -1,4 +1,4 @@
 dgfip_calculation():
-  outputs <- call_m(calcul_primitif_isf)
-  outputs <- call_m(calcul_primitif)
-  outputs <- call_m(calcul_primitif_taux)
+  outputs <- call_m(isf)
+  outputs <- call_m(primitif)
+  outputs <- call_m(taux)

--- a/src/mlang/backend_compilers/bir_to_java.ml
+++ b/src/mlang/backend_compilers/bir_to_java.ml
@@ -67,7 +67,9 @@ let print_double_cut oc () = Format.fprintf oc "@,@,"
 let get_var_pos (var : variable) var_indexes : int =
   match VariableMap.find_opt var var_indexes with
   | Some i -> i
-  | None -> Errors.raise_error "Variable not found"
+  | None ->
+      Errors.raise_error
+        ("Variable not found: " ^ Pos.unmark (var_to_mir var).name)
 
 let rec generate_java_expr (e : expression Pos.marked)
     (var_indexes : int VariableMap.t) :

--- a/src/mlang/backend_compilers/dgfip_gen_files.ml
+++ b/src/mlang/backend_compilers/dgfip_gen_files.ml
@@ -772,7 +772,7 @@ let get_rules_verif_etc prog =
             | Rule r ->
                 let rules, chainings =
                   if is_valid_app r.rule_applications then
-                    ( rule_number r.rule_name :: rules,
+                    ( Pos.unmark r.rule_number :: rules,
                       match r.rule_chaining with
                       | None -> chainings
                       | Some cn -> StringSet.add (Pos.unmark cn) chainings )
@@ -785,7 +785,7 @@ let get_rules_verif_etc prog =
                     fst
                     @@ List.fold_left
                          (fun (verifs, vn) _vc -> (vn :: verifs, vn + 1))
-                         (verifs, verification_number v.verif_name)
+                         (verifs, Pos.unmark v.verif_number)
                          v.verif_conditions
                   else verifs
                 in

--- a/src/mlang/backend_ir/bir_interface.ml
+++ b/src/mlang/backend_ir/bir_interface.ml
@@ -168,7 +168,8 @@ let translate_external_conditions idmap
   let program =
     Mast.Verification
       {
-        verif_name = [ ("000", Pos.no_pos) ];
+        verif_number = (0, Pos.no_pos);
+        verif_tags = [];
         verif_applications = [ ("iliad", Pos.no_pos) ];
         verif_conditions = verif_conds;
       }

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -479,10 +479,11 @@ module Make (N : Bir_number.NumberInterface) = struct
                 | TableVar _ -> assert false
                 (* should not happen *)
               with Not_found ->
-                Errors.raise_spanned_error
-                  ("Var not found (should not happen): "
-                  ^ Pos.unmark (Bir.var_to_mir var).Mir.Variable.name)
-                  (Pos.get_position e)
+                (* Cli.warning_print
+                 *   "Var %s used before definition, assumed undefined.\n%s"
+                 *   (Pos.unmark var.Variable.name)
+                 *   (Pos.retrieve_loc_text (Pos.get_position e)); *)
+                Undefined
             in
             r
         | GenericTableIndex -> (

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -479,11 +479,10 @@ module Make (N : Bir_number.NumberInterface) = struct
                 | TableVar _ -> assert false
                 (* should not happen *)
               with Not_found ->
-                (* Cli.warning_print
-                 *   "Var %s used before definition, assumed undefined.\n%s"
-                 *   (Pos.unmark var.Variable.name)
-                 *   (Pos.retrieve_loc_text (Pos.get_position e)); *)
-                Undefined
+                Errors.raise_spanned_error
+                  ("Var not found (should not happen): "
+                  ^ Pos.unmark (Bir.var_to_mir var).Mir.Variable.name)
+                  (Pos.get_position e)
             in
             r
         | GenericTableIndex -> (

--- a/src/mlang/driver.ml
+++ b/src/mlang/driver.ml
@@ -34,6 +34,23 @@ let process_dgfip_options (backend : string option)
     end
   | _ -> Dgfip_options.default_flags
 
+let build_m_program_of_tag (mast : Mast.source_file list) (tag : Mast.chain_tag)
+    : Mir_interface.full_program =
+  Cli.debug_print "Builing M program for %s..."
+    (Format.asprintf "%a" Format_mast.format_chain_tag tag);
+  Cli.debug_print "Elaborating...";
+  let m_program = Mast_to_mir.translate mast tag in
+  let full_m_program = Mir_interface.to_full_program m_program in
+  let full_m_program = Mir_typechecker.expand_functions full_m_program in
+  Cli.debug_print "Typechecking...";
+  let full_m_program = Mir_typechecker.typecheck full_m_program in
+  Cli.debug_print "Checking for circular variable definitions...";
+  if
+    Mir_dependency_graph.check_for_cycle full_m_program.dep_graph
+      full_m_program.program true
+  then Errors.raise_error "Cycles between rules.";
+  full_m_program
+
 (** Entry function for the executable. Returns a negative number in case of
     error. *)
 let driver (files : string list) (debug : bool) (var_info_debug : string list)
@@ -58,8 +75,7 @@ let driver (files : string list) (debug : bool) (var_info_debug : string list)
         let filebuf, input =
           if source_file <> "" then
             let input = open_in source_file in
-            (Lexing.from_channel input, Some input)
-          else if source_file <> "" then (Lexing.from_string source_file, None)
+            (Lexing.from_channel input, input)
           else failwith "You have to specify at least one file!"
         in
         current_progress source_file;
@@ -73,27 +89,13 @@ let driver (files : string list) (debug : bool) (var_info_debug : string list)
           let commands = Mparser.source_file token filebuf in
           m_program := commands :: !m_program
         with Mparser.Error ->
-          begin
-            match input with
-            | Some input -> close_in input
-            | None -> ()
-          end;
+          close_in input;
           Errors.raise_spanned_error "M syntax error"
             (Parse_utils.mk_position (filebuf.lex_start_p, filebuf.lex_curr_p)))
       !Cli.source_files;
     finish "completed!";
-    Cli.debug_print "Elaborating...";
     let source_m_program = !m_program in
-    let m_program = Mast_to_mir.translate !m_program in
-    let full_m_program = Mir_interface.to_full_program m_program in
-    let full_m_program = Mir_typechecker.expand_functions full_m_program in
-    Cli.debug_print "Typechecking...";
-    let full_m_program = Mir_typechecker.typecheck full_m_program in
-    Cli.debug_print "Checking for circular variable definitions...";
-    if
-      Mir_dependency_graph.check_for_cycle full_m_program.dep_graph
-        full_m_program.program true
-    then Errors.raise_error "Cycles between rules.";
+    let full_m_program = build_m_program_of_tag !m_program Mast.Primitif in
     let mpp = Mpp_frontend.process mpp_file full_m_program in
     let full_m_program =
       Mir_interface.to_full_program

--- a/src/mlang/m_frontend/format_mast.ml
+++ b/src/mlang/m_frontend/format_mast.ml
@@ -39,8 +39,39 @@ let format_application fmt (app : application) = Format.fprintf fmt "%s" app
 
 let format_chaining fmt (c : chaining) = Format.fprintf fmt "%s" c
 
-let format_rule_name fmt (rn : rule_name) =
-  (pp_print_list_space (pp_unmark Format.pp_print_string)) fmt rn
+let format_chain_tag fmt (t : chain_tag) =
+  Format.pp_print_string fmt
+    (match t with
+    | Primitif -> "primitif"
+    | Corrective -> "corrective"
+    | Isf -> "isf"
+    | Taux -> "taux"
+    | Irisf -> "irisf"
+    | Base_hr -> "base_HR"
+    | Base_tl -> "base_tl"
+    | Base_tl_init -> "base_tl_init"
+    | Base_tl_rect -> "base_tl_rect"
+    | Base_inr -> "base_INR"
+    | Base_inr_ref -> "base_inr_ref"
+    | Base_inr_tl -> "base_inr_tl"
+    | Base_inr_tl22 -> "base_inr_tl22"
+    | Base_inr_tl24 -> "base_inr_tl24"
+    | Base_inr_ntl -> "base_inr_ntl"
+    | Base_inr_ntl22 -> "base_inr_ntl22"
+    | Base_inr_ntl24 -> "base_inr_ntl24"
+    | Base_inr_inter22 -> "base_inr_inter22"
+    | Base_inr_intertl -> "base_inr_intertl"
+    | Base_inr_r9901 -> "base_inr_r9901"
+    | Base_abat98 -> "base_ABAT98"
+    | Base_abat99 -> "base_ABAT99"
+    | Base_initial -> "base_INITIAL"
+    | Base_premier -> "base_premier"
+    | Base_anterieure -> "base_anterieure"
+    | Base_anterieure_cor -> "base_anterieure_cor"
+    | Base_majo -> "base_MAJO"
+    | Base_stratemajo -> "base_stratemajo"
+    | Non_auto_cc -> "non_auto_cc"
+    | Horizontale -> "horizontale")
 
 let format_variable_name fmt (v : variable_name) = Format.fprintf fmt "%s" v
 
@@ -53,9 +84,6 @@ let format_variable fmt (v : variable) =
   match v with
   | Normal v -> format_variable_name fmt v
   | Generic v -> format_variable_generic_name fmt v
-
-let format_verification_name fmt (n : verification_name) =
-  (pp_print_list_space (pp_unmark Format.pp_print_string)) fmt n
 
 let format_error_name fmt (e : error_name) = Format.fprintf fmt "%s" e
 
@@ -191,9 +219,8 @@ let format_formula fmt (f : formula) =
         format_formula_decl f
 
 let format_rule fmt (r : rule) =
-  Format.fprintf fmt "regle %a:\napplication %a;\n%a;\n"
-    (pp_print_list_space (pp_unmark Format.pp_print_string))
-    r.rule_name
+  Format.fprintf fmt "regle %d:\napplication %a;\n%a;\n"
+    (Pos.unmark r.rule_number)
     (pp_print_list_comma (pp_unmark Format.pp_print_string))
     r.rule_applications
     (Format.pp_print_list
@@ -267,7 +294,8 @@ let format_verification_condition fmt (vc : verification_condition) =
     (snd vc.verif_cond_error)
 
 let format_verification fmt (v : verification) =
-  Format.fprintf fmt "verif %a : %a;\n%a" format_verification_name v.verif_name
+  Format.fprintf fmt "verif %d : %a;\n%a"
+    (Pos.unmark v.verif_number)
     (pp_print_list_space (pp_unmark format_application))
     v.verif_applications
     (pp_print_list_space (pp_unmark format_verification_condition))

--- a/src/mlang/m_frontend/format_mast.mli
+++ b/src/mlang/m_frontend/format_mast.mli
@@ -24,8 +24,6 @@ val format_value_typ : Format.formatter -> Mast.value_typ -> unit
 
 val format_variable : Format.formatter -> Mast.variable -> unit
 
-val format_rule_name : Format.formatter -> Mast.rule_name -> unit
-
 val format_source_file : Format.formatter -> Mast.source_file -> unit
 
 val pp_print_list_endline :
@@ -35,3 +33,5 @@ val pp_print_list_comma :
   (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a list -> unit
 
 val pp_unmark : ('a -> 'b -> 'c) -> 'a -> 'b Pos.marked -> 'c
+
+val format_chain_tag : Format.formatter -> Mast.chain_tag -> unit

--- a/src/mlang/m_frontend/mast.ml
+++ b/src/mlang/m_frontend/mast.ml
@@ -34,15 +34,99 @@ type application = string
 type chaining = string
 (** "enchaineur" in the M source code, utility unknown *)
 
-type rule_name = string Pos.marked list
-(** Rule can have multiple names. The last one should be an integer, indicating
-    the order of execution of the rule. *)
+type chain_tag =
+  | Primitif
+  | Corrective
+  | Isf
+  | Taux
+  | Irisf
+  | Base_hr
+  | Base_tl
+  | Base_tl_init
+  | Base_tl_rect
+  | Base_initial
+  | Base_inr
+  | Base_inr_ref
+  | Base_inr_tl
+  | Base_inr_tl22
+  | Base_inr_tl24
+  | Base_inr_ntl
+  | Base_inr_ntl22
+  | Base_inr_ntl24
+  | Base_inr_inter22
+  | Base_inr_intertl
+  | Base_inr_r9901
+  | Base_abat98
+  | Base_abat99
+  | Base_majo
+  | Base_premier
+  | Base_anterieure
+  | Base_anterieure_cor
+  | Base_stratemajo
+  | Non_auto_cc
+  | Horizontale
 
-let rule_number (name : rule_name) : int =
-  try int_of_string (Pos.unmark (List.hd (List.rev name)))
-  with _ ->
-    Errors.raise_spanned_error "this rule doesn't have an execution number"
-      (Pos.get_position (List.hd name))
+let chain_tag_of_string : string -> chain_tag = function
+  | "primitif" -> Primitif
+  | "corrective" -> Corrective
+  | "isf" -> Isf
+  | "taux" -> Taux
+  | "irisf" -> Irisf
+  | "base_HR" -> Base_hr
+  | "base_tl" -> Base_tl
+  | "base_tl_init" -> Base_tl_init
+  | "base_tl_rect" -> Base_tl_rect
+  | "base_INR" -> Base_inr
+  | "base_inr_ref" -> Base_inr_ref
+  | "base_inr_tl" -> Base_inr_tl
+  | "base_inr_tl22" -> Base_inr_tl22
+  | "base_inr_tl24" -> Base_inr_tl24
+  | "base_inr_ntl" -> Base_inr_ntl
+  | "base_inr_ntl22" -> Base_inr_ntl22
+  | "base_inr_ntl24" -> Base_inr_ntl24
+  | "base_inr_inter22" -> Base_inr_inter22
+  | "base_inr_intertl" -> Base_inr_intertl
+  | "base_inr_r9901" -> Base_inr_r9901
+  | "base_ABAT98" -> Base_abat98
+  | "base_ABAT99" -> Base_abat99
+  | "base_INITIAL" -> Base_initial
+  | "base_premier" -> Base_premier
+  | "base_anterieure" -> Base_anterieure
+  | "base_anterieure_cor" -> Base_anterieure_cor
+  | "base_MAJO" -> Base_majo
+  | "base_stratemajo" -> Base_stratemajo
+  | "non_auto_cc" -> Non_auto_cc
+  | "horizontale" -> Horizontale
+  | _ -> raise Not_found
+
+let number_and_tags_of_name (name : string Pos.marked list) :
+    int Pos.marked * chain_tag Pos.marked list =
+  let rec aux tags = function
+    | [] -> assert false (* M parser shouldn't allow it *)
+    | [ n ] ->
+        let num =
+          try Pos.map_under_mark int_of_string n
+          with _ ->
+            Errors.raise_spanned_error
+              "this rule or verification doesn't have an execution number"
+              (Pos.get_position (List.hd name))
+        in
+        (num, tags)
+    | h :: t ->
+        let tag =
+          try Pos.map_under_mark chain_tag_of_string h
+          with _ ->
+            Errors.raise_spanned_error
+              ("Unknown chain tag " ^ Pos.unmark h)
+              (Pos.get_position h)
+        in
+        aux (tag :: tags) t
+  in
+  let number, tags = aux [] name in
+  if List.length tags = 0 then
+    (number, [ (Primitif, Pos.no_pos); (Corrective, Pos.no_pos) ])
+    (* No tags means both in primitive and corrective *)
+  else (number, tags)
 
 type variable_name = string
 (** Variables are just strings *)
@@ -52,15 +136,6 @@ type func_name = string
 
 type variable_generic_name = { base : string; parameters : char list }
 (** For generic variables, we record the list of their lowercase parameters *)
-
-type verification_name = string Pos.marked list
-(** Verification clauses can have multiple names, currently unused *)
-
-let verification_number (name : verification_name) : int =
-  try int_of_string (Pos.unmark (List.hd (List.rev name)))
-  with _ ->
-    Errors.raise_spanned_error "this rule doesn't have an execution number"
-      (Pos.get_position (List.hd name))
 
 type error_name = string
 (** Ununsed for now *)
@@ -193,7 +268,8 @@ type formula =
   | MultipleFormulaes of loop_variables Pos.marked * formula_decl
 
 type rule = {
-  rule_name : rule_name;
+  rule_number : int Pos.marked;
+  rule_tags : chain_tag Pos.marked list;
   rule_applications : application Pos.marked list;
   rule_chaining : chaining Pos.marked option;
   rule_formulaes : formula Pos.marked list;
@@ -272,7 +348,8 @@ type verification_condition = {
 }
 
 type verification = {
-  verif_name : verification_name;
+  verif_number : int Pos.marked;
+  verif_tags : chain_tag Pos.marked list;
   verif_applications : application Pos.marked list;
       (** Verification conditions are application-specific *)
   verif_conditions : verification_condition Pos.marked list;

--- a/src/mlang/m_frontend/mast.ml
+++ b/src/mlang/m_frontend/mast.ml
@@ -65,6 +65,41 @@ type chain_tag =
   | Base_stratemajo
   | Non_auto_cc
   | Horizontale
+(* Make sure to update [all_tags] below when patching this *)
+
+let all_tags : chain_tag list =
+  [
+    Primitif;
+    Corrective;
+    Isf;
+    Taux;
+    Irisf;
+    Base_hr;
+    Base_tl;
+    Base_tl_init;
+    Base_tl_rect;
+    Base_initial;
+    Base_inr;
+    Base_inr_ref;
+    Base_inr_tl;
+    Base_inr_tl22;
+    Base_inr_tl24;
+    Base_inr_ntl;
+    Base_inr_ntl22;
+    Base_inr_ntl24;
+    Base_inr_inter22;
+    Base_inr_intertl;
+    Base_inr_r9901;
+    Base_abat98;
+    Base_abat99;
+    Base_majo;
+    Base_premier;
+    Base_anterieure;
+    Base_anterieure_cor;
+    Base_stratemajo;
+    Non_auto_cc;
+    Horizontale;
+  ]
 
 let chain_tag_of_string : string -> chain_tag = function
   | "primitif" -> Primitif
@@ -395,3 +430,23 @@ type function_spec = {
 
 let get_variable_name (v : variable) : string =
   match v with Normal s -> s | Generic s -> s.base
+
+let are_tags_part_of_chain (tags : chain_tag list) (chain : chain_tag) : bool =
+  let is_part_of = List.exists (( = ) chain) tags in
+  match chain with
+  | Corrective ->
+      (* Specific exclusion of "base_" rules in corrective *)
+      (not
+         (List.exists
+            (function
+              | Base_hr | Base_tl | Base_tl_init | Base_tl_rect | Base_initial
+              | Base_inr | Base_inr_ref | Base_inr_tl | Base_inr_tl22
+              | Base_inr_tl24 | Base_inr_ntl | Base_inr_ntl22 | Base_inr_ntl24
+              | Base_inr_inter22 | Base_inr_intertl | Base_inr_r9901
+              | Base_abat98 | Base_abat99 | Base_majo | Base_premier
+              | Base_anterieure | Base_anterieure_cor | Base_stratemajo ->
+                  true
+              | _ -> false)
+            tags))
+      && is_part_of
+  | _ -> is_part_of

--- a/src/mlang/m_frontend/mast_to_mir.mli
+++ b/src/mlang/m_frontend/mast_to_mir.mli
@@ -84,12 +84,12 @@ val get_conds :
 
 (** {1 Main translation function}*)
 
-val translate : Mast.program -> Mir.program
+val translate : Mast.program -> Mast.chain_tag -> Mir.program
 (** Main translation function from the M AST to the M Variable Graph. This
     function performs 6 linear passes on the input code:
 
-    - [remove_corrective_rules] removes all the rules that are not necessary for
-      the computation of the "primitive" income tax;
+    - [filter_by_tag] removes all the rules and verification that are notused in
+      the computation corresponding to the given tag;
     - [get_constants] gets the value of all constant variables, the values of
       which are needed to compute certain loop bounds;
     - [get_variables_decl] retrieves the declarations of all other variables and

--- a/src/mlang/m_frontend/mast_to_mir.mli
+++ b/src/mlang/m_frontend/mast_to_mir.mli
@@ -84,12 +84,10 @@ val get_conds :
 
 (** {1 Main translation function}*)
 
-val translate : Mast.program -> Mast.chain_tag -> Mir.program
+val translate : Mast.program -> Mir.program
 (** Main translation function from the M AST to the M Variable Graph. This
     function performs 6 linear passes on the input code:
 
-    - [filter_by_tag] removes all the rules and verification that are notused in
-      the computation corresponding to the given tag;
     - [get_constants] gets the value of all constant variables, the values of
       which are needed to compute certain loop bounds;
     - [get_variables_decl] retrieves the declarations of all other variables and

--- a/src/mlang/m_frontend/mparser.mly
+++ b/src/mlang/m_frontend/mparser.mly
@@ -233,8 +233,11 @@ rule:
 | RULE name = rule_name_symbol+ COLON apps = application_reference
   SEMICOLON c = chaining_reference?
   formulaes = formula_list
-  { {
-      rule_name = name;
+  {
+    let rule_number, rule_tags = Mast.number_and_tags_of_name name in
+    {
+      rule_number;
+      rule_tags;
       rule_applications = apps;
       rule_chaining = c;
       rule_formulaes = formulaes;
@@ -277,11 +280,14 @@ verification_name:
 
 verification:
 | VERIFICATION name = verification_name+ COLON apps = application_reference
-  SEMICOLON conds = verification_condition* { {
-  verif_name = name;
-  verif_applications = apps;
-  verif_conditions = conds;
-} }
+  SEMICOLON conds = verification_condition* {
+    let verif_number, verif_tags = Mast.number_and_tags_of_name name in
+    {
+      verif_number;
+      verif_tags;
+      verif_applications = apps;
+      verif_conditions = conds;
+    } }
 
 verification_condition:
 | IF e = expression THEN

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -370,96 +370,10 @@ let fresh_rule_id =
 (** Special rule id for initial definition of variables *)
 let initial_undef_rule_id = -1
 
-type rule_tag =
-  | Primitif
-  | Corrective
-  | Isf
-  | Taux
-  | Irisf
-  | Base_hr
-  | Base_tl
-  | Base_tl_init
-  | Base_tl_rect
-  | Base_initial
-  | Base_inr
-  | Base_inr_ref
-  | Base_inr_tl
-  | Base_inr_tl22
-  | Base_inr_tl24
-  | Base_inr_ntl
-  | Base_inr_ntl22
-  | Base_inr_ntl24
-  | Base_inr_inter22
-  | Base_inr_intertl
-  | Base_inr_r9901
-  | Base_abat98
-  | Base_abat99
-  | Base_majo
-  | Base_premier
-  | Base_anterieure
-  | Base_anterieure_cor
-  | Base_stratemajo
-
-let rule_tag_of_string : string -> rule_tag = function
-  | "primitif" -> Primitif
-  | "corrective" -> Corrective
-  | "isf" -> Isf
-  | "taux" -> Taux
-  | "irisf" -> Irisf
-  | "base_HR" -> Base_hr
-  | "base_tl" -> Base_tl
-  | "base_tl_init" -> Base_tl_init
-  | "base_tl_rect" -> Base_tl_rect
-  | "base_INR" -> Base_inr
-  | "base_inr_ref" -> Base_inr_ref
-  | "base_inr_tl" -> Base_inr_tl
-  | "base_inr_tl22" -> Base_inr_tl22
-  | "base_inr_tl24" -> Base_inr_tl24
-  | "base_inr_ntl" -> Base_inr_ntl
-  | "base_inr_ntl22" -> Base_inr_ntl22
-  | "base_inr_ntl24" -> Base_inr_ntl24
-  | "base_inr_inter22" -> Base_inr_inter22
-  | "base_inr_intertl" -> Base_inr_intertl
-  | "base_inr_r9901" -> Base_inr_r9901
-  | "base_ABAT98" -> Base_abat98
-  | "base_ABAT99" -> Base_abat99
-  | "base_INITIAL" -> Base_initial
-  | "base_premier" -> Base_premier
-  | "base_anterieure" -> Base_anterieure
-  | "base_anterieure_cor" -> Base_anterieure_cor
-  | "base_MAJO" -> Base_majo
-  | "base_stratemajo" -> Base_stratemajo
-  | _ -> raise Not_found
-
-let rule_number_and_tags_of_rule_name (rule_name : Mast.rule_name) :
-    int Pos.marked * rule_tag Pos.marked list =
-  let rec aux tags = function
-    | [] -> assert false (* M parser shouldn't allow it *)
-    | [ n ] ->
-        let num =
-          try Pos.map_under_mark int_of_string n
-          with _ ->
-            Errors.raise_spanned_error
-              "this rule doesn't have an execution number"
-              (Pos.get_position (List.hd rule_name))
-        in
-        (num, tags)
-    | h :: t ->
-        let tag =
-          try Pos.map_under_mark rule_tag_of_string h
-          with _ ->
-            Errors.raise_spanned_error
-              ("Unknown rule tag " ^ Pos.unmark h)
-              (Pos.get_position h)
-        in
-        aux (tag :: tags) t
-  in
-  aux [] rule_name
-
 type rule_data = {
   rule_vars : (Variable.id * variable_data) list;
   rule_number : int Pos.marked;
-  rule_tags : rule_tag Pos.marked list;
+  rule_tags : Mast.chain_tag Pos.marked list;
 }
 
 module RuleMap = Map.Make (struct

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -373,11 +373,17 @@ let initial_undef_rule_id = -1
 type rule_data = {
   rule_vars : (Variable.id * variable_data) list;
   rule_number : int Pos.marked;
-  rule_tags : Mast.chain_tag Pos.marked list;
+  rule_tags : Mast.chain_tag list;
 }
 
 module RuleMap = Map.Make (struct
   type t = rule_id
+
+  let compare = compare
+end)
+
+module TagMap = Map.Make (struct
+  type t = Mast.chain_tag
 
   let compare = compare
 end)
@@ -529,7 +535,7 @@ let sort_by_highest_exec_number v1 v2 =
 let get_var_sorted_by_execution_number (p : program) (name : string) sort :
     Variable.t =
   let vars = Pos.VarNameToID.find name p.program_idmap |> List.sort sort in
-  List.hd vars
+  match vars with [] -> raise Not_found | hd :: _ -> hd
 
 let find_var_by_name (p : program) (name : string Pos.marked) : Variable.t =
   try

--- a/src/mlang/m_ir/mir.mli
+++ b/src/mlang/m_ir/mir.mli
@@ -161,40 +161,10 @@ type 'variable variable_data_ = {
 
 type variable_data = variable variable_data_
 
-type rule_tag =
-  | Primitif
-  | Corrective
-  | Isf
-  | Taux
-  | Irisf
-  | Base_hr
-  | Base_tl
-  | Base_tl_init
-  | Base_tl_rect
-  | Base_initial
-  | Base_inr
-  | Base_inr_ref
-  | Base_inr_tl
-  | Base_inr_tl22
-  | Base_inr_tl24
-  | Base_inr_ntl
-  | Base_inr_ntl22
-  | Base_inr_ntl24
-  | Base_inr_inter22
-  | Base_inr_intertl
-  | Base_inr_r9901
-  | Base_abat98
-  | Base_abat99
-  | Base_majo
-  | Base_premier
-  | Base_anterieure
-  | Base_anterieure_cor
-  | Base_stratemajo
-
 type rule_data = {
   rule_vars : (variable_id * variable_data) list;
   rule_number : int Pos.marked;
-  rule_tags : rule_tag Pos.marked list;
+  rule_tags : Mast.chain_tag Pos.marked list;
 }
 
 type rule_id = int
@@ -385,6 +355,3 @@ val find_vars_by_io : program -> io -> VariableDict.t
 (** Returns a VariableDict.t containing all the variables that have a given io
     type, only one variable per name is entered in the VariableDict.t, this
     function chooses the one with the highest execution number*)
-
-val rule_number_and_tags_of_rule_name :
-  Mast.rule_name -> rule_id Pos.marked * rule_tag Pos.marked list

--- a/src/mlang/m_ir/mir.mli
+++ b/src/mlang/m_ir/mir.mli
@@ -164,12 +164,14 @@ type variable_data = variable variable_data_
 type rule_data = {
   rule_vars : (variable_id * variable_data) list;
   rule_number : int Pos.marked;
-  rule_tags : Mast.chain_tag Pos.marked list;
+  rule_tags : Mast.chain_tag list;
 }
 
 type rule_id = int
 
 module RuleMap : Map.S with type key = rule_id
+
+module TagMap : Map.S with type key = Mast.chain_tag
 
 type error_descr = {
   kind : string Pos.marked;

--- a/src/mlang/m_ir/mir_dependency_graph.mli
+++ b/src/mlang/m_ir/mir_dependency_graph.mli
@@ -29,7 +29,7 @@ val get_used_variables : Mir.expression Pos.marked -> Mir.VariableDict.t
 (** Calls the previous function with an empty dict *)
 
 val create_rules_dependency_graph :
-  Mir.program -> Mir.rule_id Mir.VariableMap.t -> RG.t
+  Mir.rule_data Mir.RuleMap.t -> Mir.rule_id Mir.VariableMap.t -> RG.t
 
 val check_for_cycle : RG.t -> Mir.program -> bool -> bool
 (** Outputs [true] and a warning in case of cycles. *)

--- a/src/mlang/m_ir/mir_interface.mli
+++ b/src/mlang/m_ir/mir_interface.mli
@@ -21,11 +21,15 @@ val reset_all_outputs : Mir.program -> Mir.program
 (** This function defines the [var_io] property of [var_data] to [Regular] for
     all variables that don't have [Input] as their [var_io]. *)
 
-type full_program = {
+type chain_order = {
   dep_graph : Mir_dependency_graph.RG.t;
-  main_execution_order : Mir.rule_id list;
-  program : Mir.program;
+  execution_order : Mir.rule_id list;
 }
 
-val to_full_program : Mir.program -> full_program
+type full_program = {
+  program : Mir.program;
+  chains_orders : chain_order Mir.TagMap.t;
+}
+
+val to_full_program : Mir.program -> Mast.chain_tag list -> full_program
 (** Creates the dependency graph and stores it *)

--- a/src/mlang/mpp_frontend/mpp_frontend.ml
+++ b/src/mlang/mpp_frontend/mpp_frontend.ml
@@ -46,7 +46,12 @@ let to_mpp_callable (cname : string Pos.marked) (translated_names : string list)
 let to_mpp_callable (cname : string Pos.marked) (args : string Pos.marked list)
     (translated_names : string list) : mpp_callable * string Pos.marked list =
   if Pos.unmark cname = "call_m" then
-    (Program (Pos.unmark (List.hd args)), List.tl args)
+    match args with
+    | [] ->
+        Errors.raise_spanned_error "Expected a chain to call"
+          (Pos.get_position cname)
+    | chain :: args ->
+        (Program (Mast.chain_tag_of_string (Pos.unmark chain)), args)
   else (to_mpp_callable cname translated_names, args)
 
 let rec to_mpp_expr (p : Mir.program) (translated_names : mpp_compute_name list)

--- a/src/mlang/mpp_ir/mpp_format.ml
+++ b/src/mlang/mpp_ir/mpp_format.ml
@@ -26,7 +26,9 @@ let format_scoped_var (fmt : formatter) (sv : scoped_var) : unit =
 let format_callable (fmt : formatter) (f : mpp_callable) =
   fprintf fmt "%s"
     (match f with
-    | Program chain -> Printf.sprintf "evaluate_program(%s)" chain
+    | Program chain ->
+        Format.asprintf "evaluate_program(%a)" Format_mast.format_chain_tag
+          chain
     | MppFunction m -> m
     | Present -> "present"
     | Abs -> "abs"

--- a/src/mlang/mpp_ir/mpp_ir.ml
+++ b/src/mlang/mpp_ir/mpp_ir.ml
@@ -28,12 +28,10 @@ type scoped_var =
 
 (* variables defined in the M codebase *)
 
-type m_chaining = string
-
 type mpp_compute_name = string
 
 type mpp_callable =
-  | Program of m_chaining (* M codebase *)
+  | Program of Mast.chain_tag (* M codebase *)
   | MppFunction of mpp_compute_name
   | Present
   | Abs

--- a/src/mlang/optimizing_ir/dead_code_removal.ml
+++ b/src/mlang/optimizing_ir/dead_code_removal.ml
@@ -41,8 +41,8 @@ let remove_dead_statements (stmts : block) (id : block_id)
       stmt_used_vars used_vars
   in
   let rec remove_dead_stmts_of stmts used_vars used_defs pos =
-    List.fold_right
-      (fun stmt ((used_vars : pos_map), (used_defs : pos_map), acc, pos) ->
+    List.fold_left
+      (fun ((used_vars : pos_map), (used_defs : pos_map), acc, pos) stmt ->
         match Pos.unmark stmt with
         | SAssign (var, var_def) ->
             let used_defs_returned =
@@ -151,8 +151,8 @@ let remove_dead_statements (stmts : block) (id : block_id)
             (used_vars, used_defs, rule_call :: acc, pos - 1)
         | SFunctionCall _ -> assert false
         (* TODO: Implement me *))
-      stmts
       (used_vars, used_defs, [], pos)
+      (List.rev stmts)
   in
   let used_vars, used_defs, new_stmts, _ =
     remove_dead_stmts_of stmts used_vars used_defs 0


### PR DESCRIPTION
This uses tags on M rules definition to identify the subgraph of each "enchaineur" used by INTER files, including corrective ones. 