### PR TITLE
Propagate verifications in mpp function types

### DIFF
--- a/src/mlang/backend_compilers/bir_to_c.ml
+++ b/src/mlang/backend_compilers/bir_to_c.ml
@@ -260,13 +260,13 @@ let generate_rule_functions (program : program) (oc : Format.formatter)
 
 let generate_mpp_function (program : program) (oc : Format.formatter)
     (f : function_name) =
-  let stmts = FunctionMap.find f program.mpp_functions in
+  let { mppf_stmts; _ } = FunctionMap.find f program.mpp_functions in
   Format.fprintf oc
     "@[<hv 4>int %s(m_output*output, m_value* TGV, m_value* LOCAL) {@,\
      m_value cond;@,\
      %a@,\
      return 0;@]}@,"
-    f (generate_stmts program) stmts
+    f (generate_stmts program) mppf_stmts
 
 let generate_mpp_functions (oc : Format.formatter) (program : Bir.program) =
   Bir.FunctionMap.iter

--- a/src/mlang/backend_compilers/bir_to_java.ml
+++ b/src/mlang/backend_compilers/bir_to_java.ml
@@ -405,7 +405,7 @@ let generate_calculateTax_method (calculation_vars_len : int)
 
 let generate_mpp_function (program : program) (oc : Format.formatter)
     (f : function_name) =
-  let stmts = FunctionMap.find f program.mpp_functions in
+  let { mppf_stmts; _ } = FunctionMap.find f program.mpp_functions in
   Format.fprintf oc
     "@[<v 2>static void %s(MCalculation mCalculation, List<MError> \
      calculationErrors) {@,\
@@ -416,7 +416,7 @@ let generate_mpp_function (program : program) (oc : Format.formatter)
      mCalculation.getTableVariables();@,\
      %a@]@,\
      }"
-    f (generate_stmts program) stmts
+    f (generate_stmts program) mppf_stmts
 
 let generate_mpp_functions (oc : Format.formatter) (program : program) =
   let functions =

--- a/src/mlang/backend_ir/bir.mli
+++ b/src/mlang/backend_ir/bir.mli
@@ -47,7 +47,7 @@ and stmt_kind =
   | SRuleCall of rule_id
   | SFunctionCall of function_name * Mir.Variable.t list
 
-type mpp_function = stmt list
+type mpp_function = { mppf_stmts : stmt list; mppf_is_verif : bool }
 
 module FunctionMap : Map.S with type key = function_name
 

--- a/src/mlang/backend_ir/bir_instrumentation.ml
+++ b/src/mlang/backend_ir/bir_instrumentation.ml
@@ -125,8 +125,7 @@ let rec get_code_locs_stmt (p : Bir.program) (stmt : Bir.stmt)
       get_code_locs_stmts p (Bir.RuleMap.find r p.rules).rule_stmts
         (Bir_interpreter.InsideRule r :: loc)
   | Bir.SFunctionCall (f, _) ->
-      get_code_locs_stmts p
-        (Bir.FunctionMap.find f p.mpp_functions)
+      get_code_locs_stmts p (Bir.FunctionMap.find f p.mpp_functions).mppf_stmts
         (Bir_interpreter.InsideFunction f :: loc)
 
 and get_code_locs_stmts (p : Bir.program) (stmts : Bir.stmt list)

--- a/src/mlang/backend_ir/bir_interface.ml
+++ b/src/mlang/backend_ir/bir_interface.ml
@@ -329,9 +329,14 @@ let adapt_program_to_function (p : Bir.program) (f : bir_function) :
   in
   let mpp_functions =
     Bir.FunctionMap.add context_function
-      (unused_input_stmts @ const_input_stmts
-      @ Bir.[ (SFunctionCall (p.main_function, []), Pos.no_pos) ]
-      @ conds_stmts)
+      Bir.
+        {
+          mppf_stmts =
+            unused_input_stmts @ const_input_stmts
+            @ Bir.[ (SFunctionCall (p.main_function, []), Pos.no_pos) ]
+            @ conds_stmts;
+          mppf_is_verif = false;
+        }
       p.mpp_functions
   in
   ( {

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -724,7 +724,8 @@ module Make (N : Bir_number.NumberInterface) = struct
         let rule = Bir.RuleMap.find r p.rules in
         evaluate_stmts p ctx rule.rule_stmts (InsideRule r :: loc) 0
     | Bir.SFunctionCall (f, _args) ->
-        evaluate_stmts p ctx (Bir.FunctionMap.find f p.mpp_functions) loc 0
+        evaluate_stmts p ctx (Bir.FunctionMap.find f p.mpp_functions).mppf_stmts
+          loc 0
   (* Mpp_function arguments seem to be used only to determine which variables
      are actually output. Does this actually make sense ? *)
 

--- a/src/mlang/optimizing_ir/bir_to_oir.ml
+++ b/src/mlang/optimizing_ir/bir_to_oir.ml
@@ -97,8 +97,8 @@ and translate_statement (p : Bir.program) (s : Bir.stmt)
       in
       (curr_block_id, blocks)
   | Bir.SFunctionCall (f, _) ->
-      let stmts = Bir.FunctionMap.find f p.mpp_functions in
-      translate_statement_list p stmts curr_block_id blocks
+      let Bir.{ mppf_stmts; _ } = Bir.FunctionMap.find f p.mpp_functions in
+      translate_statement_list p mppf_stmts curr_block_id blocks
 
 let bir_program_to_oir (p : Bir.program) : Oir.program =
   let entry_block = fresh_block_id () in
@@ -187,9 +187,12 @@ let oir_program_to_bir (p : Oir.program) : Bir.program =
     re_translate_blocks_until p.entry_block p.blocks Bir.RuleMap.empty None
   in
   let mpp_functions =
-    Bir.FunctionMap.add p.main_function
-      (Bir.remove_empty_conditionals statements)
-      Bir.FunctionMap.empty
+    Bir.FunctionMap.singleton p.main_function
+      Bir.
+        {
+          mppf_stmts = Bir.remove_empty_conditionals statements;
+          mppf_is_verif = false;
+        }
   in
   {
     mpp_functions;

--- a/src/mlang/test_framework/test_interpreter.ml
+++ b/src/mlang/test_framework/test_interpreter.ml
@@ -160,7 +160,7 @@ let add_test_conds_to_combined_program (p : Bir.program)
   in
   let mpp_functions =
     Bir.FunctionMap.add p.Bir.main_function
-      (new_stmts @ conditions_stmts)
+      Bir.{ mppf_stmts = new_stmts @ conditions_stmts; mppf_is_verif = false }
       p.mpp_functions
   in
   { p with mpp_functions }


### PR DESCRIPTION
Hackish fix to generate the expected function types for verification chain functions.

Verifications ought to be reworked at some point with the new M++ so this should be enough for now. 