### PR TITLE
Support for custom M chains

### DIFF
--- a/mpp_specs/dgfip_base.mpp
+++ b/mpp_specs/dgfip_base.mpp
@@ -108,7 +108,7 @@ sauve_base_HR():
 
 ENCH_TL():
   X = X
-#  outputs <- call_m(ENCH_TL)
+  outputs <- call_m(ENCH_TL)
 
 verif_calcul_primitive_isf():
   call_m_verif(isf,calculee)

--- a/src/mlang/m_frontend/format_mast.ml
+++ b/src/mlang/m_frontend/format_mast.ml
@@ -42,6 +42,8 @@ let format_chaining fmt (c : chaining) = Format.fprintf fmt "%s" c
 let format_chain_tag fmt (t : chain_tag) =
   Format.pp_print_string fmt
     (match t with
+    | Custom name -> "\"" ^ name ^ "\""
+    | PrimCorr -> ""
     | Primitif -> "primitif"
     | Corrective -> "corrective"
     | Isf -> "isf"

--- a/src/mlang/m_frontend/mast.ml
+++ b/src/mlang/m_frontend/mast.ml
@@ -35,6 +35,8 @@ type chaining = string
 (** "enchaineur" in the M source code, utility unknown *)
 
 type chain_tag =
+  | Custom of string (* Custom chain, not an actual rule tag *)
+  | PrimCorr (* empty tag *)
   | Primitif
   | Corrective
   | Isf
@@ -147,7 +149,7 @@ let chain_tag_of_string : string -> chain_tag = function
   | "base_stratemajo" -> Base_stratemajo
   | "non_auto_cc" -> Non_auto_cc
   | "horizontale" -> Horizontale
-  | _ -> raise Not_found
+  | s -> Custom s
 
 let number_and_tags_of_name (name : string Pos.marked list) :
     int Pos.marked * chain_tag Pos.marked list =
@@ -174,8 +176,10 @@ let number_and_tags_of_name (name : string Pos.marked list) :
   in
   let number, tags = aux [] name in
   if List.length tags = 0 then
-    (number, [ (Primitif, Pos.no_pos); (Corrective, Pos.no_pos) ])
-    (* No tags means both in primitive and corrective *)
+    ( number,
+      [
+        (PrimCorr, Pos.no_pos); (Primitif, Pos.no_pos); (Corrective, Pos.no_pos);
+      ] ) (* No tags means both in primitive and corrective *)
   else (number, tags)
 
 type variable_name = string

--- a/src/mlang/m_frontend/mast_to_mir.ml
+++ b/src/mlang/m_frontend/mast_to_mir.ml
@@ -1283,7 +1283,12 @@ let get_rules_and_var_data (idmap : Mir.idmap)
                             data_to_add)
                     ([], var_data, 0) r.Mast.rule_formulaes
                 in
-                let rule = (List.rev rule_vars, r.rule_number, r.rule_tags) in
+                let rule_tags =
+                  match r.rule_chaining with
+                  | None -> r.rule_tags
+                  | Some (chain, pos) -> (Mast.Custom chain, pos) :: r.rule_tags
+                in
+                let rule = (List.rev rule_vars, r.rule_number, rule_tags) in
                 ( Mir.RuleMap.add (Pos.unmark r.rule_number) rule rule_data,
                   var_data )
           | Mast.VariableDecl (Mast.ConstVar _) ->
@@ -1461,6 +1466,10 @@ let get_conds (error_decls : Mir.Error.t list)
                               (Mast.Primitif, Pos.no_pos);
                               (Mast.Corrective, Pos.no_pos);
                             ]
+                        | [ (Mast.Custom _, _) ] as l ->
+                            (Mast.Primitif, Pos.no_pos)
+                            :: (Mast.Corrective, Pos.no_pos)
+                            :: l
                         | l -> l);
                     }
                     conds)

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -408,7 +408,10 @@ end)
 module TagMap = Map.Make (struct
   type t = Mast.chain_tag
 
-  let compare = compare
+  let compare t1 t2 =
+    match (t1, t2) with
+    | Mast.Custom s1, Mast.Custom s2 -> String.compare s1 s2
+    | _ -> Stdlib.compare t1 t2
 end)
 
 (**{1 Verification conditions}*)

--- a/src/mlang/m_ir/mir_dependency_graph.mli
+++ b/src/mlang/m_ir/mir_dependency_graph.mli
@@ -36,4 +36,7 @@ val check_for_cycle : RG.t -> Mir.program -> bool -> bool
 
 type rule_execution_order = Mir.rule_id list
 
+val pull_rules_dependencies :
+  RG.t -> Mir.rule_id list -> RG.t * rule_execution_order
+
 val get_rules_execution_order : RG.t -> rule_execution_order


### PR DESCRIPTION
This patch support legacy specification of custom chains. A almost lost feature of the legacy compiler of which remain but a single occurrence in corrective code.

The way it works is a bit hackish as it build these custom sequence of rules from chains from tags and the coherency checks are as feeble as the tags themselves.

The graph analysis to build those chains might be useful for cheap optimisations later on (which might remove the usefulness of such custom chain, with some luck). 