### PR TITLE
Fix disappearance of rules without dependencies in graph

### DIFF
--- a/src/mlang/m_ir/mir_dependency_graph.ml
+++ b/src/mlang/m_ir/mir_dependency_graph.ml
@@ -76,6 +76,7 @@ let create_rules_dependency_graph (program : Mir.program)
     (vars_to_rules : Mir.rule_id Mir.VariableMap.t) : RG.t =
   Mir.RuleMap.fold
     (fun rule_id { Mir.rule_vars; _ } g ->
+      let g = RG.add_vertex g rule_id in
       List.fold_left
         (fun g (_vid, def) ->
           let succs = get_def_used_variables def.Mir.var_definition in


### PR DESCRIPTION
If a rule has no links to others through variable uses, it was "forgotten" by the dependency graph. This patch fixes that.