### PR TITLE
Change representation of backend variables

### DIFF
--- a/src/mlang/backend_compilers/bir_to_java.ml
+++ b/src/mlang/backend_compilers/bir_to_java.ml
@@ -64,90 +64,81 @@ let generate_name (v : variable) : string =
 
 let print_double_cut oc () = Format.fprintf oc "@,@,"
 
-let get_var_pos (var : variable) var_indexes : int =
-  match VariableMap.find_opt var var_indexes with
-  | Some i -> i
-  | None ->
-      Errors.raise_error
-        ("Variable not found: " ^ Pos.unmark (var_to_mir var).name)
+let get_var_pos (var : variable) : int = var.Bir.offset
 
-let rec generate_java_expr (e : expression Pos.marked)
-    (var_indexes : int VariableMap.t) :
+let rec generate_java_expr (e : expression Pos.marked) :
     string * (Mir.LocalVariable.t * expression Pos.marked) list =
   match Pos.unmark e with
   | Comparison (op, e1, e2) ->
-      let se1, s1 = generate_java_expr e1 var_indexes in
-      let se2, s2 = generate_java_expr e2 var_indexes in
+      let se1, s1 = generate_java_expr e1 in
+      let se2, s2 = generate_java_expr e2 in
       let se3, s3 =
         ( Format.asprintf "%s(%s, %s)" (generate_comp_op (Pos.unmark op)) se1 se2,
           s1 @ s2 )
       in
       (se3, s3)
   | Binop (op, e1, e2) ->
-      let se1, s1 = generate_java_expr e1 var_indexes in
-      let se2, s2 = generate_java_expr e2 var_indexes in
+      let se1, s1 = generate_java_expr e1 in
+      let se2, s2 = generate_java_expr e2 in
       let se3, s3 =
         ( Format.asprintf "%s(%s, %s)" (generate_binop (Pos.unmark op)) se1 se2,
           s1 @ s2 )
       in
       (se3, s3)
   | Unop (op, e) ->
-      let se, s = generate_java_expr e var_indexes in
+      let se, s = generate_java_expr e in
       let se2, s2 = (Format.asprintf "%s(%s)" (generate_unop op) se, s) in
       (se2, s2)
   | Index (var, e) ->
-      let se, s = generate_java_expr e var_indexes in
+      let se, s = generate_java_expr e in
       let unmarked_var = Pos.unmark var in
       let size =
         Option.get (Bir.var_to_mir unmarked_var).Mir.Variable.is_table
       in
       let se2, s2 =
         ( Format.asprintf "m_array_index(tgv, %d ,%s, %d)"
-            (get_var_pos unmarked_var var_indexes)
-            se size,
+            (get_var_pos unmarked_var) se size,
           s )
       in
       (se2, s2)
   | Conditional (e1, e2, e3) ->
-      let se1, s1 = generate_java_expr e1 var_indexes in
-      let se2, s2 = generate_java_expr e2 var_indexes in
-      let se3, s3 = generate_java_expr e3 var_indexes in
+      let se1, s1 = generate_java_expr e1 in
+      let se2, s2 = generate_java_expr e2 in
+      let se3, s3 = generate_java_expr e3 in
       let se4, s4 =
         (Format.asprintf "m_cond(%s, %s, %s)" se1 se2 se3, s1 @ s2 @ s3)
       in
       (se4, s4)
   | FunctionCall (PresentFunc, [ arg ]) ->
-      let se, s = generate_java_expr arg var_indexes in
+      let se, s = generate_java_expr arg in
       let se2, s2 = (Format.asprintf "mPresent(%s)" se, s) in
       (se2, s2)
   | FunctionCall (NullFunc, [ arg ]) ->
-      let se, s = generate_java_expr arg var_indexes in
+      let se, s = generate_java_expr arg in
       let se2, s2 = (Format.asprintf "m_null(%s)" se, s) in
       (se2, s2)
   | FunctionCall (ArrFunc, [ arg ]) ->
-      let se, s = generate_java_expr arg var_indexes in
+      let se, s = generate_java_expr arg in
       let se2, s2 = (Format.asprintf "m_round(%s)" se, s) in
       (se2, s2)
   | FunctionCall (InfFunc, [ arg ]) ->
-      let se, s = generate_java_expr arg var_indexes in
+      let se, s = generate_java_expr arg in
       let se2, s2 = (Format.asprintf "m_floor(%s)" se, s) in
       (se2, s2)
   | FunctionCall (MaxFunc, [ e1; e2 ]) ->
-      let se1, s1 = generate_java_expr e1 var_indexes in
-      let se2, s2 = generate_java_expr e2 var_indexes in
+      let se1, s1 = generate_java_expr e1 in
+      let se2, s2 = generate_java_expr e2 in
       let se3, s3 = (Format.asprintf "m_max(%s, %s)" se1 se2, s1 @ s2) in
       (se3, s3)
   | FunctionCall (MinFunc, [ e1; e2 ]) ->
-      let se1, s1 = generate_java_expr e1 var_indexes in
-      let se2, s2 = generate_java_expr e2 var_indexes in
+      let se1, s1 = generate_java_expr e1 in
+      let se2, s2 = generate_java_expr e2 in
       let se3, s3 = (Format.asprintf "m_min(%s, %s)" se1 se2, s1 @ s2) in
       (se3, s3)
   | FunctionCall (Multimax, [ e1; (Var v2, _) ]) ->
-      let se1, s1 = generate_java_expr e1 var_indexes in
+      let se1, s1 = generate_java_expr e1 in
       let se2, s2 =
-        ( Format.asprintf "m_multimax(%s, tgv, %d)" se1
-            (get_var_pos v2 var_indexes),
-          [] )
+        (Format.asprintf "m_multimax(%s, tgv, %d)" se1 (get_var_pos v2), [])
       in
       (se2, s1 @ s2)
   | FunctionCall _ -> assert false (* should not happen *)
@@ -158,67 +149,55 @@ let rec generate_java_expr (e : expression Pos.marked)
       | _ -> (Format.asprintf "new MValue(%s)" (string_of_float f), []))
   | Literal Undefined -> (Format.asprintf "%s" none_value, [])
   | Var var ->
-      ( Format.asprintf "tgv[%d/*\"%a\"*/]"
-          (get_var_pos var var_indexes)
-          format_var_name var,
+      ( Format.asprintf "tgv[%d/*\"%a\"*/]" (get_var_pos var) format_var_name var,
         [] )
   | LocalVar lvar ->
       (Format.asprintf "localVariables[%d]" lvar.Mir.LocalVariable.id, [])
   | GenericTableIndex -> (Format.asprintf "new MValue(genericIndex)", [])
   | Error -> assert false (* should not happen *)
   | LocalLet (lvar, e1, e2) ->
-      let _, s1 = generate_java_expr e1 var_indexes in
-      let se2, s2 = generate_java_expr e2 var_indexes in
+      let _, s1 = generate_java_expr e1 in
+      let se2, s2 = generate_java_expr e2 in
       let se3, s3 = (Format.asprintf "%s" se2, s1 @ ((lvar, e1) :: s2)) in
       (se3, s3)
 
-let format_local_vars_defs (var_indexes : int VariableMap.t)
-    (oc : Format.formatter)
+let format_local_vars_defs (oc : Format.formatter)
     (defs : (Mir.LocalVariable.t * expression Pos.marked) list) =
   Format.pp_print_list
     (fun fmt (lvar, expr) ->
-      let se, _ = generate_java_expr expr var_indexes in
+      let se, _ = generate_java_expr expr in
       Format.fprintf fmt "localVariables[%d] = %s;" lvar.Mir.LocalVariable.id se)
     oc defs
 
-let generate_var_def (var_indexes : int VariableMap.t) (var : variable)
-    (data : variable_data) (oc : Format.formatter) =
+let generate_var_def (var : variable) (data : variable_data)
+    (oc : Format.formatter) =
   match data.var_definition with
   | SimpleVar e ->
-      let se, defs = generate_java_expr e var_indexes in
-      Format.fprintf oc "%atgv[%d /*\"%a\"*/] = %s;"
-        (format_local_vars_defs var_indexes)
-        defs
-        (get_var_pos var var_indexes)
-        format_var_name var se
+      let se, defs = generate_java_expr e in
+      Format.fprintf oc "%atgv[%d /*\"%a\"*/] = %s;" format_local_vars_defs defs
+        (get_var_pos var) format_var_name var se
   | TableVar (_, IndexTable es) ->
       Format.fprintf oc "%a"
         (fun fmt ->
           Mir.IndexMap.iter (fun i v ->
-              let sv, defs = generate_java_expr v var_indexes in
+              let sv, defs = generate_java_expr v in
               Format.fprintf fmt "%atgv[%d /* %a */] = %s;"
-                (format_local_vars_defs var_indexes)
-                defs
-                (get_var_pos var var_indexes |> ( + ) i)
+                format_local_vars_defs defs
+                (get_var_pos var |> ( + ) i)
                 format_var_name var sv))
         es
   | TableVar (size, IndexGeneric e) ->
-      let se, s = generate_java_expr e var_indexes in
+      let se, s = generate_java_expr e in
       Format.fprintf oc
         "@[<hv 2>for (int genericIndex = 0; genericIndex < %d; genericIndex++) \
          {@,\
          @[<h 4> %atgv[%d + genericIndex /* %a */] = %s;@]@]@,\
          }"
-        size
-        (format_local_vars_defs var_indexes)
-        s
-        (get_var_pos var var_indexes)
-        format_var_name var se
+        size format_local_vars_defs s (get_var_pos var) format_var_name var se
   | InputVar -> assert false
 
 let generate_input_handling (function_spec : Bir_interface.bir_function)
-    (var_indexes : int VariableMap.t) (oc : Format.formatter)
-    (split_threshold : int) =
+    (oc : Format.formatter) (split_threshold : int) =
   let input_vars =
     List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
   in
@@ -239,9 +218,8 @@ let generate_input_handling (function_spec : Bir_interface.bir_function)
     Format.fprintf fmt
       "tgv[/*\"%a\"*/%d] = inputVariables.get(\"%s\") != null ? \
        inputVariables.get(\"%s\") : MValue.mUndefined;"
-      format_var_name var
-      (get_var_pos var var_indexes)
-      (generate_name var) (generate_name var)
+      format_var_name var (get_var_pos var) (generate_name var)
+      (generate_name var)
   in
   let print_method fmt inputs =
     Format.fprintf fmt
@@ -268,10 +246,10 @@ let generate_input_handling (function_spec : Bir_interface.bir_function)
     (Format.pp_print_list print_call)
     load_calls
 
-let generate_var_cond var_indexes oc (cond : condition_data) =
+let generate_var_cond oc (cond : condition_data) =
   let open Strings in
   Format.fprintf oc "cond = %s;@,"
-    (let se, _ = generate_java_expr cond.cond_expr var_indexes in
+    (let se, _ = generate_java_expr cond.cond_expr in
      se);
   let cond_error, var = cond.cond_error in
   let error_name = sanitize_str cond_error.Mir.Error.name in
@@ -310,17 +288,17 @@ let generate_rule_header (oc : Format.formatter) (rule : rule) =
   Format.fprintf oc "Rule.m_rule_%s(mCalculation, calculationErrors);"
     rule.rule_name
 
-let rec generate_stmts (program : program) (var_indexes : int VariableMap.t)
-    (oc : Format.formatter) (stmts : stmt list) =
-  Format.pp_print_list (generate_stmt program var_indexes) oc stmts
+let rec generate_stmts (program : program) (oc : Format.formatter)
+    (stmts : stmt list) =
+  Format.pp_print_list (generate_stmt program) oc stmts
 
-and generate_stmt (program : program) (var_indexes : int VariableMap.t)
-    (oc : Format.formatter) (stmt : stmt) : unit =
+and generate_stmt (program : program) (oc : Format.formatter) (stmt : stmt) :
+    unit =
   match Pos.unmark stmt with
   | SRuleCall r ->
       let rule = RuleMap.find r program.rules in
       generate_rule_header oc rule
-  | SAssign (var, vdata) -> generate_var_def var_indexes var vdata oc
+  | SAssign (var, vdata) -> generate_var_def var vdata oc
   | SConditional (cond, tt, ff) ->
       let pos = Pos.get_position stmt in
       let fname =
@@ -337,22 +315,16 @@ and generate_stmt (program : program) (var_indexes : int VariableMap.t)
       Format.fprintf oc
         "MValue %s = %s;@,@[<hv 2>if (m_is_defined_true(%s)) {@,%a@]@,}"
         cond_name
-        (let s, _ =
-           generate_java_expr (Pos.same_pos_as cond stmt) var_indexes
-         in
+        (let s, _ = generate_java_expr (Pos.same_pos_as cond stmt) in
          s)
-        cond_name
-        (generate_stmts program var_indexes)
-        tt;
+        cond_name (generate_stmts program) tt;
       Format.fprintf oc " @[<hv 2>if (m_is_defined_false(%s)) {@,%a@]@,}"
-        cond_name
-        (generate_stmts program var_indexes)
-        ff
-  | SVerif v -> generate_var_cond var_indexes oc v
+        cond_name (generate_stmts program) ff
+  | SVerif v -> generate_var_cond oc v
   | SFunctionCall (f, _) ->
       Format.fprintf oc "MppFunction.%s(mCalculation, calculationErrors);" f
 
-let generate_return (var_indexes : int VariableMap.t) (oc : Format.formatter)
+let generate_return (oc : Format.formatter)
     (function_spec : Bir_interface.bir_function) =
   let returned_variables =
     List.map fst (VariableMap.bindings function_spec.func_outputs)
@@ -361,9 +333,7 @@ let generate_return (var_indexes : int VariableMap.t) (oc : Format.formatter)
     Format.pp_print_list
       (fun oc var ->
         Format.fprintf oc "outputVariables.put(\"%a\",tgv[%d/*\"%a\"*/]);"
-          format_var_name var
-          (get_var_pos var var_indexes)
-          format_var_name var)
+          format_var_name var (get_var_pos var) format_var_name var)
       oc returned_variables
   in
   Format.fprintf oc
@@ -376,8 +346,8 @@ let generate_return (var_indexes : int VariableMap.t) (oc : Format.formatter)
      }"
     print_outputs returned_variables
 
-let generate_rule_method (program : program) (var_indexes : int VariableMap.t)
-    (oc : Format.formatter) (rule : rule) =
+let generate_rule_method (program : program) (oc : Format.formatter)
+    (rule : rule) =
   Format.fprintf oc
     "@[<v 2>static void m_rule_%s(MCalculation mCalculation, List<MError> \
      calculationErrors) {@,\
@@ -388,21 +358,17 @@ let generate_rule_method (program : program) (var_indexes : int VariableMap.t)
      mCalculation.getTableVariables();@,\
      %a@]@,\
      }"
-    rule.rule_name
-    (generate_stmts program var_indexes)
-    rule.rule_stmts
+    rule.rule_name (generate_stmts program) rule.rule_stmts
 
-let generate_rule_methods (program : program) (oc : Format.formatter)
-    (var_indexes : int VariableMap.t) : unit =
+let generate_rule_methods (oc : Format.formatter) (program : program) : unit =
   let rules = RuleMap.bindings program.rules in
   let _, rules = List.split rules in
   Format.pp_print_list ~pp_sep:print_double_cut
-    (generate_rule_method program var_indexes)
+    (generate_rule_method program)
     oc rules
 
 let generate_calculateTax_method (calculation_vars_len : int)
-    (program : program) (locals_size : int) (oc : Format.formatter)
-    (var_indexes : int VariableMap.t) =
+    (program : program) (locals_size : int) (oc : Format.formatter) () =
   Format.fprintf oc
     "@[<v 0>/**@,\
      * Main calculation method for determining tax @,\
@@ -435,12 +401,11 @@ let generate_calculateTax_method (calculation_vars_len : int)
      }@]@,\
      @,"
     print_double_cut () calculation_vars_len locals_size print_double_cut ()
-    print_double_cut () print_double_cut ()
-    (generate_stmts program var_indexes)
+    print_double_cut () print_double_cut () (generate_stmts program)
     (Bir.main_statements program)
 
-let generate_mpp_function (program : program) (var_indexes : int VariableMap.t)
-    (oc : Format.formatter) (f : function_name) =
+let generate_mpp_function (program : program) (oc : Format.formatter)
+    (f : function_name) =
   let stmts = FunctionMap.find f program.mpp_functions in
   Format.fprintf oc
     "@[<v 2>static void %s(MCalculation mCalculation, List<MError> \
@@ -452,24 +417,20 @@ let generate_mpp_function (program : program) (var_indexes : int VariableMap.t)
      mCalculation.getTableVariables();@,\
      %a@]@,\
      }"
-    f
-    (generate_stmts program var_indexes)
-    stmts
+    f (generate_stmts program) stmts
 
-let generate_mpp_functions (program : program) (oc : Format.formatter)
-    (var_indexes : int VariableMap.t) =
+let generate_mpp_functions (oc : Format.formatter) (program : program) =
   let functions =
     FunctionMap.bindings (Bir_interface.context_agnostic_mpp_functions program)
   in
   let function_names, _ = List.split functions in
   Format.pp_print_list ~pp_sep:print_double_cut
-    (generate_mpp_function program var_indexes)
+    (generate_mpp_function program)
     oc function_names
 
 let generate_main_class (program : program) (var_table_size : int)
-    (locals_size : int) (var_indexes : int VariableMap.t)
-    (function_spec : Bir_interface.bir_function) (fmt : Format.formatter)
-    (filename : string) =
+    (locals_size : int) (function_spec : Bir_interface.bir_function)
+    (fmt : Format.formatter) (filename : string) =
   let class_name =
     String.split_on_char '.' filename |> List.hd |> String.split_on_char '/'
     |> fun list -> List.nth list (List.length list - 1)
@@ -486,9 +447,7 @@ let generate_main_class (program : program) (var_table_size : int)
      }"
     Prelude.message java_imports class_name
     (generate_calculateTax_method var_table_size program locals_size)
-    var_indexes
-    (generate_return var_indexes)
-    function_spec
+    () generate_return function_spec
 
 let generate_java_program (program : program) (function_spec : Bir_interface.bir_function)
     (filename : string) : unit =
@@ -496,21 +455,19 @@ let generate_java_program (program : program) (function_spec : Bir_interface.bir
   let _oc = open_out filename in
   let oc = Format.formatter_of_out_channel _oc in
   let locals_size = Bir.get_locals_size program |> ( + ) 1 in
-  let var_indexes, var_table_size =
-    Bir_interface.get_variables_indexes program function_spec
-  in
-   let program = Bir.squish_statements program split_treshold "java_rule_" in
+  let var_table_size = Bir.size_of_tgv () in
+  let program = Bir.squish_statements program split_treshold "java_rule_" in
   Format.fprintf oc
     "@[<v 0>%a%a\
      @[<v 2>class InputHandler {@,%a@]@,}%a\
      @[<v 2>class MppFunction {@,%a@]@,}%a\
      @[<hv 2>class Rule {@,%a@]@,}@]@."
      (generate_main_class program var_table_size locals_size
-            var_indexes function_spec) filename
+             function_spec) filename
      print_double_cut ()
-     (generate_input_handling function_spec var_indexes) split_treshold
+     (generate_input_handling function_spec) split_treshold
      print_double_cut ()
-     (generate_mpp_functions program) var_indexes
+     generate_mpp_functions program
      print_double_cut ()
-     (generate_rule_methods program) var_indexes;
+     generate_rule_methods program;
   close_out _oc[@@ocamlformat "disable"]

--- a/src/mlang/backend_compilers/bir_to_java.ml
+++ b/src/mlang/backend_compilers/bir_to_java.ml
@@ -217,7 +217,7 @@ let generate_var_def (var_indexes : int VariableMap.t) (var : variable)
   | InputVar -> assert false
 
 let generate_input_handling (function_spec : Bir_interface.bir_function)
-    (var_indexes : variable_id VariableMap.t) (oc : Format.formatter)
+    (var_indexes : int VariableMap.t) (oc : Format.formatter)
     (split_threshold : int) =
   let input_vars =
     List.map fst (VariableMap.bindings function_spec.func_variable_inputs)
@@ -352,8 +352,8 @@ and generate_stmt (program : program) (var_indexes : int VariableMap.t)
   | SFunctionCall (f, _) ->
       Format.fprintf oc "MppFunction.%s(mCalculation, calculationErrors);" f
 
-let generate_return (var_indexes : variable_id VariableMap.t)
-    (oc : Format.formatter) (function_spec : Bir_interface.bir_function) =
+let generate_return (var_indexes : int VariableMap.t) (oc : Format.formatter)
+    (function_spec : Bir_interface.bir_function) =
   let returned_variables =
     List.map fst (VariableMap.bindings function_spec.func_outputs)
   in
@@ -402,7 +402,7 @@ let generate_rule_methods (program : program) (oc : Format.formatter)
 
 let generate_calculateTax_method (calculation_vars_len : int)
     (program : program) (locals_size : int) (oc : Format.formatter)
-    (var_indexes : variable_id VariableMap.t) =
+    (var_indexes : int VariableMap.t) =
   Format.fprintf oc
     "@[<v 0>/**@,\
      * Main calculation method for determining tax @,\
@@ -457,7 +457,7 @@ let generate_mpp_function (program : program) (var_indexes : int VariableMap.t)
     stmts
 
 let generate_mpp_functions (program : program) (oc : Format.formatter)
-    (var_indexes : variable_id VariableMap.t) =
+    (var_indexes : int VariableMap.t) =
   let functions =
     FunctionMap.bindings (Bir_interface.context_agnostic_mpp_functions program)
   in
@@ -467,7 +467,7 @@ let generate_mpp_functions (program : program) (oc : Format.formatter)
     oc function_names
 
 let generate_main_class (program : program) (var_table_size : int)
-    (locals_size : int) (var_indexes : variable_id VariableMap.t)
+    (locals_size : int) (var_indexes : int VariableMap.t)
     (function_spec : Bir_interface.bir_function) (fmt : Format.formatter)
     (filename : string) =
   let class_name =

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -28,8 +28,6 @@ let compare_variable v1 v2 =
   let c = String.compare v1.on_tgv v2.on_tgv in
   if c = 0 then Stdlib.compare v1.offset v2.offset else c
 
-type variable_id = Mir.variable_id
-
 module VariableMap = Map.Make (struct
   type t = variable
 

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -26,7 +26,10 @@ type variable = { on_tgv : tgv_id; offset : int; mir_var : Mir.Variable.t }
 
 let compare_variable v1 v2 =
   let c = String.compare v1.on_tgv v2.on_tgv in
-  if c = 0 then Stdlib.compare v1.offset v2.offset else c
+  if c <> 0 then c
+  else
+    let c = Stdlib.compare v1.offset v2.offset in
+    if c <> 0 then c else Mir.Variable.compare v1.mir_var v2.mir_var
 
 module VariableMap = Map.Make (struct
   type t = variable

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -292,28 +292,9 @@ let rec remove_empty_conditionals (stmts : stmt list) : stmt list =
          | _ -> stmt :: acc)
        [] stmts)
 
-let rec get_used_variables_ (e : expression Pos.marked) (acc : VariableSet.t) :
+let get_used_variables_ (e : expression Pos.marked) (acc : VariableSet.t) :
     VariableSet.t =
-  match Pos.unmark e with
-  | Mir.Comparison (_, e1, e2) | Mir.Binop (_, e1, e2) | Mir.LocalLet (_, e1, e2)
-    ->
-      let acc = get_used_variables_ e1 acc in
-      let acc = get_used_variables_ e2 acc in
-      acc
-  | Mir.Unop (_, e) -> get_used_variables_ e acc
-  | Mir.Index ((var, _), e) ->
-      let acc = VariableSet.add var acc in
-      let acc = get_used_variables_ e acc in
-      acc
-  | Mir.Conditional (e1, e2, e3) ->
-      let acc = get_used_variables_ e1 acc in
-      let acc = get_used_variables_ e2 acc in
-      let acc = get_used_variables_ e3 acc in
-      acc
-  | Mir.FunctionCall (_, args) ->
-      List.fold_left (fun acc arg -> get_used_variables_ arg acc) acc args
-  | Mir.LocalVar _ | Mir.Literal _ | Mir.GenericTableIndex | Mir.Error -> acc
-  | Mir.Var var -> VariableSet.add var acc
+  Mir.fold_expr_var (fun acc var -> VariableSet.add var acc) acc (Pos.unmark e)
 
 let get_used_variables (e : expression Pos.marked) : VariableSet.t =
   get_used_variables_ e VariableSet.empty

--- a/src/mlang/backend_ir/bir.mli
+++ b/src/mlang/backend_ir/bir.mli
@@ -18,6 +18,8 @@ type rule_id = Mir.rule_id
 
 module RuleMap = Mir.RuleMap
 
+type tgv_id = string
+
 type variable
 
 type variable_id = int
@@ -84,15 +86,17 @@ type program = {
   outputs : unit VariableMap.t;
 }
 
-val var_from_mir : Mir.Variable.t -> variable
+val default_tgv : tgv_id
+
+val var_from_mir : tgv_id -> Mir.Variable.t -> variable
 
 val var_to_mir : variable -> Mir.Variable.t
 
 val compare_variable : variable -> variable -> int
 
-val map_from_mir_map : 'a Mir.VariableMap.t -> 'a VariableMap.t
+val map_from_mir_map : tgv_id -> 'a Mir.VariableMap.t -> 'a VariableMap.t
 
-val dict_from_mir_dict : Mir.VariableDict.t -> VariableDict.t
+val dict_from_mir_dict : tgv_id -> Mir.VariableDict.t -> VariableDict.t
 
 val main_statements : program -> stmt list
 

--- a/src/mlang/backend_ir/bir.mli
+++ b/src/mlang/backend_ir/bir.mli
@@ -22,7 +22,7 @@ type tgv_id = string
 
 type variable
 
-type variable_id = int
+(* type variable_id = int *)
 
 module VariableMap : Map.S with type key = variable
 

--- a/src/mlang/backend_ir/bir.mli
+++ b/src/mlang/backend_ir/bir.mli
@@ -26,31 +26,7 @@ type variable_id = int
 
 module VariableMap : Map.S with type key = variable
 
-module VariableDict : sig
-  type t
-
-  val bindings : t -> (variable_id * variable) list
-
-  val add : variable -> t -> t
-
-  val empty : t
-
-  val find : variable_id -> t -> variable
-
-  val mem : variable -> t -> bool
-
-  val union : t -> t -> t
-
-  val inter : t -> t -> t
-
-  val fold : (variable -> 'b -> 'b) -> t -> 'b -> 'b
-
-  val singleton : variable -> t
-
-  val filter : (variable_id -> variable -> bool) -> t -> t
-
-  val for_all : (variable -> bool) -> t -> bool
-end
+module VariableSet : Set.S with type elt = variable
 
 type expression = variable Mir.expression_
 
@@ -96,7 +72,7 @@ val compare_variable : variable -> variable -> int
 
 val map_from_mir_map : tgv_id -> 'a Mir.VariableMap.t -> 'a VariableMap.t
 
-val dict_from_mir_dict : tgv_id -> Mir.VariableDict.t -> VariableDict.t
+val set_from_mir_dict : tgv_id -> Mir.VariableDict.t -> VariableSet.t
 
 val main_statements : program -> stmt list
 
@@ -110,7 +86,7 @@ val squish_statements : program -> int -> string -> program
     existing rules semantics, with these chunks being rule definitions and
     inserting rule calls in their place*)
 
-val get_assigned_variables : program -> VariableDict.t
+val get_assigned_variables : program -> VariableSet.t
 
 val get_local_variables : program -> unit Mir.LocalVariableMap.t
 
@@ -119,6 +95,6 @@ val get_locals_size : program -> int
 val remove_empty_conditionals : stmt list -> stmt list
 
 val get_used_variables_ :
-  expression Pos.marked -> VariableDict.t -> VariableDict.t
+  expression Pos.marked -> VariableSet.t -> VariableSet.t
 
-val get_used_variables : expression Pos.marked -> VariableDict.t
+val get_used_variables : expression Pos.marked -> VariableSet.t

--- a/src/mlang/backend_ir/bir.mli
+++ b/src/mlang/backend_ir/bir.mli
@@ -20,9 +20,7 @@ module RuleMap = Mir.RuleMap
 
 type tgv_id = string
 
-type variable
-
-(* type variable_id = int *)
+type variable = { on_tgv : tgv_id; offset : int; mir_var : Mir.Variable.t }
 
 module VariableMap : Map.S with type key = variable
 
@@ -63,6 +61,8 @@ type program = {
 }
 
 val default_tgv : tgv_id
+
+val size_of_tgv : unit -> int
 
 val var_from_mir : tgv_id -> Mir.Variable.t -> variable
 

--- a/src/mlang/backend_ir/bir_interface.ml
+++ b/src/mlang/backend_ir/bir_interface.ml
@@ -27,7 +27,7 @@ let get_variables_indexes (p : Bir.program) (function_spec : bir_function) :
     List.map fst (Bir.VariableMap.bindings function_spec.func_variable_inputs)
   in
   let assigned_variables =
-    List.map snd (Bir.VariableDict.bindings (Bir.get_assigned_variables p))
+    Bir.VariableSet.elements (Bir.get_assigned_variables p)
   in
   let output_vars =
     List.map fst (Bir.VariableMap.bindings function_spec.func_outputs)
@@ -200,7 +200,7 @@ let generate_function_all_vars (p : Bir.program) : bir_function =
   let input_vars =
     let program_input_vars =
       Mir.find_vars_by_io p.mir_program Input
-      |> Bir.(dict_from_mir_dict default_tgv)
+      |> Bir.(set_from_mir_dict default_tgv)
     in
     let max_exec_vars =
       Pos.VarNameToID.fold
@@ -209,12 +209,12 @@ let generate_function_all_vars (p : Bir.program) : bir_function =
             Mast_to_mir.list_max_execution_number v
             |> Bir.(var_from_mir default_tgv)
           in
-          Bir.VariableDict.add max_exec_var acc)
-        p.idmap Bir.VariableDict.empty
+          Bir.VariableSet.add max_exec_var acc)
+        p.idmap Bir.VariableSet.empty
     in
-    Bir.VariableDict.fold
+    Bir.VariableSet.fold
       (fun k acc -> Bir.VariableMap.add k () acc)
-      (Bir.VariableDict.inter program_input_vars max_exec_vars)
+      (Bir.VariableSet.inter program_input_vars max_exec_vars)
       Bir.VariableMap.empty
   in
   Cli.debug_print "Using all %d outputs and %d inputs from m sources"

--- a/src/mlang/backend_ir/bir_interface.ml
+++ b/src/mlang/backend_ir/bir_interface.ml
@@ -21,39 +21,6 @@ type bir_function = {
   func_conds : Bir.condition_data Bir.VariableMap.t;
 }
 
-let get_variables_indexes (p : Bir.program) (function_spec : bir_function) :
-    int Bir.VariableMap.t * int =
-  let input_vars =
-    List.map fst (Bir.VariableMap.bindings function_spec.func_variable_inputs)
-  in
-  let assigned_variables =
-    Bir.VariableSet.elements (Bir.get_assigned_variables p)
-  in
-  let output_vars =
-    List.map fst (Bir.VariableMap.bindings function_spec.func_outputs)
-  in
-  let all_relevant_variables =
-    List.fold_left
-      (fun acc var -> Bir.VariableMap.add var () acc)
-      Bir.VariableMap.empty
-      (input_vars @ assigned_variables @ output_vars)
-  in
-  let counter = ref 0 in
-  let var_indexes =
-    Bir.VariableMap.mapi
-      (fun var _ ->
-        let id = !counter in
-        let size =
-          match (Bir.var_to_mir var).Mir.Variable.is_table with
-          | None -> 1
-          | Some size -> size
-        in
-        counter := !counter + size;
-        id)
-      all_relevant_variables
-  in
-  (var_indexes, !counter)
-
 let var_set_from_variable_name_list (p : Bir.program)
     (names : string Pos.marked list) : unit Bir.VariableMap.t =
   List.fold_left

--- a/src/mlang/backend_ir/bir_interface.ml
+++ b/src/mlang/backend_ir/bir_interface.ml
@@ -59,7 +59,7 @@ let var_set_from_variable_name_list (p : Bir.program)
   List.fold_left
     (fun acc name ->
       let var = Mir.find_var_by_name p.mir_program name in
-      Bir.VariableMap.add (Bir.var_from_mir var) () acc)
+      Bir.VariableMap.add (Bir.var_from_mir Bir.default_tgv var) () acc)
     Bir.VariableMap.empty names
 
 let check_const_expression_is_really_const (e : Mir.expression Pos.marked) :
@@ -85,7 +85,7 @@ let const_var_set_from_list (p : Bir.program)
                  compare v1.Mir.Variable.execution_number
                    v2.Mir.Variable.execution_number)
                (Pos.VarNameToID.find (Pos.unmark name) p.idmap))
-          |> Bir.var_from_mir
+          |> Bir.(var_from_mir default_tgv)
         with Not_found -> (
           try
             let name = Mir.find_var_name_by_alias p.mir_program name in
@@ -95,7 +95,7 @@ let const_var_set_from_list (p : Bir.program)
                    compare v1.Mir.Variable.execution_number
                      v2.Mir.Variable.execution_number)
                  (Pos.VarNameToID.find name p.idmap))
-            |> Bir.var_from_mir
+            |> Bir.(var_from_mir default_tgv)
           with Errors.StructuredError _ ->
             Errors.raise_spanned_error
               (Format.asprintf "unknown variable %s" (Pos.unmark name))
@@ -114,7 +114,9 @@ let const_var_set_from_list (p : Bir.program)
       in
       check_const_expression_is_really_const new_e;
       Bir.VariableMap.add var
-        (Pos.map_under_mark (Mir.map_expr_var Bir.var_from_mir) new_e)
+        (Pos.map_under_mark
+           (Mir.map_expr_var Bir.(var_from_mir default_tgv))
+           new_e)
         acc)
     Bir.VariableMap.empty names
 
@@ -182,27 +184,30 @@ let translate_external_conditions idmap
   in
   Mir.VariableMap.fold
     (fun v data acc ->
-      Bir.VariableMap.add (Bir.var_from_mir v)
-        (Mir.map_cond_data_var Bir.var_from_mir data)
+      Bir.VariableMap.add
+        Bir.(var_from_mir default_tgv v)
+        (Mir.map_cond_data_var Bir.(var_from_mir default_tgv) data)
         acc)
     conds Bir.VariableMap.empty
 
 let generate_function_all_vars (p : Bir.program) : bir_function =
   let output_vars =
     Mir.VariableDict.fold
-      (fun k acc -> Bir.VariableMap.add (Bir.var_from_mir k) () acc)
+      (fun k acc -> Bir.VariableMap.add Bir.(var_from_mir default_tgv k) () acc)
       (Mir.find_vars_by_io p.mir_program Output)
       Bir.VariableMap.empty
   in
   let input_vars =
     let program_input_vars =
-      Mir.find_vars_by_io p.mir_program Input |> Bir.dict_from_mir_dict
+      Mir.find_vars_by_io p.mir_program Input
+      |> Bir.(dict_from_mir_dict default_tgv)
     in
     let max_exec_vars =
       Pos.VarNameToID.fold
         (fun _ v acc ->
           let max_exec_var =
-            Mast_to_mir.list_max_execution_number v |> Bir.var_from_mir
+            Mast_to_mir.list_max_execution_number v
+            |> Bir.(var_from_mir default_tgv)
           in
           Bir.VariableDict.add max_exec_var acc)
         p.idmap Bir.VariableDict.empty
@@ -310,12 +315,15 @@ let adapt_program_to_function (p : Bir.program) (f : bir_function) :
       (fun var def acc ->
         match def.Mir.var_definition with
         | Mir.InputVar ->
-            if Bir.VariableMap.mem (Bir.var_from_mir var) f.func_variable_inputs
+            if
+              Bir.VariableMap.mem
+                Bir.(var_from_mir default_tgv var)
+                f.func_variable_inputs
             then acc
             else
               let pos = Pos.no_pos in
               ( Bir.SAssign
-                  ( Bir.var_from_mir var,
+                  ( Bir.(var_from_mir default_tgv) var,
                     {
                       Mir.var_typ = None;
                       Mir.var_io = Regular;

--- a/src/mlang/backend_ir/bir_interface.mli
+++ b/src/mlang/backend_ir/bir_interface.mli
@@ -24,9 +24,6 @@ type bir_function = {
 }
 (** Input-output data necessary to interpret a BIR program*)
 
-val get_variables_indexes :
-  Bir.program -> bir_function -> int Bir.VariableMap.t * int
-
 val translate_external_conditions :
   Mir.idmap ->
   Mast.expression Pos.marked list ->

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -305,7 +305,7 @@ module Make (N : Bir_number.NumberInterface) = struct
           List.iter
             Mir.(
               fun var ->
-                let bvar = Bir.var_from_mir var in
+                let bvar = Bir.(var_from_mir default_tgv) var in
                 try
                   let var_l = Bir.VariableMap.find bvar ctx.ctx_vars in
                   Format.printf "[%a %a] -> %a@\n"
@@ -628,7 +628,7 @@ module Make (N : Bir_number.NumberInterface) = struct
                           (var, Bir.VariableMap.find var ctx.ctx_vars) :: acc)
                         []
                         (List.map
-                           (fun (_, x) -> Bir.var_from_mir x)
+                           (fun (_, x) -> Bir.(var_from_mir default_tgv) x)
                            (Mir.VariableDict.bindings
                               (Mir_dependency_graph.get_used_variables
                                  (Pos.map_under_mark

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -292,43 +292,24 @@ module VariableMap = struct
       map
 end
 
-module VariableDictMap = Map.Make (struct
+(* module VariableDictMap = Map.Make (struct
+ *   type t = Variable.id
+ * 
+ *   let compare = compare
+ * end)
+ * 
+ * type variable_dict = variable VariableDictMap.t *)
+
+(** Variable dictionary, act as a set but refered by keys *)
+module VariableDict = Dict.Make (struct
   type t = Variable.id
+
+  type elt = Variable.t
+
+  let key_of_elt v = v.Variable.id
 
   let compare = compare
 end)
-
-type variable_dict = variable VariableDictMap.t
-
-(** Variable dictionary, act as a set but refered by keys *)
-module VariableDict = struct
-  type t = variable_dict
-
-  let find = VariableDictMap.find
-
-  let filter = VariableDictMap.filter
-
-  let empty = VariableDictMap.empty
-
-  let bindings = VariableDictMap.bindings
-
-  let singleton v = VariableDictMap.singleton v.Variable.id v
-
-  let add v t = VariableDictMap.add v.Variable.id v t
-
-  let mem v t = VariableDictMap.mem v.Variable.id t
-
-  let fold f t acc = VariableDictMap.fold (fun _ v acc -> f v acc) t acc
-
-  let union t1 t2 = VariableDictMap.union (fun _ v _ -> Some v) t1 t2
-
-  let inter t1 t2 =
-    VariableDictMap.merge
-      (fun _ v1 v2 -> match (v1, v2) with Some _, Some _ -> v1 | _ -> None)
-      t1 t2
-
-  let for_all f t = VariableDictMap.for_all (fun _ v -> f v) t
-end
 
 module VariableSet = Set.Make (Variable)
 

--- a/src/mlang/m_ir/mir.mli
+++ b/src/mlang/m_ir/mir.mli
@@ -125,9 +125,7 @@ module VariableMap : sig
     unit
 end
 
-module VariableDictMap : Map.S with type key = variable_id
-
-type variable_dict = variable VariableDictMap.t
+module VariableDict : Dict.S with type key = variable_id and type elt = variable
 
 module VariableSet : Set.S with type elt = variable
 
@@ -213,7 +211,7 @@ type idmap = variable list Pos.VarNameToID.t
 type exec_pass = { exec_pass_set_variables : literal Pos.marked VariableMap.t }
 
 type program = {
-  program_vars : variable_dict;
+  program_vars : VariableDict.t;
       (** A static register of all variables that can be used during a
           calculation *)
   program_rules : rule_data RuleMap.t;
@@ -294,33 +292,6 @@ module Error : sig
   val err_descr_string : t -> string Pos.marked
 
   val compare : t -> t -> int
-end
-
-(** Variable dictionary, act as a set but refered by keys *)
-module VariableDict : sig
-  type t = variable_dict
-
-  val bindings : t -> (variable_id * variable) list
-
-  val add : variable -> t -> t
-
-  val empty : t
-
-  val find : variable_id -> t -> variable
-
-  val mem : variable -> t -> bool
-
-  val union : t -> t -> t
-
-  val inter : t -> t -> t
-
-  val fold : (variable -> 'b -> 'b) -> t -> 'b -> 'b
-
-  val singleton : variable -> t
-
-  val filter : (variable_id -> variable -> bool) -> t -> t
-
-  val for_all : (variable -> bool) -> t -> bool
 end
 
 val false_literal : literal

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -74,7 +74,7 @@ let generate_input_condition (crit : Mir.Variable.t -> bool)
   (* this might do wierd thing iif all variables to check are not "saisie" since
      the filter may find duplicates used in different contexts *)
   let variables_to_check =
-    Bir.dict_from_mir_dict Bir.default_tgv
+    Bir.set_from_mir_dict Bir.default_tgv
     @@ Mir.VariableDict.filter (fun _ var -> crit var) p.program.program_vars
   in
   let mk_call_present x =
@@ -82,7 +82,7 @@ let generate_input_condition (crit : Mir.Variable.t -> bool)
   in
   let mk_or e1 e2 = (Mir.Binop ((Or, pos), e1, e2), pos) in
   let mk_false = (Mir.Literal (Float 0.), pos) in
-  Bir.VariableDict.fold
+  Bir.VariableSet.fold
     (fun var acc -> mk_or (mk_call_present var) acc)
     variables_to_check mk_false
 

--- a/src/mlang/optimizing_ir/dead_code_removal.ml
+++ b/src/mlang/optimizing_ir/dead_code_removal.ml
@@ -25,9 +25,9 @@ let remove_dead_statements (stmts : block) (id : block_id)
     =
   (* used_vars contains, for each variable, the location of the top-most use of
      this variables in every basic block *)
-  let update_used_vars (stmt_used_vars : Bir.VariableDict.t) (pos : int)
+  let update_used_vars (stmt_used_vars : Bir.VariableSet.t) (pos : int)
       (used_vars : pos_map) : pos_map =
-    Bir.VariableDict.fold
+    Bir.VariableSet.fold
       (fun stmt_used_var (used_vars : pos_map) ->
         Bir.VariableMap.update stmt_used_var
           (function
@@ -46,7 +46,7 @@ let remove_dead_statements (stmts : block) (id : block_id)
         match Pos.unmark stmt with
         | SAssign (var, var_def) ->
             let used_defs_returned =
-              update_used_vars (Bir.VariableDict.singleton var) pos used_defs
+              update_used_vars (Bir.VariableSet.singleton var) pos used_defs
             in
             if
               (* here we determine whether this definition is useful or not *)
@@ -117,7 +117,7 @@ let remove_dead_statements (stmts : block) (id : block_id)
                         Mir.IndexMap.fold
                           (fun _ e used_vars ->
                             Bir.get_used_variables_ e used_vars)
-                          es Bir.VariableDict.empty)
+                          es Bir.VariableSet.empty)
                 | Mir.InputVar -> assert false
                 (* should not happen *)
               in

--- a/src/mlang/optimizing_ir/inlining.ml
+++ b/src/mlang/optimizing_ir/inlining.ml
@@ -141,7 +141,7 @@ let rec inline_in_expr (e : Bir.expression) (ctx : ctx)
                                  current_block)
                         var_defs
                     in
-                    Bir.VariableDict.for_all
+                    Bir.VariableSet.for_all
                       (fun var ->
                         not (exists_def_between_previous_x_def_and_here var))
                       vars_used_in_previous_x_def

--- a/src/mlang/test_framework/test_interpreter.ml
+++ b/src/mlang/test_framework/test_interpreter.ml
@@ -65,7 +65,8 @@ let to_MIR_function_and_inputs (program : Bir.program) (t : test_file)
     List.fold_left
       (fun (fv, in_f) (var, value, pos) ->
         let var =
-          find_var_of_name program.mir_program (var, pos) |> Bir.var_from_mir
+          find_var_of_name program.mir_program (var, pos)
+          |> Bir.(var_from_mir default_tgv)
         in
         let lit =
           match value with I i -> Mir.Float (float_of_int i) | F f -> Float f

--- a/src/mlang/utils/dict.ml
+++ b/src/mlang/utils/dict.ml
@@ -1,0 +1,73 @@
+module type S = sig
+  type key
+
+  type elt
+
+  type t
+
+  val bindings : t -> (key * elt) list
+
+  val add : elt -> t -> t
+
+  val empty : t
+
+  val find : key -> t -> elt
+
+  val mem : elt -> t -> bool
+
+  val union : t -> t -> t
+
+  val inter : t -> t -> t
+
+  val fold : (elt -> 'b -> 'b) -> t -> 'b -> 'b
+
+  val singleton : elt -> t
+
+  val filter : (key -> elt -> bool) -> t -> t
+
+  val for_all : (elt -> bool) -> t -> bool
+end
+
+module Make (I : sig
+  type t
+
+  type elt
+
+  val key_of_elt : elt -> t
+
+  val compare : t -> t -> int
+end) =
+struct
+  module DictMap = Map.Make (I)
+
+  type key = I.t
+
+  type elt = I.elt
+
+  type t = I.elt DictMap.t
+
+  let find = DictMap.find
+
+  let filter = DictMap.filter
+
+  let empty = DictMap.empty
+
+  let bindings = DictMap.bindings
+
+  let singleton v = DictMap.singleton (I.key_of_elt v) v
+
+  let add v t = DictMap.add (I.key_of_elt v) v t
+
+  let mem v t = DictMap.mem (I.key_of_elt v) t
+
+  let fold f t acc = DictMap.fold (fun _ v acc -> f v acc) t acc
+
+  let union t1 t2 = DictMap.union (fun _ v _ -> Some v) t1 t2
+
+  let inter t1 t2 =
+    DictMap.merge
+      (fun _ v1 v2 -> match (v1, v2) with Some _, Some _ -> v1 | _ -> None)
+      t1 t2
+
+  let for_all f t = DictMap.for_all (fun _ v -> f v) t
+end

--- a/src/mlang/utils/dict.mli
+++ b/src/mlang/utils/dict.mli
@@ -1,0 +1,41 @@
+module type S = sig
+  type key
+
+  type elt
+
+  type t
+
+  val bindings : t -> (key * elt) list
+
+  val add : elt -> t -> t
+
+  val empty : t
+
+  val find : key -> t -> elt
+
+  val mem : elt -> t -> bool
+
+  val union : t -> t -> t
+
+  val inter : t -> t -> t
+
+  val fold : (elt -> 'b -> 'b) -> t -> 'b -> 'b
+
+  val singleton : elt -> t
+
+  val filter : (key -> elt -> bool) -> t -> t
+
+  val for_all : (elt -> bool) -> t -> bool
+end
+
+module Make : functor
+  (I : sig
+     type t
+
+     type elt
+
+     val key_of_elt : elt -> t
+
+     val compare : t -> t -> int
+   end)
+  -> S with type key = I.t and type elt = I.elt


### PR DESCRIPTION
This is bound to change further in the futur, but is good enough for our immediate needs.

We now represent TGV variables as offset of a given TGV in the backend. It will be useful for copies handling.

Most changes in the backend code generation are the direct consequences of the existence of an offset upstream, making `var_indexes` useless. Reviewers shouldn't need to look too hard on those. 