### PR TITLE
Relax M table access to variables

### DIFF
--- a/src/mlang/backend_compilers/bir_to_c.ml
+++ b/src/mlang/backend_compilers/bir_to_c.ml
@@ -134,7 +134,6 @@ let rec generate_c_expr (e : expression Pos.marked) :
   | Literal Undefined -> (Format.asprintf "%s" none_value, [])
   | Var var -> (Format.asprintf "%a" (generate_variable None) var, [])
   | LocalVar lvar -> (Format.asprintf "LOCAL[%d]" lvar.Mir.LocalVariable.id, [])
-  | GenericTableIndex -> (Format.asprintf "m_literal(generic_index)", [])
   | Error -> assert false (* should not happen *)
   | LocalLet (lvar, e1, e2) ->
       let _, s1 = generate_c_expr e1 in

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -219,8 +219,6 @@ let rec generate_c_expr (e : expression Pos.marked)
         value_comp = "mlocal" ^ string_of_int lvar.Mir.LocalVariable.id;
         locals = [];
       }
-  | GenericTableIndex ->
-      { def_test = "1"; value_comp = "generic_index"; locals = [] }
   | Error -> assert false (* should not happen *)
   | LocalLet (lvar, e1, e2) ->
       let se1 = generate_c_expr e1 var_indexes in

--- a/src/mlang/backend_compilers/bir_to_java.ml
+++ b/src/mlang/backend_compilers/bir_to_java.ml
@@ -153,7 +153,6 @@ let rec generate_java_expr (e : expression Pos.marked) :
         [] )
   | LocalVar lvar ->
       (Format.asprintf "localVariables[%d]" lvar.Mir.LocalVariable.id, [])
-  | GenericTableIndex -> (Format.asprintf "new MValue(genericIndex)", [])
   | Error -> assert false (* should not happen *)
   | LocalLet (lvar, e1, e2) ->
       let _, s1 = generate_java_expr e1 in

--- a/src/mlang/backend_compilers/bir_to_java.ml
+++ b/src/mlang/backend_compilers/bir_to_java.ml
@@ -186,14 +186,14 @@ let generate_var_def (var : variable) (data : variable_data)
                 (get_var_pos var |> ( + ) i)
                 format_var_name var sv))
         es
-  | TableVar (size, IndexGeneric e) ->
+  | TableVar (_size, IndexGeneric (v, e)) ->
       let se, s = generate_java_expr e in
       Format.fprintf oc
-        "@[<hv 2>for (int genericIndex = 0; genericIndex < %d; genericIndex++) \
-         {@,\
-         @[<h 4> %atgv[%d + genericIndex /* %a */] = %s;@]@]@,\
-         }"
-        size format_local_vars_defs s (get_var_pos var) format_var_name var se
+        "if(!tgv[%d/* %a */].isUndefined())@[<hov 2>{@ %atgv[%d/* %a */ + \
+         (int)tgv[%d/* %a */].getValue()] = %s;@] }@,"
+        (get_var_pos v) format_var_name v format_local_vars_defs s
+        (get_var_pos var) format_var_name var (get_var_pos v) format_var_name v
+        se
   | InputVar -> assert false
 
 let generate_input_handling (function_spec : Bir_interface.bir_function)

--- a/src/mlang/backend_compilers/bir_to_python.ml
+++ b/src/mlang/backend_compilers/bir_to_python.ml
@@ -97,10 +97,12 @@ let undefined_class_prelude : string =
   \    if isinstance(x, Undefined): return x\n\
   \    else: return floor(x + 0.000001)\n\n\
    class GenericIndex:\n\
-  \    def __init__(self, lambda_function):\n\
+  \    def __init__(self, lambda_function, var):\n\
   \      self.l = lambda_function\n\
+  \      self.i = var\n\
   \    def __getitem__(self, x):\n\
-  \      return self.l(x)"
+  \      if isinstance(self.i, Undefined) or self.i != x: return x\n\
+  \      else: self.l(x)"
 
 let none_value = "Undefined()"
 
@@ -313,14 +315,14 @@ let generate_var_def (var : variable) (data : variable_data)
           Mir.IndexMap.iter (fun _ v ->
               Format.fprintf fmt "%a, " (generate_python_expr false) v))
         es
-  | TableVar (_, IndexGeneric e) ->
+  | TableVar (_, IndexGeneric (v, e)) ->
       if !verbose_output then
         Format.fprintf oc "# Defined %a@\n" Pos.format_position_short
           (Pos.get_position e);
-      Format.fprintf oc "%a = GenericIndex(lambda generic_index: %a)@\n@\n"
+      Format.fprintf oc "%a = GenericIndex(lambda index: %a, %a)@\n@\n"
         generate_tgv_variable var
         (generate_python_expr false)
-        e
+        e generate_tgv_variable v
   | InputVar -> assert false
 
 let generate_header (oc : Format.formatter) () : unit =

--- a/src/mlang/backend_compilers/bir_to_python.ml
+++ b/src/mlang/backend_compilers/bir_to_python.ml
@@ -290,7 +290,6 @@ let rec generate_python_expr safe_bool_binops fmt (e : expression Pos.marked) :
   | Literal Undefined -> Format.fprintf fmt "%s" none_value
   | Var var -> Format.fprintf fmt "%a" generate_tgv_variable var
   | LocalVar lvar -> Format.fprintf fmt "v%d" lvar.Mir.LocalVariable.id
-  | GenericTableIndex -> Format.fprintf fmt "generic_index"
   | Error -> assert false (* TODO *)
   | LocalLet (lvar, e1, e2) ->
       Format.fprintf fmt "(lambda v%d: %a)(%a)" lvar.Mir.LocalVariable.id

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -238,7 +238,7 @@ let get_local_variables (p : program) : unit Mir.LocalVariableMap.t =
           (fun (acc : unit Mir.LocalVariableMap.t) arg ->
             get_local_vars_expr acc arg)
           acc args
-    | Mir.Literal _ | Mir.Var _ | Mir.GenericTableIndex | Mir.Error -> acc
+    | Mir.Literal _ | Mir.Var _ | Mir.Error -> acc
     | Mir.LocalVar lvar -> Mir.LocalVariableMap.add lvar () acc
     | Mir.LocalLet (lvar, e1, e2) ->
         let acc = get_local_vars_expr acc e1 in

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -260,7 +260,7 @@ let get_local_variables (p : program) : unit Mir.LocalVariableMap.t =
                     Mir.IndexMap.fold
                       (fun _ e acc -> get_local_vars_expr acc e)
                       es acc
-                | Mir.IndexGeneric e -> get_local_vars_expr acc e)
+                | Mir.IndexGeneric (_v, e) -> get_local_vars_expr acc e)
             | _ -> acc)
         | SConditional (cond, s1, s2) ->
             let acc = get_local_vars_expr acc (cond, Pos.no_pos) in

--- a/src/mlang/backend_ir/bir_interface.ml
+++ b/src/mlang/backend_ir/bir_interface.ml
@@ -300,11 +300,20 @@ let adapt_program_to_function (p : Bir.program) (f : bir_function) :
                           | None ->
                               Mir.SimpleVar (Mir.Literal Mir.Undefined, pos)
                           | Some size ->
-                              Mir.TableVar
-                                ( size,
-                                  Mir.IndexGeneric
-                                    (Pos.same_pos_as (Mir.Literal Mir.Undefined)
-                                       var.Mir.Variable.name) )
+                              let idxmap =
+                                let rec loop i acc =
+                                  if i < 0 then acc
+                                  else
+                                    loop (i - 1)
+                                      (Mir.IndexMap.add i
+                                         (Pos.same_pos_as
+                                            (Mir.Literal Mir.Undefined)
+                                            var.Mir.Variable.name)
+                                         acc)
+                                in
+                                loop (size - 1) Mir.IndexMap.empty
+                              in
+                              Mir.TableVar (size, Mir.IndexTable idxmap)
                         end;
                     } ),
                 pos )

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -64,7 +64,6 @@ module type S = sig
   type ctx = {
     ctx_local_vars : value Pos.marked Mir.LocalVariableMap.t;
     ctx_vars : var_value Bir.VariableMap.t;
-    ctx_generic_index : int option;
   }
 
   val empty_ctx : ctx
@@ -160,14 +159,12 @@ module Make (N : Bir_number.NumberInterface) = struct
   type ctx = {
     ctx_local_vars : value Pos.marked Mir.LocalVariableMap.t;
     ctx_vars : var_value Bir.VariableMap.t;
-    ctx_generic_index : int option;
   }
 
   let empty_ctx : ctx =
     {
       ctx_local_vars = Mir.LocalVariableMap.empty;
       ctx_vars = Bir.VariableMap.empty;
-      ctx_generic_index = None;
     }
 
   let literal_to_value (l : Mir.literal) : value =
@@ -485,10 +482,6 @@ module Make (N : Bir_number.NumberInterface) = struct
                   (Pos.get_position e)
             in
             r
-        | GenericTableIndex -> (
-            match ctx.ctx_generic_index with
-            | None -> assert false (* should not happen *)
-            | Some i -> Number (N.of_int (Int64.of_int i)))
         | Error ->
             raise
               (RuntimeError

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -529,9 +529,8 @@ module Make (N : Bir_number.NumberInterface) = struct
             | _ -> true_value ())
         | FunctionCall (NullFunc, [ arg ]) -> (
             match evaluate_expr ctx p arg with
-              | Undefined -> Undefined
-              | Number f ->
-                if N.is_zero f then true_value () else false_value ())
+            | Undefined -> Undefined
+            | Number f -> if N.is_zero f then true_value () else false_value ())
         | FunctionCall (MinFunc, [ arg1; arg2 ]) -> (
             match (evaluate_expr ctx p arg1, evaluate_expr ctx p arg2) with
             | Undefined, Number f | Number f, Undefined ->
@@ -649,20 +648,52 @@ module Make (N : Bir_number.NumberInterface) = struct
           (Pos.unmark (Mir.Error.err_descr_string err));
         ctx
 
-  let evaluate_variable (p : Bir.program) (ctx : ctx)
+  let evaluate_variable (p : Bir.program) (ctx : ctx) (curr_value : var_value)
       (vdef : Bir.variable Mir.variable_def_) : var_value =
     match vdef with
     | Mir.SimpleVar e -> SimpleVar (evaluate_expr ctx p.mir_program e)
     | Mir.TableVar (size, es) ->
         TableVar
           ( size,
-            Array.init size (fun idx ->
-                match es with
-                | IndexGeneric e ->
-                    evaluate_expr
-                      { ctx with ctx_generic_index = Some idx }
-                      p.mir_program e
-                | IndexTable es ->
+            match es with
+            | IndexGeneric (v, e) ->
+                let i =
+                  match Bir.VariableMap.find v ctx.ctx_vars with
+                  | SimpleVar n -> n
+                  | TableVar _ -> assert false
+                  (* should not happen *)
+                  | exception Not_found ->
+                      raise
+                        (RuntimeError
+                           ( ErrorValue
+                               ( "no value found for dynamic index",
+                                 Pos.get_position e ),
+                             ctx ))
+                in
+                let tval =
+                  match curr_value with
+                  | SimpleVar _ -> assert false (* should not happen *)
+                  | TableVar (s, vals) ->
+                      assert (s = size);
+                      vals
+                in
+                (match i with
+                | Undefined -> ()
+                | Number f ->
+                    let i = int_of_float (N.to_float f) in
+                    if i < 0 || i >= size then
+                      raise
+                        (RuntimeError
+                           ( IndexOutOfBounds
+                               ("dynamic index out of bound", Pos.get_position e),
+                             ctx )));
+                Array.init size (fun idx ->
+                    match i with
+                    | Number f when int_of_float (N.to_float f) = idx ->
+                        evaluate_expr ctx p.mir_program e
+                    | Number _ | Undefined -> tval.(idx))
+            | IndexTable es ->
+                Array.init size (fun idx ->
                     let e = Mir.IndexMap.find idx es in
                     evaluate_expr ctx p.mir_program e) )
     | Mir.InputVar -> assert false
@@ -671,11 +702,21 @@ module Make (N : Bir_number.NumberInterface) = struct
       (loc : code_location) =
     match Pos.unmark stmt with
     | Bir.SAssign (var, vdata) ->
-        let res = evaluate_variable p ctx vdata.var_definition in
+        let value =
+          try Bir.VariableMap.find var ctx.ctx_vars
+          with Not_found -> (
+            match (Bir.var_to_mir var).is_table with
+            | Some size -> TableVar (size, Array.make size Undefined)
+            | None -> SimpleVar Undefined)
+        in
+        let res = evaluate_variable p ctx value vdata.var_definition in
         !assign_hook var (fun _ -> var_value_to_var_literal res) loc;
         { ctx with ctx_vars = Bir.VariableMap.add var res ctx.ctx_vars }
     | Bir.SConditional (b, t, f) -> (
-        match evaluate_variable p ctx (SimpleVar (b, Pos.no_pos)) with
+        match
+          evaluate_variable p ctx (SimpleVar Undefined)
+            (SimpleVar (b, Pos.no_pos))
+        with
         | SimpleVar (Number z) when N.(z =. zero ()) ->
             evaluate_stmts p ctx f (ConditionalBranch false :: loc) 0
         | SimpleVar (Number _) ->

--- a/src/mlang/backend_ir/bir_interpreter.mli
+++ b/src/mlang/backend_ir/bir_interpreter.mli
@@ -83,7 +83,6 @@ module type S = sig
   type ctx = {
     ctx_local_vars : value Pos.marked Mir.LocalVariableMap.t;
     ctx_vars : var_value Bir.VariableMap.t;
-    ctx_generic_index : int option;
   }
   (** Interpretation context *)
 

--- a/src/mlang/m_frontend/mast_to_mir.ml
+++ b/src/mlang/m_frontend/mast_to_mir.ml
@@ -254,25 +254,22 @@ let get_var_from_name_lax (d : Mir.Variable.t list Pos.VarNameToID.t)
 
 (**{2 Loops}*)
 
+type var_or_int_index = VarIndex of Mast.variable | IntIndex of int
+
 (** The M language added a new feature in its 2017 edition : you can specify
     loop variable ranges bounds with constant variables. Because we need the
     actual value of the bounds to unroll everything, this function queries the
     const value in the context if needed. *)
 let var_or_int_value (ctx : translating_context) (l : Mast.literal Pos.marked) :
-    int =
+    var_or_int_index =
   match Pos.unmark l with
   | Mast.Variable v -> (
       try
-        (* We look up the value of the variable, which has to be const *)
+        (* We look up the value of the variable, which may be const *)
         let name = Mast.get_variable_name v in
-        ConstMap.find name ctx.const_map |> Pos.unmark |> int_of_float
-      with Not_found ->
-        Errors.raise_spanned_error
-          (Format.asprintf
-             "variable %s is not an integer constant and cannot be used here"
-             (Mast.get_variable_name v))
-          (Pos.get_position l))
-  | Mast.Float f -> int_of_float f
+        IntIndex (ConstMap.find name ctx.const_map |> Pos.unmark |> int_of_float)
+      with Not_found -> VarIndex v)
+  | Mast.Float f -> IntIndex (int_of_float f)
 
 let loop_variables_size (lpvl : loop_param_value list) (pos : Pos.t) =
   let size_err p =
@@ -357,9 +354,19 @@ let translate_loop_variables (lvs : Mast.loop_variables Pos.marked)
                        match value with
                        | Mast.Single l -> [ var_or_int l ]
                        | Mast.Range (l1, l2) -> make_range_list l1 l2
-                       | Mast.Interval (l1, l2) ->
-                           make_int_range_list (var_or_int_value ctx l1)
-                             (var_or_int_value ctx l2))
+                       | Mast.Interval (l1, l2) -> (
+                           let lb = var_or_int_value ctx l1 in
+                           let ub = var_or_int_value ctx l2 in
+                           match (lb, ub) with
+                           | VarIndex v, _ | _, VarIndex v ->
+                               Errors.raise_spanned_error
+                                 (Format.asprintf
+                                    "variable %s is not an integer constant \
+                                     and cannot be used here"
+                                    (Mast.get_variable_name v))
+                                 pos
+                           | IntIndex lb, IntIndex ub ->
+                               make_int_range_list lb ub))
                      values)
               in
               let sz = loop_variables_size values pos in
@@ -385,14 +392,10 @@ let translate_loop_variables (lvs : Mast.loop_variables Pos.marked)
     replace *inside the string* the loop parameter by its value to produce the
     new variable. *)
 
-(** A variable whose name is [X] should be translated as the generic table index
-    expression. However sometimes there is a variable called [X] (yes...) so if
-    there is no loop in the context we return the variable [X] for ["X"]. *)
-let get_var_or_x (d : Mir.Variable.t list Pos.VarNameToID.t)
+let get_var (d : Mir.Variable.t list Pos.VarNameToID.t)
     (exec_number : Mir.execution_number) (name : Mast.variable_name Pos.marked)
-    (is_lvalue : bool) (in_table : bool) (lax : bool) : Mir.expression =
-  if Pos.unmark name = "X" && in_table then Mir.GenericTableIndex
-  else if lax then Mir.Var (get_var_from_name_lax d name exec_number is_lvalue)
+    (is_lvalue : bool) (lax : bool) : Mir.expression =
+  if lax then Mir.Var (get_var_from_name_lax d name exec_number is_lvalue)
   else Mir.Var (get_var_from_name d name exec_number is_lvalue)
 
 (** The M language has a weird and very annoying "feature", which is that you
@@ -642,34 +645,30 @@ let get_variables_decl (p : Mast.program)
     [translate_variable idmap exec_number table_definition lc var lax]. SSA is
     all about assigning the correct variable assignment instance when a variable
     is used somewhere. That is why [translate_variable] needs the
-    [execution_number]. [table_definition] is needed because the M language has
-    a special ["X"] variable (generic table index) that has to be distinguished
-    from a variable simply named ["X"]. [lc] is the loop context and the thing
-    that complicates this function the most: variables used inside loops have
-    loop parameters that have to be instantiated to give a normal variable name.
-    [var] is the main argument that you want to translate. [lax] is a special
-    argument for SSA construction that, if sets to [true], allows
-    [translate_variable] to return a variable assigned exactly at [exec_number]
-    (otherwise it always return a variable) in another rule or before in the
-    same rule. *)
+    [execution_number]. [lc] is the loop context and the thing that complicates
+    this function the most: variables used inside loops have loop parameters
+    that have to be instantiated to give a normal variable name. [var] is the
+    main argument that you want to translate. [lax] is a special argument for
+    SSA construction that, if sets to [true], allows [translate_variable] to
+    return a variable assigned exactly at [exec_number] (otherwise it always
+    return a variable) in another rule or before in the same rule. *)
 let rec translate_variable (idmap : Mir.idmap)
     (exec_number : Mir.execution_number)
-    (const_map : float Pos.marked ConstMap.t) (table_definition : bool)
-    (lc : loop_context option) (var : Mast.variable Pos.marked)
-    (is_lvalue : bool) (lax : bool) : Mir.expression Pos.marked =
+    (const_map : float Pos.marked ConstMap.t) (lc : loop_context option)
+    (var : Mast.variable Pos.marked) (is_lvalue : bool) (lax : bool) :
+    Mir.expression Pos.marked =
   match Pos.unmark var with
   | Mast.Normal name -> begin
       match ConstMap.find_opt name const_map with
       | Some (f, _pos) -> Pos.same_pos_as (Mir.Literal (Float f)) var
       | None ->
           Pos.same_pos_as
-            (get_var_or_x idmap exec_number (Pos.same_pos_as name var) is_lvalue
-               table_definition lax)
+            (get_var idmap exec_number (Pos.same_pos_as name var) is_lvalue lax)
             var
     end
   | Mast.Generic gen_name -> (
       if List.length gen_name.Mast.parameters == 0 then
-        translate_variable idmap exec_number const_map table_definition lc
+        translate_variable idmap exec_number const_map lc
           (Pos.same_pos_as (Mast.Normal gen_name.Mast.base) var)
           is_lvalue lax
       else
@@ -681,25 +680,25 @@ let rec translate_variable (idmap : Mir.idmap)
               (Pos.get_position var)
         | Some lc ->
             instantiate_generic_variables_parameters idmap exec_number const_map
-              table_definition lc gen_name is_lvalue (Pos.get_position var) lax)
+              lc gen_name is_lvalue (Pos.get_position var) lax)
 
 (** The following function deal with the "trying all cases" pragma *)
 and instantiate_generic_variables_parameters (idmap : Mir.idmap)
     (exec_number : Mir.execution_number)
-    (const_map : float Pos.marked ConstMap.t) (table_definition : bool)
-    (lc : loop_context) (gen_name : Mast.variable_generic_name)
-    (is_lvalue : bool) (pos : Pos.t) (lax : bool) : Mir.expression Pos.marked =
-  instantiate_generic_variables_parameters_aux idmap exec_number const_map
-    table_definition lc gen_name.Mast.base is_lvalue pos lax
+    (const_map : float Pos.marked ConstMap.t) (lc : loop_context)
+    (gen_name : Mast.variable_generic_name) (is_lvalue : bool) (pos : Pos.t)
+    (lax : bool) : Mir.expression Pos.marked =
+  instantiate_generic_variables_parameters_aux idmap exec_number const_map lc
+    gen_name.Mast.base is_lvalue pos lax
 
 and instantiate_generic_variables_parameters_aux (idmap : Mir.idmap)
     (exec_number : Mir.execution_number)
-    (const_map : float Pos.marked ConstMap.t) (table_definition : bool)
-    (lc : loop_context) (var_name : string) (is_lvalue : bool) (pos : Pos.t)
-    (lax : bool) : Mir.expression Pos.marked =
+    (const_map : float Pos.marked ConstMap.t) (lc : loop_context)
+    (var_name : string) (is_lvalue : bool) (pos : Pos.t) (lax : bool) :
+    Mir.expression Pos.marked =
   match ParamsMap.choose_opt lc with
   | None ->
-      translate_variable idmap exec_number const_map table_definition (Some lc)
+      translate_variable idmap exec_number const_map (Some lc)
         (Mast.Normal var_name, pos)
         is_lvalue lax
   | Some (param, (value, size)) ->
@@ -726,7 +725,7 @@ and instantiate_generic_variables_parameters_aux (idmap : Mir.idmap)
               value var_name
       in
       instantiate_generic_variables_parameters_aux idmap exec_number const_map
-        table_definition
+        (* table_definition *)
         (ParamsMap.remove param lc)
         new_var_name is_lvalue pos lax
 
@@ -779,11 +778,9 @@ let get_var_redefinitions (p : Mast.program) (idmap : Mir.idmap)
                                match
                                  Pos.unmark
                                    (translate_variable idmap exec_number
-                                      const_map
-                                      ((Pos.unmark f.Mast.lvalue).Mast.index
-                                     <> None)
-                                      None (Pos.unmark f.Mast.lvalue).Mast.var
-                                      true false)
+                                      const_map None
+                                      (Pos.unmark f.Mast.lvalue).Mast.var true
+                                      false)
                                with
                                | Mir.Var var -> var
                                | _ -> assert false
@@ -833,10 +830,7 @@ let get_var_redefinitions (p : Mast.program) (idmap : Mir.idmap)
                                  match
                                    Pos.unmark
                                      (translate_variable idmap exec_number
-                                        const_map
-                                        ((Pos.unmark f.Mast.lvalue).Mast.index
-                                       <> None)
-                                        (Some lc)
+                                        const_map (Some lc)
                                         (Pos.unmark f.Mast.lvalue).Mast.var
                                         false false)
                                  with
@@ -877,8 +871,8 @@ let translate_table_index (ctx : translating_context)
       Pos.same_pos_as (Mir.Literal (Mir.Float (float_of_int i'))) i
   | Mast.SymbolIndex v ->
       let var =
-        translate_variable ctx.idmap ctx.exec_number ctx.const_map
-          ctx.table_definition ctx.lc (Pos.same_pos_as v i) false false
+        translate_variable ctx.idmap ctx.exec_number ctx.const_map ctx.lc
+          (Pos.same_pos_as v i) false false
       in
       var
 
@@ -920,8 +914,7 @@ let rec translate_expression (ctx : translating_context)
                       ( Pos.same_pos_as Mast.Eq set_var,
                         Pos.same_pos_as local_var_expr e,
                         translate_variable ctx.idmap ctx.exec_number
-                          ctx.const_map ctx.table_definition ctx.lc set_var
-                          false false )
+                          ctx.const_map ctx.lc set_var false false )
                 | Mast.FloatValue i ->
                     Mir.Comparison
                       ( Pos.same_pos_as Mast.Eq i,
@@ -983,8 +976,8 @@ let rec translate_expression (ctx : translating_context)
         Mir.Unop (op, new_e)
     | Mast.Index (t, i) ->
         let t_var =
-          translate_variable ctx.idmap ctx.exec_number ctx.const_map
-            ctx.table_definition ctx.lc t false false
+          translate_variable ctx.idmap ctx.exec_number ctx.const_map ctx.lc t
+            false false
         in
         let new_i = translate_table_index ctx i in
         Mir.Index
@@ -1011,8 +1004,8 @@ let rec translate_expression (ctx : translating_context)
         match l with
         | Mast.Variable var ->
             let new_var =
-              translate_variable ctx.idmap ctx.exec_number ctx.const_map
-                ctx.table_definition ctx.lc (Pos.same_pos_as var f) false false
+              translate_variable ctx.idmap ctx.exec_number ctx.const_map ctx.lc
+                (Pos.same_pos_as var f) false false
             in
             Pos.unmark new_var
         | Mast.Float f -> Mir.Literal (Mir.Float f))
@@ -1047,7 +1040,19 @@ and translate_func_args (ctx : translating_context) (args : Mast.func_args) :
 (** {2 Translation of source file items}*)
 
 (** Helper type to indicate the kind of variable assignment *)
-type index_def = NoIndex | SingleIndex of int | GenericIndex
+type index_def = NoIndex | ConstIndex of int | DynamicIndex of Mir.variable
+
+let translate_index_def ctx var : translating_context * index_def =
+  let v, pos = var in
+  match var_or_int_value ctx (Mast.Variable v, pos) with
+  | IntIndex i -> (ctx, ConstIndex i)
+  | VarIndex v -> (
+      match
+        translate_variable ctx.idmap ctx.exec_number ctx.const_map ctx.lc
+          (v, pos) true true
+      with
+      | Mir.Var v, _ -> (ctx, DynamicIndex v)
+      | _ -> assert false)
 
 (** Translates lvalues into the assigning variable as well as the type of
     assignment *)
@@ -1056,8 +1061,8 @@ let translate_lvalue (ctx : translating_context) (lval : Mast.lvalue Pos.marked)
   let var =
     match
       Pos.unmark
-        (translate_variable ctx.idmap ctx.exec_number ctx.const_map
-           ctx.table_definition ctx.lc (Pos.unmark lval).Mast.var true true)
+        (translate_variable ctx.idmap ctx.exec_number ctx.const_map ctx.lc
+           (Pos.unmark lval).Mast.var true true)
     with
     | Mir.Var (var : Mir.Variable.t) -> var
     | _ -> assert false
@@ -1066,30 +1071,27 @@ let translate_lvalue (ctx : translating_context) (lval : Mast.lvalue Pos.marked)
   match (Pos.unmark lval).Mast.index with
   | Some ti -> (
       match Pos.unmark ti with
-      | Mast.SymbolIndex (Mast.Normal "X") ->
-          ({ ctx with table_definition = true }, var, GenericIndex)
-      | Mast.LiteralIndex i -> (ctx, var, SingleIndex i)
+      | Mast.LiteralIndex i -> (ctx, var, ConstIndex i)
       | Mast.SymbolIndex (Mast.Normal _ as v) ->
-          let i = var_or_int_value ctx (Pos.same_pos_as (Mast.Variable v) ti) in
-          (ctx, var, SingleIndex i)
+          let ctx, index_def = translate_index_def ctx (Pos.same_pos_as v ti) in
+          (ctx, var, index_def)
       | Mast.SymbolIndex (Mast.Generic _ as v) ->
           let mir_v =
-            translate_variable ctx.idmap ctx.exec_number ctx.const_map
-              ctx.table_definition ctx.lc (Pos.same_pos_as v ti) true false
+            translate_variable ctx.idmap ctx.exec_number ctx.const_map ctx.lc
+              (Pos.same_pos_as v ti) true false
           in
-          let i =
+          let ctx, index_def =
             match Pos.unmark mir_v with
             | Mir.Var v ->
-                var_or_int_value ctx
+                translate_index_def ctx
                   (Pos.same_pos_as
-                     (Mast.Variable
-                        (Mast.Normal (Pos.unmark v.Mir.Variable.name)))
+                     (Mast.Normal (Pos.unmark v.Mir.Variable.name))
                      ti)
-            | Mir.Literal (Float f) -> int_of_float f
+            | Mir.Literal (Float f) -> (ctx, ConstIndex (int_of_float f))
             | _ -> assert false
             (* should not happen*)
           in
-          (ctx, var, SingleIndex i))
+          (ctx, var, index_def))
   | None -> (ctx, var, NoIndex)
 
 (** Date types are not supported *)
@@ -1146,8 +1148,8 @@ let add_var_def (var_data : Mir.variable_data Mir.VariableMap.t)
          match decl_data.var_decl_is_table with
          | Some size -> (
              match def_kind with
-             | NoIndex -> assert false (* should not happen*)
-             | SingleIndex i ->
+             | NoIndex -> assert false (* should not happen *)
+             | ConstIndex i ->
                  {
                    Mir.var_definition =
                      Mir.TableVar
@@ -1155,10 +1157,10 @@ let add_var_def (var_data : Mir.variable_data Mir.VariableMap.t)
                    Mir.var_typ;
                    Mir.var_io = io;
                  }
-             | GenericIndex ->
+             | DynamicIndex v ->
                  {
                    Mir.var_definition =
-                     Mir.TableVar (size, Mir.IndexGeneric var_expr);
+                     Mir.TableVar (size, Mir.IndexGeneric (v, var_expr));
                    Mir.var_typ;
                    Mir.var_io = io;
                  })

--- a/src/mlang/m_ir/format_mir.ml
+++ b/src/mlang/m_ir/format_mir.ml
@@ -81,7 +81,6 @@ let rec format_expression fmt (e : expression) =
         (Pos.unmark var.Variable.name)
         format_execution_number_short var.Variable.execution_number
   | LocalVar lvar -> Format.fprintf fmt "t%d" lvar.LocalVariable.id
-  | GenericTableIndex -> Format.fprintf fmt "X"
   | Error -> Format.fprintf fmt "erreur"
   | LocalLet (lvar, (e1, _), (e2, _)) ->
       Format.fprintf fmt "soit t%d = (%a) dans %a" lvar.LocalVariable.id

--- a/src/mlang/m_ir/format_mir.ml
+++ b/src/mlang/m_ir/format_mir.ml
@@ -95,8 +95,10 @@ let format_variable_def fmt (def : variable_def) =
   match def with
   | SimpleVar e -> Format.fprintf fmt "%a@\n" format_expression (Pos.unmark e)
   | InputVar -> Format.fprintf fmt "[User input]@\n"
-  | TableVar (_, IndexGeneric e) ->
-      Format.fprintf fmt "X -> %a@\n" format_expression (Pos.unmark e)
+  | TableVar (_, IndexGeneric (v, e)) ->
+      Format.fprintf fmt "%s -> %a@\n"
+        (Pos.unmark v.Variable.name)
+        format_expression (Pos.unmark e)
   | TableVar (_, IndexTable defs) ->
       IndexMap.map_printer (Format_mast.pp_unmark format_expression) fmt defs
 

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -241,7 +241,6 @@ type 'variable expression_ =
   | Literal of (literal[@opaque])
   | Var of 'variable
   | LocalVar of (LocalVariable.t[@opaque])
-  | GenericTableIndex
   | Error
   | LocalLet of
       (LocalVariable.t[@opaque])
@@ -263,7 +262,6 @@ let rec map_expr_var (f : 'v -> 'v2) (e : 'v expression_) : 'v2 expression_ =
   | LocalLet (v, e1, e2) -> LocalLet (v, map e1, map e2)
   | Literal l -> Literal l
   | LocalVar v -> LocalVar v
-  | GenericTableIndex -> GenericTableIndex
   | Error -> Error
 
 let rec fold_expr_var (f : 'a -> 'v -> 'a) (acc : 'a) (e : 'v expression_) : 'a
@@ -277,7 +275,7 @@ let rec fold_expr_var (f : 'a -> 'v -> 'a) (acc : 'a) (e : 'v expression_) : 'a
   | Conditional (e1, e2, e3) -> fold (fold (fold acc e1) e2) e3
   | FunctionCall (_, es) -> List.fold_left fold acc es
   | Var v -> f acc v
-  | Literal _ | LocalVar _ | GenericTableIndex | Error -> acc
+  | Literal _ | LocalVar _ | Error -> acc
 
 (** MIR programs are just mapping from variables to their definitions, and make
     a massive use of [VariableMap]. *)

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -343,7 +343,7 @@ end
 type 'variable index_def =
   | IndexTable of
       ('variable expression_ Pos.marked IndexMap.t[@name "index_map"])
-  | IndexGeneric of 'variable expression_ Pos.marked
+  | IndexGeneric of 'variable * 'variable expression_ Pos.marked
 
 (** The definitions here are modeled closely to the source M language. One could
     also adopt a more lambda-calculus-compatible model with functions used to
@@ -363,7 +363,7 @@ let map_var_def_var (f : 'v -> 'v2) (vdef : 'v variable_def_) :
       let idef =
         match idef with
         | IndexTable idx_map -> IndexTable (IndexMap.map map_expr idx_map)
-        | IndexGeneric e -> IndexGeneric (map_expr e)
+        | IndexGeneric (v, e) -> IndexGeneric (f v, map_expr e)
       in
       TableVar (i, idef)
 

--- a/src/mlang/m_ir/mir.mli
+++ b/src/mlang/m_ir/mir.mli
@@ -103,7 +103,6 @@ type 'variable expression_ =
   | Literal of (literal[@opaque])
   | Var of 'variable
   | LocalVar of local_variable
-  | GenericTableIndex
   | Error
   | LocalLet of
       local_variable

--- a/src/mlang/m_ir/mir.mli
+++ b/src/mlang/m_ir/mir.mli
@@ -146,7 +146,7 @@ end
 type 'variable index_def =
   | IndexTable of
       ('variable expression_ Pos.marked IndexMap.t[@name "index_map"])
-  | IndexGeneric of 'variable expression_ Pos.marked
+  | IndexGeneric of 'variable * 'variable expression_ Pos.marked
 
 type 'variable variable_def_ =
   | SimpleVar of 'variable expression_ Pos.marked

--- a/src/mlang/m_ir/mir_dependency_graph.ml
+++ b/src/mlang/m_ir/mir_dependency_graph.ml
@@ -54,7 +54,7 @@ let rec get_used_variables_ (e : Mir.expression Pos.marked)
       acc
   | Mir.FunctionCall (_, args) ->
       List.fold_left (fun acc arg -> get_used_variables_ arg acc) acc args
-  | Mir.LocalVar _ | Mir.Literal _ | Mir.GenericTableIndex | Mir.Error -> acc
+  | Mir.LocalVar _ | Mir.Literal _ | Mir.Error -> acc
   | Mir.Var var -> Mir.VariableDict.add var acc
 
 let get_used_variables (e : Mir.expression Pos.marked) : Mir.VariableDict.t =

--- a/src/mlang/m_ir/mir_dependency_graph.ml
+++ b/src/mlang/m_ir/mir_dependency_graph.ml
@@ -66,7 +66,7 @@ let get_def_used_variables (def : Mir.variable_def) : Mir.VariableDict.t =
   | Mir.SimpleVar e -> get_used_variables e
   | Mir.TableVar (_, def) -> (
       match def with
-      | Mir.IndexGeneric e -> get_used_variables e
+      | Mir.IndexGeneric (v, e) -> Mir.VariableDict.add v (get_used_variables e)
       | Mir.IndexTable es ->
           Mir.IndexMap.fold
             (fun _ e acc -> Mir.VariableDict.union acc (get_used_variables e))

--- a/src/mlang/m_ir/mir_typechecker.ml
+++ b/src/mlang/m_ir/mir_typechecker.ml
@@ -47,10 +47,6 @@ let rec typecheck_top_down ~(in_generic_table : bool)
       typecheck_top_down ~in_generic_table e1;
       typecheck_top_down ~in_generic_table e2
   | Error | LocalVar _ -> ()
-  | GenericTableIndex ->
-      if not in_generic_table then
-        Errors.raise_spanned_error
-          "Generic table index appears outside of table" (Pos.get_position e)
   | Index ((var, var_pos), e') ->
       (* Tables are only tables of arrays *)
       typecheck_top_down ~in_generic_table e';
@@ -155,7 +151,7 @@ let rec check_non_recursivity_expr (e : expression Pos.marked)
       check_non_recursivity_expr e3 lvar
   | FunctionCall (_, args) ->
       List.iter (fun arg -> check_non_recursivity_expr arg lvar) args
-  | Literal _ | LocalVar _ | GenericTableIndex | Error -> ()
+  | Literal _ | LocalVar _ | Error -> ()
   | Var var ->
       if var = lvar then
         Errors.raise_spanned_error
@@ -256,7 +252,6 @@ let rec expand_functions_expr (e : 'var expression_ Pos.marked) :
   | Literal _ -> e
   | Var _ -> e
   | LocalVar _ -> e
-  | GenericTableIndex -> e
   | Error -> e
   | LocalLet (lvar, e1, e2) ->
       let new_e1 = expand_functions_expr e1 in

--- a/src/mlang/m_ir/mir_typechecker.ml
+++ b/src/mlang/m_ir/mir_typechecker.ml
@@ -182,7 +182,7 @@ let typecheck (p : Mir_interface.full_program) : Mir_interface.full_program =
         def
     | TableVar (size, defs) -> (
         match defs with
-        | IndexGeneric e ->
+        | IndexGeneric (_v, e) ->
             typecheck_top_down ~in_generic_table:true e;
             def
         | IndexTable es ->
@@ -366,11 +366,12 @@ let expand_functions (p : Mir_interface.full_program) :
                  }
              | TableVar (size, defg) -> (
                  match defg with
-                 | IndexGeneric e ->
+                 | IndexGeneric (v, e) ->
                      {
                        def with
                        var_definition =
-                         TableVar (size, IndexGeneric (expand_functions_expr e));
+                         TableVar
+                           (size, IndexGeneric (v, expand_functions_expr e));
                      }
                  | IndexTable es ->
                      {

--- a/src/mlang/optimizing_ir/dead_code_removal.ml
+++ b/src/mlang/optimizing_ir/dead_code_removal.ml
@@ -112,7 +112,8 @@ let remove_dead_statements (stmts : block) (id : block_id)
                 | Mir.SimpleVar e -> Bir.get_used_variables e
                 | Mir.TableVar (_, def) -> (
                     match def with
-                    | Mir.IndexGeneric e -> Bir.get_used_variables e
+                    | Mir.IndexGeneric (v, e) ->
+                        Bir.get_used_variables_ e (Bir.VariableSet.singleton v)
                     | Mir.IndexTable es ->
                         Mir.IndexMap.fold
                           (fun _ e used_vars ->

--- a/src/mlang/optimizing_ir/inlining.ml
+++ b/src/mlang/optimizing_ir/inlining.ml
@@ -272,13 +272,14 @@ let rec inline_in_stmt (stmt : stmt) (ctx : ctx) (current_block : block_id)
           (new_stmt, new_ctx, current_stmt_pos)
       | TableVar (size, defs) -> (
           match defs with
-          | IndexGeneric def ->
+          | IndexGeneric (v, def) ->
               let new_def =
                 inline_in_expr (Pos.unmark def) ctx current_block
                   current_stmt_pos
               in
               let new_def =
-                Mir.TableVar (size, IndexGeneric (Pos.same_pos_as new_def def))
+                Mir.TableVar
+                  (size, IndexGeneric (v, Pos.same_pos_as new_def def))
               in
               let new_stmt =
                 Pos.same_pos_as

--- a/src/mlang/optimizing_ir/inlining.ml
+++ b/src/mlang/optimizing_ir/inlining.ml
@@ -51,7 +51,7 @@ let rec no_local_vars (e : Bir.expression Pos.marked) : bool =
   match Pos.unmark e with
   | Mir.LocalVar _ -> false
   | Mir.LocalLet _ -> false
-  | Mir.Literal _ | Mir.GenericTableIndex | Mir.Error | Mir.Var _ -> true
+  | Mir.Literal _ | Mir.Error | Mir.Var _ -> true
   | Mir.Binop (_, e1, e2) | Mir.Comparison (_, e1, e2) ->
       no_local_vars e1 && no_local_vars e2
   | Mir.Index (_, e1) | Mir.Unop (_, e1) -> no_local_vars e1
@@ -66,7 +66,7 @@ let rec has_this_local_var (e : Bir.expression Pos.marked)
   | Mir.LocalVar l' -> l = l'
   | Mir.LocalLet (l', e1, e2) ->
       l = l' || has_this_local_var e1 l || has_this_local_var e2 l
-  | Mir.Literal _ | Mir.GenericTableIndex | Mir.Error | Mir.Var _ -> false
+  | Mir.Literal _ | Mir.Error | Mir.Var _ -> false
   | Mir.Binop (_, e1, e2) | Mir.Comparison (_, e1, e2) ->
       has_this_local_var e1 l || has_this_local_var e2 l
   | Mir.Index (_, e1) | Mir.Unop (_, e1) -> has_this_local_var e1 l
@@ -78,9 +78,7 @@ let rec has_this_local_var (e : Bir.expression Pos.marked)
 
 let rec expr_size (e : Bir.expression Pos.marked) : int =
   match Pos.unmark e with
-  | Mir.LocalVar _ | Mir.LocalLet _ | Mir.Literal _ | Mir.GenericTableIndex
-  | Mir.Error | Mir.Var _ ->
-      1
+  | Mir.LocalVar _ | Mir.LocalLet _ | Mir.Literal _ | Mir.Error | Mir.Var _ -> 1
   | Mir.Binop (_, e1, e2) | Mir.Comparison (_, e1, e2) ->
       expr_size e1 + expr_size e2 + 1
   | Mir.Index (_, e1) | Mir.Unop (_, e1) -> expr_size e1 + 1
@@ -231,7 +229,7 @@ let rec inline_in_expr (e : Bir.expression) (ctx : ctx)
       match Mir.LocalVariableMap.find_opt l ctx.ctx_local_vars with
       | None -> e
       | Some e' -> e')
-  | Mir.Literal _ | Mir.GenericTableIndex | Mir.Error -> e
+  | Mir.Literal _ | Mir.Error -> e
   | Mir.Index (v, e2) ->
       let new_e2 =
         Pos.same_pos_as

--- a/src/mlang/optimizing_ir/partial_evaluation.ml
+++ b/src/mlang/optimizing_ir/partial_evaluation.ml
@@ -485,7 +485,6 @@ let rec partially_evaluate_expr (ctx : partial_ev_ctx) (p : Mir.program)
           in
           match oe with None -> (e, d) | Some e' -> (Pos.same_pos_as e' e, d)
         with Not_found -> (e, Top))
-    | GenericTableIndex -> (e, Float)
     | Error -> assert false
     (* (e, Top) *)
     (* let l1 = b in l2 *)

--- a/src/mlang/optimizing_ir/partial_evaluation.ml
+++ b/src/mlang/optimizing_ir/partial_evaluation.ml
@@ -671,14 +671,14 @@ let rec partially_evaluate_stmt (stmt : stmt) (block_id : block_id)
             (SimpleVar e', add_var_def_to_ctx ctx block_id var partial_e')
         | TableVar (size, def) -> (
             match def with
-            | IndexGeneric e ->
+            | IndexGeneric (v, e) ->
                 let e', d' = partially_evaluate_expr ctx p.mir_program e in
                 let partial_e' =
                   Option.map
                     (fun x -> TableVar (size, Array.init size (fun _ -> x)))
                     (expr_to_partial (Pos.unmark e') d')
                 in
-                ( TableVar (size, IndexGeneric e'),
+                ( TableVar (size, IndexGeneric (v, e')),
                   add_var_def_to_ctx ctx block_id var partial_e' )
             | IndexTable es ->
                 let es' =


### PR DESCRIPTION
This gets Mlang closer to the expressivity of the legacy compiler by allowing access to table variables through dynamic indexing.
It also removes the hack with the implicit loop variable `X`.

I feel this is not entirely satisfactory as it introduce writes to specific cells of array, whereas Mlang tried to represent table writes as whole array modifications until now. We should smooth up the way table variables are handled, I'm not sure how.

This also introduces potential out of bound accesses unobservable before runtime. I implemented proper boundary checks in the interpreter only.  