### PR TITLE
Generate rules in separate files corresponding to sources in DGFIP backend

### DIFF
--- a/examples/dgfip_c/backend_tests/Makefile
+++ b/examples/dgfip_c/backend_tests/Makefile
@@ -47,6 +47,9 @@ ir_%.c: %.m_spec $(SOURCE_FILES)
 # Compiling the generated C
 ##################################################
 
+### list existing C file from M equivalent
+M_C_FILES=$(filter $(wildcard *.c),$(notdir $(SOURCE_FILES:.m=.c)))
+
 CC=$(C_COMPILER)
 
 ifeq ($(C_COMPILER), clang)
@@ -58,6 +61,7 @@ endif
 ir_%.o: export AFL_DONT_OPTIMIZE=1
 ir_%.o: ir_%.c
 	$(CC) -I ../ $(F_BRACKET_OPT) $(C_OPT) -c $< \
+	$(M_C_FILES) \
 	contexte.c famille.c penalite.c restitue.c revcor.c \
 	revenu.c variatio.c var.c irdata.c
 
@@ -70,6 +74,7 @@ ir_%.o: ir_%.c
 
 test_harness.exe: ir_tests.o test_harness.o
 	$(CC) -fPIE -lm -o $@ $^ \
+	$(M_C_FILES) \
 	contexte.o famille.o penalite.o restitue.o revcor.o \
 	revenu.o variatio.o var.o irdata.o
 
@@ -79,6 +84,7 @@ run_tests: test_harness.exe FORCE
 
 perf_harness.exe: ir_tests.o perf_harness.o ../m_value.o
 	$(CC) -fPIE -lm -o $@ $^ \
+	$(M_C_FILES) \
 	contexte.o famille.o penalite.o restitue.o revcor.o \
 	revenu.o variatio.o var.o irdata.o
 
@@ -128,6 +134,7 @@ clean_fuzz_tests:
 
 clean:
 	rm -f ir_tests.* *.o tests.m_spec *.exe *.tmp ../m_value.o \
+	$(M_C_FILES) \
 	contexte.* famille.* penalite.* restitue.* revcor.* \
 	revenu.* tableg*.* tablev.* variatio.* var.* \
 	conf.h annee.h desc.h desc_inv.h

--- a/src/mlang/backend_compilers/bir_to_c.ml
+++ b/src/mlang/backend_compilers/bir_to_c.ml
@@ -241,7 +241,8 @@ and generate_rule_function_header ~(definition : bool) (oc : Format.formatter)
     (rule : rule) =
   let arg_type = if definition then "m_value *" else "" in
   let ret_type = if definition then "void " else "" in
-  Format.fprintf oc "%sm_rule_%s(%sTGV, %sLOCAL)%s@\n" ret_type rule.rule_name
+  Format.fprintf oc "%sm_rule_%s(%sTGV, %sLOCAL)%s@\n" ret_type
+    (Pos.unmark rule.rule_name)
     arg_type arg_type
     (if definition then "" else ";")
 

--- a/src/mlang/backend_compilers/bir_to_c.ml
+++ b/src/mlang/backend_compilers/bir_to_c.ml
@@ -222,7 +222,7 @@ let rec generate_stmt (program : program) (oc : Format.formatter) (stmt : stmt)
         format_local_vars_defs defs cond_name scond cond_name
         (generate_stmts program) tt cond_name (generate_stmts program) ff
   | SVerif v -> generate_var_cond v oc
-  | SRuleCall r -> (
+  | SRovCall r -> (
       let rov = ROVMap.find r program.rules_and_verifs in
       match rov.rov_code with
       | Rule _ ->

--- a/src/mlang/backend_compilers/bir_to_c.ml
+++ b/src/mlang/backend_compilers/bir_to_c.ml
@@ -238,22 +238,26 @@ and generate_stmts (program : program) (oc : Format.formatter)
   Format.pp_print_list (generate_stmt program) oc stmts
 
 and generate_rule_function_header ~(definition : bool) (oc : Format.formatter)
-    (rule : rule) =
+    (rule : rule_or_verif) =
   let arg_type = if definition then "m_value *" else "" in
   let ret_type = if definition then "void " else "" in
-  Format.fprintf oc "%sm_rule_%s(%sTGV, %sLOCAL)%s@\n" ret_type
+  let tname =
+    match rule.rule_code with Rule _ -> "rule" | Verif _ -> "verif"
+  in
+  Format.fprintf oc "%sm_%s_%s(%sTGV, %sLOCAL)%s@\n" ret_type tname
     (Pos.unmark rule.rule_name)
     arg_type arg_type
     (if definition then "" else ";")
 
 let generate_rule_function (program : program) (oc : Format.formatter)
-    (rule : rule) =
+    (rule : rule_or_verif) =
   Format.fprintf oc "%a@[<v 2>{@ %a@]@;}@\n"
     (generate_rule_function_header ~definition:true)
-    rule (generate_stmts program) rule.rule_stmts
+    rule (generate_stmts program)
+    (Bir.rule_or_verif_as_statements rule)
 
 let generate_rule_functions (program : program) (oc : Format.formatter)
-    (rules : rule RuleMap.t) =
+    (rules : rule_or_verif RuleMap.t) =
   Format.pp_print_list ~pp_sep:Format.pp_print_cut
     (generate_rule_function program)
     oc

--- a/src/mlang/backend_compilers/bir_to_c.ml
+++ b/src/mlang/backend_compilers/bir_to_c.ml
@@ -223,15 +223,15 @@ let rec generate_stmt (program : program) (oc : Format.formatter) (stmt : stmt)
         (generate_stmts program) tt cond_name (generate_stmts program) ff
   | SVerif v -> generate_var_cond v oc
   | SRuleCall r -> (
-      let rule = RuleMap.find r program.rules in
-      match rule.rule_code with
+      let rov = ROVMap.find r program.rules_and_verifs in
+      match rov.rov_code with
       | Rule _ ->
-          generate_rule_function_header ~definition:false oc rule;
+          generate_rov_function_header ~definition:false oc rov;
           Format.fprintf oc ";"
       | Verif _ ->
           Format.fprintf oc "if(%a){@[<v 2>"
-            (generate_rule_function_header ~definition:false)
-            rule;
+            (generate_rov_function_header ~definition:false)
+            rov;
           Format.fprintf oc "output->is_error = true;@;";
           Format.fprintf oc "free(TGV);@;";
           Format.fprintf oc "free(LOCAL);@;";
@@ -243,41 +243,40 @@ and generate_stmts (program : program) (oc : Format.formatter)
     (stmts : stmt list) =
   Format.pp_print_list (generate_stmt program) oc stmts
 
-and generate_rule_function_header ~(definition : bool) (oc : Format.formatter)
-    (rule : rule_or_verif) =
+and generate_rov_function_header ~(definition : bool) (oc : Format.formatter)
+    (rov : rule_or_verif) =
   let arg_type = if definition then "m_value *" else "" in
   let tname, ret_type =
-    match rule.rule_code with
+    match rov.rov_code with
     | Rule _ -> ("rule", "void ")
     | Verif _ -> ("verif", "int ")
   in
   let ret_type = if definition then ret_type else "" in
   Format.fprintf oc "%sm_%s_%s(%sTGV, %sLOCAL)@\n" ret_type tname
-    (Pos.unmark rule.rule_name)
-    arg_type arg_type
+    (Pos.unmark rov.rov_name) arg_type arg_type
 
-let generate_rule_function (program : program) (oc : Format.formatter)
-    (rule : rule_or_verif) =
+let generate_rov_function (program : program) (oc : Format.formatter)
+    (rov : rule_or_verif) =
   let decl, ret =
     let noprint _ _ = () in
-    match rule.rule_code with
+    match rov.rov_code with
     | Rule _ -> (noprint, noprint)
     | Verif _ ->
         ( (fun fmt () -> Format.fprintf fmt "m_value cond;@;"),
           fun fmt () -> Format.fprintf fmt "@ return 0;" )
   in
   Format.fprintf oc "%a@[<v 2>{@ %a%a%a@]@;}@\n"
-    (generate_rule_function_header ~definition:true)
-    rule decl () (generate_stmts program)
-    (Bir.rule_or_verif_as_statements rule)
+    (generate_rov_function_header ~definition:true)
+    rov decl () (generate_stmts program)
+    (Bir.rule_or_verif_as_statements rov)
     ret ()
 
-let generate_rule_functions (program : program) (oc : Format.formatter)
-    (rules : rule_or_verif RuleMap.t) =
+let generate_rov_functions (program : program) (oc : Format.formatter)
+    (rovs : rule_or_verif ROVMap.t) =
   Format.pp_print_list ~pp_sep:Format.pp_print_cut
-    (generate_rule_function program)
+    (generate_rov_function program)
     oc
-    (RuleMap.bindings rules |> List.map snd)
+    (ROVMap.bindings rovs |> List.map snd)
 
 let generate_mpp_function (program : program) (oc : Format.formatter)
     (f : function_name) =
@@ -629,7 +628,7 @@ let generate_c_program (program : program)
     generate_get_output_name_from_index_func function_spec
     generate_get_output_num_func function_spec
     generate_empty_output_func function_spec
-    (generate_rule_functions program) program.rules
+    (generate_rov_functions program) program.rules_and_verifs
     generate_mpp_functions program
     (generate_main_function_signature_and_var_decls program
        var_table_size) function_spec

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -333,7 +333,7 @@ let rec generate_stmt (program : program) (var_indexes : Dgfip_varid.var_id_map)
           (generate_stmts program var_indexes)
           iffalse
   | SVerif v -> generate_var_cond var_indexes v oc
-  | SRuleCall r ->
+  | SRovCall r ->
       let rov = ROVMap.find r program.rules_and_verifs in
       generate_rov_function_header ~definition:false oc rov
   | SFunctionCall (f, _) -> Format.fprintf oc "%s(irdata);\n" f);

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -361,11 +361,12 @@ let generate_rule_function (program : program)
     (var_indexes : Dgfip_varid.var_id_map) (oc : Format.formatter)
     (rule : rule_or_verif) =
   let decl, ret =
+    let noprint _ _ = () in
     match rule.rule_code with
-    | Rule _ -> ((fun _ _ -> ()), fun fmt () -> Format.fprintf fmt "@ return 0;")
+    | Rule _ -> (noprint, fun fmt () -> Format.fprintf fmt "@ return 0;")
     | Verif _ ->
         ( (fun fmt () -> Format.fprintf fmt "int cond_def;@ double cond;@;"),
-          fun _ _ -> () )
+          noprint )
   in
   Format.fprintf oc "%a@[<v 2>{@ %a%a%a@]@;}@\n"
     (generate_rule_function_header ~definition:true)

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -347,7 +347,9 @@ and generate_rule_function_header ~(definition : bool) (oc : Format.formatter)
     (rule : rule) =
   let arg_type = if definition then "T_irdata *" else "" in
   let ret_type = if definition then "int " else "" in
-  Format.fprintf oc "%sregle_%s(%sirdata)%s@\n" ret_type rule.rule_name arg_type
+  Format.fprintf oc "%sregle_%s(%sirdata)%s@\n" ret_type
+    (Pos.unmark rule.rule_name)
+    arg_type
     (if definition then "" else ";")
 
 let generate_rule_function (program : program)

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -651,10 +651,8 @@ let generate_rules_files (program : program) (vm : Dgfip_varid.var_id_map) =
 #define _fmax(x,y) fmax((x),(y))
 #define _fmin(x,y) fmin((x),(y))
 #else
-double _fmax(double x, double y)
-{ return (x > y) ? x : y; }
-double _fmin(double x, double y)
-{ return (x < y) ? x : y; }
+double _fmax(double x, double y);
+double _fmin(double x, double y);
 #endif
 |};
         generate_rule_functions program vm fmt rules;

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -637,9 +637,26 @@ let generate_rules_files (program : program) (vm : Dgfip_varid.var_id_map) =
       else
         let oc = open_out file in
         let fmt = Format.formatter_of_out_channel oc in
-        Format.fprintf fmt "#include <math.h>\n";
-        Format.fprintf fmt "#include <stdio.h>\n";
-        Format.fprintf fmt "#include \"var.h\"\n\n";
+        Format.fprintf fmt
+          {|
+#include <math.h>
+#include <stdio.h>
+#include "var.h"
+
+#ifndef FLG_MULTITHREAD
+#define add_erreur(a,b,c) add_erreur(b,c)
+#endif
+
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199409L)
+#define _fmax(x,y) fmax((x),(y))
+#define _fmin(x,y) fmin((x),(y))
+#else
+double _fmax(double x, double y)
+{ return (x > y) ? x : y; }
+double _fmin(double x, double y)
+{ return (x < y) ? x : y; }
+#endif
+|};
         generate_rule_functions program vm fmt rules;
         Format.pp_print_flush fmt ();
         close_out oc;

--- a/src/mlang/backend_compilers/bir_to_java.ml
+++ b/src/mlang/backend_compilers/bir_to_java.ml
@@ -295,7 +295,7 @@ let rec generate_stmts (program : program) (oc : Format.formatter)
 and generate_stmt (program : program) (oc : Format.formatter) (stmt : stmt) :
     unit =
   match Pos.unmark stmt with
-  | SRuleCall r ->
+  | SRovCall r ->
       let rov = ROVMap.find r program.rules_and_verifs in
       generate_rov_header oc rov
   | SAssign (var, vdata) -> generate_var_def var vdata oc

--- a/src/mlang/backend_compilers/bir_to_java.ml
+++ b/src/mlang/backend_compilers/bir_to_java.ml
@@ -283,12 +283,10 @@ let generate_var_cond oc (cond : condition_data) =
 
 let fresh_cond_counter = ref 0
 
-let generate_rule_header (oc : Format.formatter) (rule : rule_or_verif) =
-  let tname =
-    match rule.rule_code with Rule _ -> "rule" | Verif _ -> "verif"
-  in
+let generate_rov_header (oc : Format.formatter) (rov : rule_or_verif) =
+  let tname = match rov.rov_code with Rule _ -> "rule" | Verif _ -> "verif" in
   Format.fprintf oc "Rule.m_%s_%s(mCalculation, calculationErrors);" tname
-    (Pos.unmark rule.rule_name)
+    (Pos.unmark rov.rov_name)
 
 let rec generate_stmts (program : program) (oc : Format.formatter)
     (stmts : stmt list) =
@@ -298,8 +296,8 @@ and generate_stmt (program : program) (oc : Format.formatter) (stmt : stmt) :
     unit =
   match Pos.unmark stmt with
   | SRuleCall r ->
-      let rule = RuleMap.find r program.rules in
-      generate_rule_header oc rule
+      let rov = ROVMap.find r program.rules_and_verifs in
+      generate_rov_header oc rov
   | SAssign (var, vdata) -> generate_var_def var vdata oc
   | SConditional (cond, tt, ff) ->
       let pos = Pos.get_position stmt in
@@ -348,10 +346,10 @@ let generate_return (oc : Format.formatter)
      }"
     print_outputs returned_variables
 
-let generate_rule_method (program : program) (oc : Format.formatter)
-    (rule : rule_or_verif) =
+let generate_rov_method (program : program) (oc : Format.formatter)
+    (rov : rule_or_verif) =
   let tname, stmts =
-    match rule.rule_code with
+    match rov.rov_code with
     | Rule stmts -> ("rule", stmts)
     | Verif stmt -> ("verif", [ stmt ])
   in
@@ -365,16 +363,14 @@ let generate_rule_method (program : program) (oc : Format.formatter)
      mCalculation.getTableVariables();@,\
      %a@]@,\
      }"
-    tname
-    (Pos.unmark rule.rule_name)
-    (generate_stmts program) stmts
+    tname (Pos.unmark rov.rov_name) (generate_stmts program) stmts
 
-let generate_rule_methods (oc : Format.formatter) (program : program) : unit =
-  let rules = RuleMap.bindings program.rules in
-  let _, rules = List.split rules in
+let generate_rov_methods (oc : Format.formatter) (program : program) : unit =
+  let rovs = ROVMap.bindings program.rules_and_verifs in
+  let _, rovs = List.split rovs in
   Format.pp_print_list ~pp_sep:print_double_cut
-    (generate_rule_method program)
-    oc rules
+    (generate_rov_method program)
+    oc rovs
 
 let generate_calculateTax_method (calculation_vars_len : int)
     (program : program) (locals_size : int) (oc : Format.formatter) () =
@@ -478,5 +474,5 @@ let generate_java_program (program : program) (function_spec : Bir_interface.bir
      print_double_cut ()
      generate_mpp_functions program
      print_double_cut ()
-     generate_rule_methods program;
+     generate_rov_methods program;
   close_out _oc[@@ocamlformat "disable"]

--- a/src/mlang/backend_compilers/bir_to_java.ml
+++ b/src/mlang/backend_compilers/bir_to_java.ml
@@ -285,7 +285,7 @@ let fresh_cond_counter = ref 0
 
 let generate_rule_header (oc : Format.formatter) (rule : rule) =
   Format.fprintf oc "Rule.m_rule_%s(mCalculation, calculationErrors);"
-    rule.rule_name
+    (Pos.unmark rule.rule_name)
 
 let rec generate_stmts (program : program) (oc : Format.formatter)
     (stmts : stmt list) =
@@ -357,7 +357,8 @@ let generate_rule_method (program : program) (oc : Format.formatter)
      mCalculation.getTableVariables();@,\
      %a@]@,\
      }"
-    rule.rule_name (generate_stmts program) rule.rule_stmts
+    (Pos.unmark rule.rule_name)
+    (generate_stmts program) rule.rule_stmts
 
 let generate_rule_methods (oc : Format.formatter) (program : program) : unit =
   let rules = RuleMap.bindings program.rules in

--- a/src/mlang/backend_compilers/bir_to_python.ml
+++ b/src/mlang/backend_compilers/bir_to_python.ml
@@ -425,7 +425,7 @@ and generate_stmt program oc stmt =
         cond_name cond_name (generate_stmts program) tt cond_name
         (generate_stmts program) ff
   | SVerif v -> generate_var_cond v oc
-  | SRuleCall _ | SFunctionCall _ -> assert false
+  | SRovCall _ | SFunctionCall _ -> assert false
 (* Rule and mpp_function calls removed with [Bir.get_all_statements] below *)
 
 let generate_return oc (function_spec : Bir_interface.bir_function) =

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -177,7 +177,9 @@ let squish_statements (program : program) (threshold : int)
     let id = Mir.fresh_rule_id () in
     {
       rule_id = id;
-      rule_name = (rule_suffix ^ string_of_int id, Pos.no_pos);
+      rule_name =
+        ( rule_suffix ^ string_of_int (Mir.num_of_rule_or_verif_id id),
+          Pos.no_pos );
       rule_code = Rule (List.rev stmts);
     }
   in

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -95,7 +95,11 @@ type variable_data = variable Mir.variable_data_
 
 type function_name = string
 
-type rule = { rule_id : rule_id; rule_name : string; rule_stmts : stmt list }
+type rule = {
+  rule_id : rule_id;
+  rule_name : string Pos.marked;
+  rule_stmts : stmt list;
+}
 
 and stmt = stmt_kind Pos.marked
 
@@ -165,7 +169,7 @@ let squish_statements (program : program) (threshold : int)
     let id = Mir.fresh_rule_id () in
     {
       rule_id = id;
-      rule_name = rule_suffix ^ string_of_int id;
+      rule_name = (rule_suffix ^ string_of_int id, Pos.no_pos);
       rule_stmts = List.rev stmts;
     }
   in

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -143,7 +143,7 @@ let rec get_block_statements (p : program) (stmts : stmt list) : stmt list =
       match Pos.unmark stmt with
       | SRuleCall r -> (
           match (RuleMap.find r p.rules).rule_code with
-          | Rule stmts -> List.rev stmts @ stmts
+          | Rule rstmts -> List.rev rstmts @ stmts
           | Verif stmt -> stmt :: stmts)
       | SConditional (e, t, f) ->
           let t = get_block_statements p t in

--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -174,7 +174,7 @@ let rec count_instr_blocks (p : program) (stmts : stmt list) : int =
 let squish_statements (program : program) (threshold : int)
     (rule_suffix : string) =
   let rule_from_stmts stmts =
-    let id = Mir.fresh_rule_id () in
+    let id = Mir.RuleID (Mir.fresh_rule_num ()) in
     {
       rule_id = id;
       rule_name =

--- a/src/mlang/backend_ir/bir.mli
+++ b/src/mlang/backend_ir/bir.mli
@@ -50,7 +50,7 @@ and stmt_kind =
   | SAssign of variable * variable_data
   | SConditional of expression * stmt list * stmt list
   | SVerif of condition_data
-  | SRuleCall of rov_id
+  | SRovCall of rov_id
   | SFunctionCall of function_name * Mir.Variable.t list
 
 type mpp_function = { mppf_stmts : stmt list; mppf_is_verif : bool }

--- a/src/mlang/backend_ir/bir.mli
+++ b/src/mlang/backend_ir/bir.mli
@@ -36,7 +36,11 @@ type variable_data = variable Mir.variable_data_
 
 type function_name = string
 
-type rule = { rule_id : rule_id; rule_name : string; rule_stmts : stmt list }
+type rule = {
+  rule_id : rule_id;
+  rule_name : string Pos.marked;
+  rule_stmts : stmt list;
+}
 
 and stmt = stmt_kind Pos.marked
 

--- a/src/mlang/backend_ir/bir.mli
+++ b/src/mlang/backend_ir/bir.mli
@@ -36,10 +36,12 @@ type variable_data = variable Mir.variable_data_
 
 type function_name = string
 
-type rule = {
+type rule_or_verif_code = Rule of stmt list | Verif of stmt
+
+and rule_or_verif = {
   rule_id : rule_id;
   rule_name : string Pos.marked;
-  rule_stmts : stmt list;
+  rule_code : rule_or_verif_code;
 }
 
 and stmt = stmt_kind Pos.marked
@@ -57,7 +59,7 @@ module FunctionMap : Map.S with type key = function_name
 
 type program = {
   mpp_functions : mpp_function FunctionMap.t;
-  rules : rule RuleMap.t;
+  rules : rule_or_verif RuleMap.t;
   main_function : function_name;
   idmap : Mir.idmap;
   mir_program : Mir.program;
@@ -77,6 +79,8 @@ val compare_variable : variable -> variable -> int
 val map_from_mir_map : tgv_id -> 'a Mir.VariableMap.t -> 'a VariableMap.t
 
 val set_from_mir_dict : tgv_id -> Mir.VariableDict.t -> VariableSet.t
+
+val rule_or_verif_as_statements : rule_or_verif -> stmt list
 
 val main_statements : program -> stmt list
 

--- a/src/mlang/backend_ir/bir.mli
+++ b/src/mlang/backend_ir/bir.mli
@@ -14,9 +14,9 @@
    You should have received a copy of the GNU General Public License along with
    this program. If not, see <https://www.gnu.org/licenses/>. *)
 
-type rule_id = Mir.rule_id
+type rov_id = Mir.rov_id
 
-module RuleMap = Mir.RuleMap
+module ROVMap = Mir.RuleMap
 
 type tgv_id = string
 
@@ -39,9 +39,9 @@ type function_name = string
 type rule_or_verif_code = Rule of stmt list | Verif of stmt
 
 and rule_or_verif = {
-  rule_id : rule_id;
-  rule_name : string Pos.marked;
-  rule_code : rule_or_verif_code;
+  rov_id : rov_id;
+  rov_name : string Pos.marked;
+  rov_code : rule_or_verif_code;
 }
 
 and stmt = stmt_kind Pos.marked
@@ -50,7 +50,7 @@ and stmt_kind =
   | SAssign of variable * variable_data
   | SConditional of expression * stmt list * stmt list
   | SVerif of condition_data
-  | SRuleCall of rule_id
+  | SRuleCall of rov_id
   | SFunctionCall of function_name * Mir.Variable.t list
 
 type mpp_function = { mppf_stmts : stmt list; mppf_is_verif : bool }
@@ -59,7 +59,7 @@ module FunctionMap : Map.S with type key = function_name
 
 type program = {
   mpp_functions : mpp_function FunctionMap.t;
-  rules : rule_or_verif RuleMap.t;
+  rules_and_verifs : rule_or_verif ROVMap.t;
   main_function : function_name;
   idmap : Mir.idmap;
   mir_program : Mir.program;

--- a/src/mlang/backend_ir/bir_instrumentation.ml
+++ b/src/mlang/backend_ir/bir_instrumentation.ml
@@ -122,7 +122,8 @@ let rec get_code_locs_stmt (p : Bir.program) (stmt : Bir.stmt)
   | Bir.SVerif _ -> CodeLocationMap.empty
   | Bir.SAssign (var, _) -> CodeLocationMap.singleton loc var
   | Bir.SRuleCall r ->
-      get_code_locs_stmts p (Bir.RuleMap.find r p.rules).rule_stmts
+      get_code_locs_stmts p
+        (Bir.rule_or_verif_as_statements (Bir.RuleMap.find r p.rules))
         (Bir_interpreter.InsideRule r :: loc)
   | Bir.SFunctionCall (f, _) ->
       get_code_locs_stmts p (Bir.FunctionMap.find f p.mpp_functions).mppf_stmts

--- a/src/mlang/backend_ir/bir_instrumentation.ml
+++ b/src/mlang/backend_ir/bir_instrumentation.ml
@@ -123,7 +123,7 @@ let rec get_code_locs_stmt (p : Bir.program) (stmt : Bir.stmt)
   | Bir.SAssign (var, _) -> CodeLocationMap.singleton loc var
   | Bir.SRuleCall r ->
       get_code_locs_stmts p
-        (Bir.rule_or_verif_as_statements (Bir.RuleMap.find r p.rules))
+        (Bir.rule_or_verif_as_statements (Bir.ROVMap.find r p.rules_and_verifs))
         (Bir_interpreter.InsideRule r :: loc)
   | Bir.SFunctionCall (f, _) ->
       get_code_locs_stmts p (Bir.FunctionMap.find f p.mpp_functions).mppf_stmts

--- a/src/mlang/backend_ir/bir_instrumentation.ml
+++ b/src/mlang/backend_ir/bir_instrumentation.ml
@@ -121,7 +121,7 @@ let rec get_code_locs_stmt (p : Bir.program) (stmt : Bir.stmt)
            (Bir_interpreter.ConditionalBranch false :: loc))
   | Bir.SVerif _ -> CodeLocationMap.empty
   | Bir.SAssign (var, _) -> CodeLocationMap.singleton loc var
-  | Bir.SRuleCall r ->
+  | Bir.SRovCall r ->
       get_code_locs_stmts p
         (Bir.rule_or_verif_as_statements (Bir.ROVMap.find r p.rules_and_verifs))
         (Bir_interpreter.InsideRule r :: loc)

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -29,7 +29,7 @@ let format_code_location_segment (fmt : Format.formatter)
   match s with
   | InsideBlock i -> Format.fprintf fmt "#%d" i
   | ConditionalBranch b -> Format.fprintf fmt "?%b" b
-  | InsideRule r -> Format.fprintf fmt "R_%d" r
+  | InsideRule r -> Format.fprintf fmt "R_%d" (Mir.num_of_rule_or_verif_id r)
   | InsideFunction f -> Format.fprintf fmt "%s" f
 
 type code_location = code_location_segment list
@@ -264,7 +264,7 @@ module Make (N : Bir_number.NumberInterface) = struct
           let vars = Pos.VarNameToID.find query p.Mir.program_idmap in
           let vars =
             List.sort
-              (fun var1 var2 ->
+              (fun (var1 : Mir.Variable.t) var2 ->
                 Mir.(
                   compare_execution_number var1.Variable.execution_number
                     var2.Variable.execution_number))
@@ -281,7 +281,8 @@ module Make (N : Bir_number.NumberInterface) = struct
                     try
                       let rule, def = Mir.find_var_definition p var in
                       Format.fprintf fmt "rule %d, %a"
-                        (Pos.unmark rule.rule_number)
+                        (Mir.num_of_rule_or_verif_id
+                           (Pos.unmark rule.rule_number))
                         Format_mir.format_variable_def def.var_definition
                     with Not_found -> Format.fprintf fmt "unused definition")
                   ())

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -722,7 +722,9 @@ module Make (N : Bir_number.NumberInterface) = struct
         | _ -> ctx)
     | Bir.SRuleCall r ->
         let rule = Bir.RuleMap.find r p.rules in
-        evaluate_stmts p ctx rule.rule_stmts (InsideRule r :: loc) 0
+        evaluate_stmts p ctx
+          (Bir.rule_or_verif_as_statements rule)
+          (InsideRule r :: loc) 0
     | Bir.SFunctionCall (f, _args) ->
         evaluate_stmts p ctx (Bir.FunctionMap.find f p.mpp_functions).mppf_stmts
           loc 0

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -21,7 +21,7 @@ type var_literal =
 type code_location_segment =
   | InsideBlock of int
   | ConditionalBranch of bool
-  | InsideRule of Bir.rule_id
+  | InsideRule of Bir.rov_id
   | InsideFunction of Bir.function_name
 
 let format_code_location_segment (fmt : Format.formatter)
@@ -722,7 +722,7 @@ module Make (N : Bir_number.NumberInterface) = struct
         | Number f when not (N.is_zero f) -> report_violatedcondition data ctx
         | _ -> ctx)
     | Bir.SRuleCall r ->
-        let rule = Bir.RuleMap.find r p.rules in
+        let rule = Bir.ROVMap.find r p.rules_and_verifs in
         evaluate_stmts p ctx
           (Bir.rule_or_verif_as_statements rule)
           (InsideRule r :: loc) 0

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -721,7 +721,7 @@ module Make (N : Bir_number.NumberInterface) = struct
         match evaluate_expr ctx p.mir_program data.cond_expr with
         | Number f when not (N.is_zero f) -> report_violatedcondition data ctx
         | _ -> ctx)
-    | Bir.SRuleCall r ->
+    | Bir.SRovCall r ->
         let rule = Bir.ROVMap.find r p.rules_and_verifs in
         evaluate_stmts p ctx
           (Bir.rule_or_verif_as_statements rule)

--- a/src/mlang/backend_ir/bir_interpreter.mli
+++ b/src/mlang/backend_ir/bir_interpreter.mli
@@ -32,7 +32,7 @@ type var_literal =
 type code_location_segment =
   | InsideBlock of int
   | ConditionalBranch of bool
-  | InsideRule of Bir.rule_id
+  | InsideRule of Bir.rov_id
   | InsideFunction of Bir.function_name
 
 val format_code_location_segment :

--- a/src/mlang/backend_ir/format_bir.ml
+++ b/src/mlang/backend_ir/format_bir.ml
@@ -44,7 +44,8 @@ let rec format_stmt fmt (stmt : stmt) =
         (Format.pp_print_option (fun fmt v ->
              Format.fprintf fmt " (%s)" (Pos.unmark v.Mir.Variable.name)))
         cond_error_opt_var
-  | SRuleCall r -> Format.fprintf fmt "call_rule(%d)@\n" r
+  | SRuleCall r ->
+      Format.fprintf fmt "call_rule(%d)@\n" (Mir.num_of_rule_or_verif_id r)
   | SFunctionCall (func, args) ->
       Format.fprintf fmt "call_function: %s with args %a@," func
         (Format.pp_print_list (fun fmt arg ->
@@ -57,10 +58,12 @@ and format_stmts fmt (stmts : stmt list) =
 let format_rule fmt rule =
   match rule.rule_code with
   | Rule stmts ->
-      Format.fprintf fmt "rule %d:@\n@[<h 2>  %a@]@\n" rule.rule_id format_stmts
-        stmts
+      Format.fprintf fmt "rule %d:@\n@[<h 2>  %a@]@\n"
+        (Mir.num_of_rule_or_verif_id rule.rule_id)
+        format_stmts stmts
   | Verif stmt ->
-      Format.fprintf fmt "verif %d:@\n@[<h 2>  %a@]@\n" rule.rule_id
+      Format.fprintf fmt "verif %d:@\n@[<h 2>  %a@]@\n"
+        (Mir.num_of_rule_or_verif_id rule.rule_id)
         format_stmts [ stmt ]
 
 let format_rules fmt rules =

--- a/src/mlang/backend_ir/format_bir.ml
+++ b/src/mlang/backend_ir/format_bir.ml
@@ -56,22 +56,22 @@ and format_stmts fmt (stmts : stmt list) =
   Format.pp_print_list ~pp_sep:(fun _ () -> ()) format_stmt fmt stmts
 
 let format_rule fmt rule =
-  match rule.rule_code with
+  match rule.rov_code with
   | Rule stmts ->
       Format.fprintf fmt "rule %d:@\n@[<h 2>  %a@]@\n"
-        (Mir.num_of_rule_or_verif_id rule.rule_id)
+        (Mir.num_of_rule_or_verif_id rule.rov_id)
         format_stmts stmts
   | Verif stmt ->
       Format.fprintf fmt "verif %d:@\n@[<h 2>  %a@]@\n"
-        (Mir.num_of_rule_or_verif_id rule.rule_id)
+        (Mir.num_of_rule_or_verif_id rule.rov_id)
         format_stmts [ stmt ]
 
 let format_rules fmt rules =
   Format.pp_print_list
     ~pp_sep:(fun _ () -> ())
     format_rule fmt
-    (Bir.RuleMap.bindings rules |> List.map snd)
+    (Bir.ROVMap.bindings rules |> List.map snd)
 
 let format_program fmt (p : program) =
-  Format.fprintf fmt "%a%a" format_rules p.rules format_stmts
+  Format.fprintf fmt "%a%a" format_rules p.rules_and_verifs format_stmts
     (Bir.main_statements p)

--- a/src/mlang/backend_ir/format_bir.ml
+++ b/src/mlang/backend_ir/format_bir.ml
@@ -55,8 +55,13 @@ and format_stmts fmt (stmts : stmt list) =
   Format.pp_print_list ~pp_sep:(fun _ () -> ()) format_stmt fmt stmts
 
 let format_rule fmt rule =
-  Format.fprintf fmt "rule %d:@\n@[<h 2>  %a@]@\n" rule.rule_id format_stmts
-    rule.rule_stmts
+  match rule.rule_code with
+  | Rule stmts ->
+      Format.fprintf fmt "rule %d:@\n@[<h 2>  %a@]@\n" rule.rule_id format_stmts
+        stmts
+  | Verif stmt ->
+      Format.fprintf fmt "verif %d:@\n@[<h 2>  %a@]@\n" rule.rule_id
+        format_stmts [ stmt ]
 
 let format_rules fmt rules =
   Format.pp_print_list

--- a/src/mlang/backend_ir/format_bir.ml
+++ b/src/mlang/backend_ir/format_bir.ml
@@ -44,7 +44,7 @@ let rec format_stmt fmt (stmt : stmt) =
         (Format.pp_print_option (fun fmt v ->
              Format.fprintf fmt " (%s)" (Pos.unmark v.Mir.Variable.name)))
         cond_error_opt_var
-  | SRuleCall r ->
+  | SRovCall r ->
       Format.fprintf fmt "call_rule(%d)@\n" (Mir.num_of_rule_or_verif_id r)
   | SFunctionCall (func, args) ->
       Format.fprintf fmt "call_function: %s with args %a@," func

--- a/src/mlang/backend_ir/format_bir.mli
+++ b/src/mlang/backend_ir/format_bir.mli
@@ -24,6 +24,6 @@ val format_stmts : Format.formatter -> Bir.stmt list -> unit
 
 val format_rule : Format.formatter -> Bir.rule_or_verif -> unit
 
-val format_rules : Format.formatter -> Bir.rule_or_verif Bir.RuleMap.t -> unit
+val format_rules : Format.formatter -> Bir.rule_or_verif Bir.ROVMap.t -> unit
 
 val format_program : Format.formatter -> Bir.program -> unit

--- a/src/mlang/backend_ir/format_bir.mli
+++ b/src/mlang/backend_ir/format_bir.mli
@@ -22,8 +22,8 @@ val format_stmt : Format.formatter -> Bir.stmt -> unit
 
 val format_stmts : Format.formatter -> Bir.stmt list -> unit
 
-val format_rule : Format.formatter -> Bir.rule -> unit
+val format_rule : Format.formatter -> Bir.rule_or_verif -> unit
 
-val format_rules : Format.formatter -> Bir.rule Bir.RuleMap.t -> unit
+val format_rules : Format.formatter -> Bir.rule_or_verif Bir.RuleMap.t -> unit
 
 val format_program : Format.formatter -> Bir.program -> unit

--- a/src/mlang/m_frontend/mast_to_mir.ml
+++ b/src/mlang/m_frontend/mast_to_mir.ml
@@ -1460,6 +1460,7 @@ let get_conds (error_decls : Mir.Error.t list)
                   in
                   Mir.VariableMap.add dummy_var
                     {
+                      Mir.cond_number = verif.verif_number;
                       Mir.cond_expr = e;
                       Mir.cond_error = err;
                       Mir.cond_tags =

--- a/src/mlang/m_frontend/mast_to_mir.ml
+++ b/src/mlang/m_frontend/mast_to_mir.ml
@@ -1190,7 +1190,7 @@ let get_rules_and_var_data (idmap : Mir.idmap)
     (var_decl_data : var_decl_data Mir.VariableMap.t)
     (const_map : float Pos.marked ConstMap.t) (p : Mast.program) :
     (Mir.Variable.t list
-    * Mir.rule_id Pos.marked
+    * Mir.rov_id Pos.marked
     * Mast.chain_tag Pos.marked list)
     Mir.RuleMap.t
     * Mir.variable_data Mir.VariableMap.t =

--- a/src/mlang/m_frontend/mast_to_mir.ml
+++ b/src/mlang/m_frontend/mast_to_mir.ml
@@ -1189,7 +1189,9 @@ let add_var_def (var_data : Mir.variable_data Mir.VariableMap.t)
 let get_rules_and_var_data (idmap : Mir.idmap)
     (var_decl_data : var_decl_data Mir.VariableMap.t)
     (const_map : float Pos.marked ConstMap.t) (p : Mast.program) :
-    (Mir.Variable.t list * int Pos.marked * Mast.chain_tag Pos.marked list)
+    (Mir.Variable.t list
+    * Mir.rule_id Pos.marked
+    * Mast.chain_tag Pos.marked list)
     Mir.RuleMap.t
     * Mir.variable_data Mir.VariableMap.t =
   List.fold_left
@@ -1291,8 +1293,11 @@ let get_rules_and_var_data (idmap : Mir.idmap)
                   | None -> r.rule_tags
                   | Some (chain, pos) -> (Mast.Custom chain, pos) :: r.rule_tags
                 in
-                let rule = (List.rev rule_vars, r.rule_number, rule_tags) in
-                ( Mir.RuleMap.add (Pos.unmark r.rule_number) rule rule_data,
+                let rule_number =
+                  Pos.map_under_mark (fun n -> Mir.RuleID n) r.rule_number
+                in
+                let rule = (List.rev rule_vars, rule_number, rule_tags) in
+                ( Mir.RuleMap.add (Pos.unmark rule_number) rule rule_data,
                   var_data )
           | Mast.VariableDecl (Mast.ConstVar _) ->
               (* constant variables occurences are substituted by their
@@ -1460,7 +1465,10 @@ let get_conds (error_decls : Mir.Error.t list)
                   in
                   Mir.VariableMap.add dummy_var
                     {
-                      Mir.cond_number = verif.verif_number;
+                      Mir.cond_number =
+                        Pos.map_under_mark
+                          (fun n -> Mir.VerifID n)
+                          verif.verif_number;
                       Mir.cond_expr = e;
                       Mir.cond_error = err;
                       Mir.cond_tags =
@@ -1522,7 +1530,12 @@ let translate (p : Mast.program) : Mir.program =
   in
   let rules =
     Mir.RuleMap.add Mir.initial_undef_rule_id
-      Mir.{ rule_vars = orphans; rule_number = (0, Pos.no_pos); rule_tags = [] }
+      Mir.
+        {
+          rule_vars = orphans;
+          rule_number = (RuleID 0, Pos.no_pos);
+          rule_tags = [];
+        }
       rules
   in
   let conds = get_conds error_decls const_map idmap p in

--- a/src/mlang/m_ir/format_mir.ml
+++ b/src/mlang/m_ir/format_mir.ml
@@ -154,7 +154,8 @@ let format_program_rules fmt (vars : VariableDict.t)
             VariableMap.add var def var_defs)
           VariableMap.empty rule_vars
       in
-      Format.fprintf fmt "Regle %d\n%a\n" (Pos.unmark rule_number)
+      Format.fprintf fmt "Regle %d\n%a\n"
+        (num_of_rule_or_verif_id (Pos.unmark rule_number))
         format_variables var_defs)
     rules
 

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -387,7 +387,7 @@ type 'variable variable_data_ = {
 
 type variable_data = variable variable_data_
 
-type rule_id = RuleID of int | VerifID of int
+type rov_id = RuleID of int | VerifID of int
 
 let num_of_rule_or_verif_id = function RuleID n | VerifID n -> n
 
@@ -403,12 +403,12 @@ let initial_undef_rule_id = RuleID (-1)
 
 type rule_data = {
   rule_vars : (Variable.id * variable_data) list;
-  rule_number : rule_id Pos.marked;
+  rule_number : rov_id Pos.marked;
   rule_tags : Mast.chain_tag list;
 }
 
 module RuleMap = Map.Make (struct
-  type t = rule_id
+  type t = rov_id
 
   let compare = compare
 end)
@@ -500,7 +500,7 @@ module Error = struct
 end
 
 type 'variable condition_data_ = {
-  cond_number : rule_id Pos.marked;
+  cond_number : rov_id Pos.marked;
   cond_expr : 'variable expression_ Pos.marked;
   cond_error : (Error.t[@opaque]) * 'variable option;
   cond_tags : Mast.chain_tag Pos.marked list;

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -498,6 +498,7 @@ module Error = struct
 end
 
 type 'variable condition_data_ = {
+  cond_number : int Pos.marked;
   cond_expr : 'variable expression_ Pos.marked;
   cond_error : (Error.t[@opaque]) * 'variable option;
   cond_tags : Mast.chain_tag Pos.marked list;
@@ -506,6 +507,7 @@ type 'variable condition_data_ = {
 let map_cond_data_var (f : 'v -> 'v2) (cond : 'v condition_data_) :
     'v2 condition_data_ =
   {
+    cond_number = cond.cond_number;
     cond_expr = Pos.map_under_mark (map_expr_var f) cond.cond_expr;
     cond_error =
       (let e, v = cond.cond_error in

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -387,21 +387,23 @@ type 'variable variable_data_ = {
 
 type variable_data = variable variable_data_
 
-type rule_id = int
+type rule_id = RuleID of int | VerifID of int
+
+let num_of_rule_or_verif_id = function RuleID n | VerifID n -> n
 
 let fresh_rule_id =
   let count = ref 0 in
   fun () ->
     let n = !count in
     incr count;
-    n
+    RuleID n
 
 (** Special rule id for initial definition of variables *)
-let initial_undef_rule_id = -1
+let initial_undef_rule_id = RuleID (-1)
 
 type rule_data = {
   rule_vars : (Variable.id * variable_data) list;
-  rule_number : int Pos.marked;
+  rule_number : rule_id Pos.marked;
   rule_tags : Mast.chain_tag list;
 }
 
@@ -498,7 +500,7 @@ module Error = struct
 end
 
 type 'variable condition_data_ = {
-  cond_number : int Pos.marked;
+  cond_number : rule_id Pos.marked;
   cond_expr : 'variable expression_ Pos.marked;
   cond_error : (Error.t[@opaque]) * 'variable option;
   cond_tags : Mast.chain_tag Pos.marked list;

--- a/src/mlang/m_ir/mir.ml
+++ b/src/mlang/m_ir/mir.ml
@@ -391,12 +391,12 @@ type rule_id = RuleID of int | VerifID of int
 
 let num_of_rule_or_verif_id = function RuleID n | VerifID n -> n
 
-let fresh_rule_id =
+let fresh_rule_num =
   let count = ref 0 in
   fun () ->
     let n = !count in
     incr count;
-    RuleID n
+    n
 
 (** Special rule id for initial definition of variables *)
 let initial_undef_rule_id = RuleID (-1)

--- a/src/mlang/m_ir/mir.mli
+++ b/src/mlang/m_ir/mir.mli
@@ -168,7 +168,7 @@ type 'variable variable_data_ = {
 
 type variable_data = variable variable_data_
 
-type rule_id = int
+type rule_id = RuleID of int | VerifID of int
 
 module RuleMap : Map.S with type key = rule_id
 
@@ -197,7 +197,7 @@ type error = {
 }
 
 type 'variable condition_data_ = {
-  cond_number : int Pos.marked;
+  cond_number : rule_id Pos.marked;
   cond_expr : 'variable expression_ Pos.marked;
   cond_error : error * 'variable option;
   cond_tags : Mast.chain_tag Pos.marked list;
@@ -257,7 +257,7 @@ module Variable : sig
     attributes:(string Pos.marked * Mast.literal Pos.marked) list ->
     origin:variable option ->
     subtypes:variable_subtype list ->
-    is_table:rule_id option ->
+    is_table:int option ->
     variable
 
   val compare : t -> t -> int
@@ -301,6 +301,8 @@ val false_literal : literal
 
 val true_literal : literal
 
+val num_of_rule_or_verif_id : rule_id -> int
+
 val same_execution_number : execution_number -> execution_number -> bool
 
 val find_var_name_by_alias : program -> string Pos.marked -> string
@@ -318,7 +320,7 @@ val fold_vars : (variable -> variable_data -> 'a -> 'a) -> program -> 'a -> 'a
 val map_vars :
   (variable -> variable_data -> variable_data) -> program -> program
 
-val compare_execution_number : execution_number -> execution_number -> rule_id
+val compare_execution_number : execution_number -> execution_number -> int
 
 val find_var_definition : program -> variable -> rule_data * variable_data
 

--- a/src/mlang/m_ir/mir.mli
+++ b/src/mlang/m_ir/mir.mli
@@ -328,7 +328,7 @@ val max_exec_number : execution_number -> execution_number -> max_result
 
 val is_candidate_valid : execution_number -> execution_number -> bool -> bool
 
-val fresh_rule_id : unit -> rule_id
+val fresh_rule_num : unit -> int
 
 val initial_undef_rule_id : rule_id
 

--- a/src/mlang/m_ir/mir.mli
+++ b/src/mlang/m_ir/mir.mli
@@ -168,13 +168,13 @@ type 'variable variable_data_ = {
 
 type variable_data = variable variable_data_
 
-type rule_id = RuleID of int | VerifID of int
+type rov_id = RuleID of int | VerifID of int
 
-module RuleMap : Map.S with type key = rule_id
+module RuleMap : Map.S with type key = rov_id
 
 type rule_data = {
   rule_vars : (variable_id * variable_data) list;
-  rule_number : rule_id Pos.marked;
+  rule_number : rov_id Pos.marked;
   rule_tags : Mast.chain_tag list;
 }
 
@@ -197,7 +197,7 @@ type error = {
 }
 
 type 'variable condition_data_ = {
-  cond_number : rule_id Pos.marked;
+  cond_number : rov_id Pos.marked;
   cond_expr : 'variable expression_ Pos.marked;
   cond_error : error * 'variable option;
   cond_tags : Mast.chain_tag Pos.marked list;
@@ -301,7 +301,7 @@ val false_literal : literal
 
 val true_literal : literal
 
-val num_of_rule_or_verif_id : rule_id -> int
+val num_of_rule_or_verif_id : rov_id -> int
 
 val same_execution_number : execution_number -> execution_number -> bool
 
@@ -330,7 +330,7 @@ val is_candidate_valid : execution_number -> execution_number -> bool -> bool
 
 val fresh_rule_num : unit -> int
 
-val initial_undef_rule_id : rule_id
+val initial_undef_rule_id : rov_id
 
 val subtypes_of_decl : Mast.variable_decl -> variable_subtype list
 

--- a/src/mlang/m_ir/mir.mli
+++ b/src/mlang/m_ir/mir.mli
@@ -197,6 +197,7 @@ type error = {
 }
 
 type 'variable condition_data_ = {
+  cond_number : int Pos.marked;
   cond_expr : 'variable expression_ Pos.marked;
   cond_error : error * 'variable option;
   cond_tags : Mast.chain_tag Pos.marked list;

--- a/src/mlang/m_ir/mir_dependency_graph.ml
+++ b/src/mlang/m_ir/mir_dependency_graph.ml
@@ -17,7 +17,7 @@
 module RG =
   Graph.Persistent.Digraph.ConcreteBidirectionalLabeled
     (struct
-      type t = Mir.rule_id
+      type t = Mir.rov_id
 
       let hash v = Mir.num_of_rule_or_verif_id v (* no verif here anyway *)
 
@@ -73,7 +73,7 @@ let get_def_used_variables (def : Mir.variable_def) : Mir.VariableDict.t =
             es Mir.VariableDict.empty)
 
 let create_rules_dependency_graph (chain_rules : Mir.rule_data Mir.RuleMap.t)
-    (vars_to_rules : Mir.rule_id Mir.VariableMap.t) : RG.t =
+    (vars_to_rules : Mir.rov_id Mir.VariableMap.t) : RG.t =
   Mir.RuleMap.fold
     (fun rule_id { Mir.rule_vars; _ } g ->
       let g = RG.add_vertex g rule_id in
@@ -196,11 +196,11 @@ let check_for_cycle (g : RG.t) (p : Mir.program) (print_debug : bool) : bool =
   end
   else false
 
-type rule_execution_order = Mir.rule_id list
+type rule_execution_order = Mir.rov_id list
 
 module Traversal = Graph.Traverse.Dfs (RG)
 
-let pull_rules_dependencies (g : RG.t) (rules : Mir.rule_id list) :
+let pull_rules_dependencies (g : RG.t) (rules : Mir.rov_id list) :
     RG.t * rule_execution_order =
   let order =
     List.fold_left

--- a/src/mlang/m_ir/mir_dependency_graph.ml
+++ b/src/mlang/m_ir/mir_dependency_graph.ml
@@ -19,7 +19,7 @@ module RG =
     (struct
       type t = Mir.rule_id
 
-      let hash v = v
+      let hash v = Mir.num_of_rule_or_verif_id v (* no verif here anyway *)
 
       let compare = compare
 
@@ -178,12 +178,14 @@ let check_for_cycle (g : RG.t) (p : Mir.program) (print_debug : bool) : bool =
                  (let rule =
                     Mir.RuleMap.find (List.hd edges |> fst) p.program_rules
                   in
-                  string_of_int (Pos.unmark rule.rule_number)
+                  string_of_int
+                    (Mir.num_of_rule_or_verif_id (Pos.unmark rule.rule_number))
                   :: List.map
                        (fun (rule_id, edge) ->
                          let rule = Mir.RuleMap.find rule_id p.program_rules in
                          Format.asprintf "depends on %d through vars: {%s}"
-                           (Pos.unmark rule.rule_number)
+                           (Mir.num_of_rule_or_verif_id
+                              (Pos.unmark rule.rule_number))
                            (RG.E.label edge))
                        edges))
             :: !cycles_strings)

--- a/src/mlang/m_ir/mir_dependency_graph.mli
+++ b/src/mlang/m_ir/mir_dependency_graph.mli
@@ -29,12 +29,12 @@ val get_used_variables : Mir.expression Pos.marked -> Mir.VariableDict.t
 (** Calls the previous function with an empty dict *)
 
 val create_rules_dependency_graph :
-  Mir.rule_data Mir.RuleMap.t -> Mir.rule_id Mir.VariableMap.t -> RG.t
+  Mir.rule_data Mir.RuleMap.t -> Mir.rov_id Mir.VariableMap.t -> RG.t
 
 val check_for_cycle : RG.t -> Mir.program -> bool -> bool
 (** Outputs [true] and a warning in case of cycles. *)
 
-type rule_execution_order = Mir.rule_id list
+type rule_execution_order = Mir.rov_id list
 
 val get_var_dependencies :
   ?strict:bool ->
@@ -44,6 +44,6 @@ val get_var_dependencies :
   Mir.variable list
 
 val pull_rules_dependencies :
-  RG.t -> Mir.rule_id list -> RG.t * rule_execution_order
+  RG.t -> Mir.rov_id list -> RG.t * rule_execution_order
 
 val get_rules_execution_order : RG.t -> rule_execution_order

--- a/src/mlang/m_ir/mir_interface.ml
+++ b/src/mlang/m_ir/mir_interface.ml
@@ -50,7 +50,7 @@ let reset_all_outputs (p : program) : program =
 
 type chain_order = {
   dep_graph : Mir_dependency_graph.RG.t;
-  execution_order : Mir.rule_id list;
+  execution_order : Mir.rov_id list;
 }
 
 type full_program = {
@@ -65,14 +65,14 @@ let to_full_program (program : program) (chains : Mast.chain_tag list) :
       (fun (chains, seen_customs) tag ->
         let vars_to_rules, chain_rules =
           Mir.RuleMap.fold
-            (fun rule_id rule (vars, rules) ->
+            (fun rov_id rule (vars, rules) ->
               if Mast.are_tags_part_of_chain rule.rule_tags tag then
                 ( List.fold_left
                     (fun vars (vid, _def) ->
                       let var = VariableDict.find vid program.program_vars in
-                      VariableMap.add var rule_id vars)
+                      VariableMap.add var rov_id vars)
                     vars rule.rule_vars,
-                  RuleMap.add rule_id rule rules )
+                  RuleMap.add rov_id rule rules )
               else (vars, rules))
             program.program_rules
             (VariableMap.empty, RuleMap.empty)
@@ -86,7 +86,7 @@ let to_full_program (program : program) (chains : Mast.chain_tag list) :
         in
         let customs, _ =
           RuleMap.fold
-            (fun rule_id rule (customs, in_primcorr) ->
+            (fun rov_id rule (customs, in_primcorr) ->
               List.fold_left
                 (fun (customs, in_primcorr) tag ->
                   match tag with
@@ -101,10 +101,10 @@ let to_full_program (program : program) (chains : Mast.chain_tag list) :
                       else
                         match TagMap.find_opt tag customs with
                         | Some rs ->
-                            ( TagMap.add tag (rule_id :: rs) customs,
+                            ( TagMap.add tag (rov_id :: rs) customs,
                               ipc || in_primcorr )
                         | None ->
-                            ( TagMap.add tag [ rule_id ] customs,
+                            ( TagMap.add tag [ rov_id ] customs,
                               ipc || in_primcorr ))
                   | _ -> (customs, in_primcorr))
                 (customs, in_primcorr) rule.rule_tags)

--- a/src/mlang/m_ir/mir_interface.mli
+++ b/src/mlang/m_ir/mir_interface.mli
@@ -23,7 +23,7 @@ val reset_all_outputs : Mir.program -> Mir.program
 
 type chain_order = {
   dep_graph : Mir_dependency_graph.RG.t;
-  execution_order : Mir.rule_id list;
+  execution_order : Mir.rov_id list;
 }
 
 type full_program = {

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -517,7 +517,9 @@ let create_combined_program (m_program : Mir_interface.full_program)
               ctx.used_chains
           then
             let rule_name =
-              Pos.map_under_mark string_of_int rule_data.Mir.rule_number
+              Pos.map_under_mark
+                (fun n -> string_of_int (Mir.num_of_rule_or_verif_id n))
+                rule_data.Mir.rule_number
             in
             let rule_code =
               Bir.Rule (translate_m_code m_program rule_data.Mir.rule_vars)
@@ -531,7 +533,9 @@ let create_combined_program (m_program : Mir_interface.full_program)
         (fun _var cond_data rules ->
           let rule_id = Pos.unmark cond_data.Mir.cond_number in
           let rule_name =
-            Pos.same_pos_as (string_of_int rule_id) cond_data.Mir.cond_number
+            Pos.same_pos_as
+              (string_of_int (Mir.num_of_rule_or_verif_id rule_id))
+              cond_data.Mir.cond_number
           in
           let rule_code = Bir.Verif (generate_verif_cond cond_data) in
           Mir.RuleMap.add rule_id Bir.{ rule_id; rule_name; rule_code } rules)

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -515,7 +515,7 @@ let create_combined_program (m_program : Mir_interface.full_program)
               ctx.used_chains
           then
             let rule_name =
-              string_of_int (Pos.unmark rule_data.Mir.rule_number)
+              Pos.map_under_mark string_of_int rule_data.Mir.rule_number
             in
             let rule_stmts =
               translate_m_code m_program rule_data.Mir.rule_vars

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -215,7 +215,7 @@ let wrap_m_code_call (m_program : Mir_interface.full_program)
     List.fold_left
       (fun stmts rov_id ->
         let rule = Mir.RuleMap.find rov_id m_program.program.program_rules in
-        Pos.same_pos_as (Bir.SRuleCall rov_id) rule.Mir.rule_number :: stmts)
+        Pos.same_pos_as (Bir.SRovCall rov_id) rule.Mir.rule_number :: stmts)
       [] execution_order
   in
   let program_stmts = List.rev program_stmts in
@@ -261,7 +261,7 @@ let generate_verif_call (m_program : Mir_interface.full_program)
   List.map
     (fun verif ->
       Pos.map_under_mark
-        (fun verif_id -> Bir.SRuleCall verif_id)
+        (fun verif_id -> Bir.SRovCall verif_id)
         verif.Mir.cond_number)
     verifs
 

--- a/src/mlang/optimizing_ir/bir_to_oir.ml
+++ b/src/mlang/optimizing_ir/bir_to_oir.ml
@@ -74,7 +74,7 @@ and translate_statement (p : Bir.program) (s : Bir.stmt)
         append_to_block (Oir.SGoto join_block, Pos.no_pos) last_b2id blocks
       in
       (join_block, blocks)
-  | Bir.SRuleCall rov_id ->
+  | Bir.SRovCall rov_id ->
       (* To properly optimize M code, we have to instanciate each call as
          independent code *)
       let rule = Bir.ROVMap.find rov_id p.Bir.rules_and_verifs in
@@ -103,7 +103,7 @@ and translate_statement (p : Bir.program) (s : Bir.stmt)
       let blocks =
         append_to_block
           (Pos.same_pos_as
-             (Oir.SRuleCall (instance_id, instance_name, List.rev stmts))
+             (Oir.SRovCall (instance_id, instance_name, List.rev stmts))
              s)
           curr_block_id blocks
       in
@@ -147,7 +147,7 @@ let rec re_translate_statement (s : Oir.stmt)
         Some (Pos.same_pos_as (Bir.SConditional (e, b1, b2)) s),
         rules )
   | Oir.SGoto b -> (Some b, None, rules)
-  | Oir.SRuleCall (rov_id, rov_name, stmts) -> (
+  | Oir.SRovCall (rov_id, rov_name, stmts) -> (
       let _, stmts, rules = re_translate_statement_list stmts rules blocks in
       let stmts = List.rev stmts in
       let rule =
@@ -161,7 +161,7 @@ let rec re_translate_statement (s : Oir.stmt)
       | None -> (None, None, rules)
       | Some rule ->
           ( None,
-            Some (Pos.same_pos_as (Bir.SRuleCall rov_id) s),
+            Some (Pos.same_pos_as (Bir.SRovCall rov_id) s),
             Bir.ROVMap.add rov_id rule rules ))
   | Oir.SFunctionCall _ -> assert false
 

--- a/src/mlang/optimizing_ir/bir_to_oir.ml
+++ b/src/mlang/optimizing_ir/bir_to_oir.ml
@@ -81,7 +81,9 @@ and translate_statement (p : Bir.program) (s : Bir.stmt)
       let instance_id = Mir.fresh_rule_id () in
       let instance_name =
         Pos.map_under_mark
-          (fun name -> name ^ "_i" ^ string_of_int instance_id)
+          (fun name ->
+            name ^ "_i"
+            ^ string_of_int (Mir.num_of_rule_or_verif_id instance_id))
           rule.rule_name
       in
       let stmts =

--- a/src/mlang/optimizing_ir/bir_to_oir.ml
+++ b/src/mlang/optimizing_ir/bir_to_oir.ml
@@ -79,7 +79,11 @@ and translate_statement (p : Bir.program) (s : Bir.stmt)
          independent code *)
       let rule = Bir.RuleMap.find rule_id p.Bir.rules in
       let instance_id = Mir.fresh_rule_id () in
-      let instance_name = rule.rule_name ^ "_i" ^ string_of_int instance_id in
+      let instance_name =
+        Pos.map_under_mark
+          (fun name -> name ^ "_i" ^ string_of_int instance_id)
+          rule.rule_name
+      in
       let stmts =
         let dummy = fresh_block_id () in
         let dummy_blocks = initialize_block dummy Oir.BlockMap.empty in

--- a/src/mlang/optimizing_ir/dead_code_removal.ml
+++ b/src/mlang/optimizing_ir/dead_code_removal.ml
@@ -142,12 +142,12 @@ let remove_dead_statements (stmts : block) (id : block_id)
               stmt :: acc,
               pos - 1 )
         | SGoto _ -> (used_vars, used_defs, stmt :: acc, pos - 1)
-        | SRuleCall (rov_id, name, stmts) ->
+        | SRovCall (rov_id, name, stmts) ->
             let used_vars, used_defs, new_stmts, pos =
               remove_dead_stmts_of stmts used_vars used_defs pos
             in
             let rule_call =
-              Pos.same_pos_as (SRuleCall (rov_id, name, new_stmts)) stmt
+              Pos.same_pos_as (SRovCall (rov_id, name, new_stmts)) stmt
             in
             (used_vars, used_defs, rule_call :: acc, pos - 1)
         | SFunctionCall _ -> assert false

--- a/src/mlang/optimizing_ir/dead_code_removal.ml
+++ b/src/mlang/optimizing_ir/dead_code_removal.ml
@@ -142,12 +142,12 @@ let remove_dead_statements (stmts : block) (id : block_id)
               stmt :: acc,
               pos - 1 )
         | SGoto _ -> (used_vars, used_defs, stmt :: acc, pos - 1)
-        | SRuleCall (rule_id, name, stmts) ->
+        | SRuleCall (rov_id, name, stmts) ->
             let used_vars, used_defs, new_stmts, pos =
               remove_dead_stmts_of stmts used_vars used_defs pos
             in
             let rule_call =
-              Pos.same_pos_as (SRuleCall (rule_id, name, new_stmts)) stmt
+              Pos.same_pos_as (SRuleCall (rov_id, name, new_stmts)) stmt
             in
             (used_vars, used_defs, rule_call :: acc, pos - 1)
         | SFunctionCall _ -> assert false

--- a/src/mlang/optimizing_ir/format_oir.ml
+++ b/src/mlang/optimizing_ir/format_oir.ml
@@ -38,7 +38,8 @@ let rec format_stmt fmt (stmt : stmt) =
         cond_error_opt_var
   | SGoto b -> Format.fprintf fmt "goto %d@," b
   | SRuleCall (_rid, name, stmts) ->
-      Format.fprintf fmt "call(%s)@[<v 3>{@,%a@]}@," name format_stmts stmts
+      Format.fprintf fmt "call(%s)@[<v 3>{@,%a@]}@," (Pos.unmark name)
+        format_stmts stmts
   | SFunctionCall (func, args) ->
       Format.fprintf fmt "call_function: %s with args %a@," func
         (Format.pp_print_list (fun fmt arg ->

--- a/src/mlang/optimizing_ir/format_oir.ml
+++ b/src/mlang/optimizing_ir/format_oir.ml
@@ -37,7 +37,7 @@ let rec format_stmt fmt (stmt : stmt) =
              Format.fprintf fmt " (%s)" (Pos.unmark v.Mir.Variable.name)))
         cond_error_opt_var
   | SGoto b -> Format.fprintf fmt "goto %d@," b
-  | SRuleCall (_rid, name, stmts) ->
+  | SRovCall (_rid, name, stmts) ->
       Format.fprintf fmt "call(%s)@[<v 3>{@,%a@]}@," (Pos.unmark name)
         format_stmts stmts
   | SFunctionCall (func, args) ->

--- a/src/mlang/optimizing_ir/inlining.ml
+++ b/src/mlang/optimizing_ir/inlining.ml
@@ -329,7 +329,7 @@ let rec inline_in_stmt (stmt : stmt) (ctx : ctx) (current_block : block_id)
       in
       (new_stmt, ctx, current_stmt_pos)
   | SGoto _ -> (stmt, ctx, current_stmt_pos)
-  | SRuleCall (rov_id, name, stmts) ->
+  | SRovCall (rov_id, name, stmts) ->
       let new_stmts, ctx, new_pos =
         List.fold_left
           (fun (stmts, ctx, stmt_pos) stmt ->
@@ -341,7 +341,7 @@ let rec inline_in_stmt (stmt : stmt) (ctx : ctx) (current_block : block_id)
           stmts
       in
       let new_stmt =
-        Pos.same_pos_as (SRuleCall (rov_id, name, List.rev new_stmts)) stmt
+        Pos.same_pos_as (SRovCall (rov_id, name, List.rev new_stmts)) stmt
       in
       (new_stmt, ctx, new_pos)
   | SFunctionCall _ -> assert false

--- a/src/mlang/optimizing_ir/inlining.ml
+++ b/src/mlang/optimizing_ir/inlining.ml
@@ -329,7 +329,7 @@ let rec inline_in_stmt (stmt : stmt) (ctx : ctx) (current_block : block_id)
       in
       (new_stmt, ctx, current_stmt_pos)
   | SGoto _ -> (stmt, ctx, current_stmt_pos)
-  | SRuleCall (rule_id, name, stmts) ->
+  | SRuleCall (rov_id, name, stmts) ->
       let new_stmts, ctx, new_pos =
         List.fold_left
           (fun (stmts, ctx, stmt_pos) stmt ->
@@ -341,7 +341,7 @@ let rec inline_in_stmt (stmt : stmt) (ctx : ctx) (current_block : block_id)
           stmts
       in
       let new_stmt =
-        Pos.same_pos_as (SRuleCall (rule_id, name, List.rev new_stmts)) stmt
+        Pos.same_pos_as (SRuleCall (rov_id, name, List.rev new_stmts)) stmt
       in
       (new_stmt, ctx, new_pos)
   | SFunctionCall _ -> assert false

--- a/src/mlang/optimizing_ir/oir.ml
+++ b/src/mlang/optimizing_ir/oir.ml
@@ -27,7 +27,7 @@ and stmt_kind =
           the join point after *)
   | SVerif of Bir.condition_data
   | SGoto of block_id
-  | SRuleCall of Bir.rov_id * string Pos.marked * stmt list
+  | SRovCall of Bir.rov_id * string Pos.marked * stmt list
   | SFunctionCall of Bir.function_name * Mir.variable list
 
 type block = stmt list
@@ -49,7 +49,7 @@ let count_instr (p : program) : int =
         match Pos.unmark s with
         | SConditional _ | SAssign _ | SVerif _ | SFunctionCall _ -> acc + 1
         | SGoto _ -> acc
-        | SRuleCall (_, _, stmts) -> aux acc stmts)
+        | SRovCall (_, _, stmts) -> aux acc stmts)
       acc stmts
   in
   BlockMap.fold (fun _ block acc -> aux acc block) p.blocks 0

--- a/src/mlang/optimizing_ir/oir.ml
+++ b/src/mlang/optimizing_ir/oir.ml
@@ -27,7 +27,7 @@ and stmt_kind =
           the join point after *)
   | SVerif of Bir.condition_data
   | SGoto of block_id
-  | SRuleCall of Bir.rule_id * string * stmt list
+  | SRuleCall of Bir.rule_id * string Pos.marked * stmt list
   | SFunctionCall of Bir.function_name * Mir.variable list
 
 type block = stmt list

--- a/src/mlang/optimizing_ir/oir.ml
+++ b/src/mlang/optimizing_ir/oir.ml
@@ -27,7 +27,7 @@ and stmt_kind =
           the join point after *)
   | SVerif of Bir.condition_data
   | SGoto of block_id
-  | SRuleCall of Bir.rule_id * string Pos.marked * stmt list
+  | SRuleCall of Bir.rov_id * string Pos.marked * stmt list
   | SFunctionCall of Bir.function_name * Mir.variable list
 
 type block = stmt list

--- a/src/mlang/optimizing_ir/oir.mli
+++ b/src/mlang/optimizing_ir/oir.mli
@@ -25,7 +25,7 @@ and stmt_kind =
   | SConditional of Bir.expression * block_id * block_id * block_id
   | SVerif of Bir.condition_data
   | SGoto of block_id
-  | SRuleCall of Bir.rule_id * string * stmt list
+  | SRuleCall of Bir.rule_id * string Pos.marked * stmt list
   | SFunctionCall of Bir.function_name * Mir.variable list
 
 type block = stmt list

--- a/src/mlang/optimizing_ir/oir.mli
+++ b/src/mlang/optimizing_ir/oir.mli
@@ -25,7 +25,7 @@ and stmt_kind =
   | SConditional of Bir.expression * block_id * block_id * block_id
   | SVerif of Bir.condition_data
   | SGoto of block_id
-  | SRuleCall of Bir.rule_id * string Pos.marked * stmt list
+  | SRuleCall of Bir.rov_id * string Pos.marked * stmt list
   | SFunctionCall of Bir.function_name * Mir.variable list
 
 type block = stmt list

--- a/src/mlang/optimizing_ir/oir.mli
+++ b/src/mlang/optimizing_ir/oir.mli
@@ -25,7 +25,7 @@ and stmt_kind =
   | SConditional of Bir.expression * block_id * block_id * block_id
   | SVerif of Bir.condition_data
   | SGoto of block_id
-  | SRuleCall of Bir.rov_id * string Pos.marked * stmt list
+  | SRovCall of Bir.rov_id * string Pos.marked * stmt list
   | SFunctionCall of Bir.function_name * Mir.variable list
 
 type block = stmt list

--- a/src/mlang/optimizing_ir/partial_evaluation.ml
+++ b/src/mlang/optimizing_ir/partial_evaluation.ml
@@ -748,7 +748,7 @@ let rec partially_evaluate_stmt (stmt : stmt) (block_id : block_id)
             :: new_block,
             ctx ))
   | SGoto _ -> (stmt :: new_block, ctx)
-  | SRuleCall (rov_id, name, stmts) ->
+  | SRovCall (rov_id, name, stmts) ->
       let stmts, ctx =
         List.fold_left
           (fun (new_block, ctx) stmt ->
@@ -756,7 +756,7 @@ let rec partially_evaluate_stmt (stmt : stmt) (block_id : block_id)
           ([], ctx) stmts
       in
       let stmt =
-        Pos.same_pos_as (SRuleCall (rov_id, name, List.rev stmts)) stmt
+        Pos.same_pos_as (SRovCall (rov_id, name, List.rev stmts)) stmt
       in
       (stmt :: new_block, ctx)
   | SFunctionCall _ -> assert false

--- a/src/mlang/optimizing_ir/partial_evaluation.ml
+++ b/src/mlang/optimizing_ir/partial_evaluation.ml
@@ -748,7 +748,7 @@ let rec partially_evaluate_stmt (stmt : stmt) (block_id : block_id)
             :: new_block,
             ctx ))
   | SGoto _ -> (stmt :: new_block, ctx)
-  | SRuleCall (rule_id, name, stmts) ->
+  | SRuleCall (rov_id, name, stmts) ->
       let stmts, ctx =
         List.fold_left
           (fun (new_block, ctx) stmt ->
@@ -756,7 +756,7 @@ let rec partially_evaluate_stmt (stmt : stmt) (block_id : block_id)
           ([], ctx) stmts
       in
       let stmt =
-        Pos.same_pos_as (SRuleCall (rule_id, name, List.rev stmts)) stmt
+        Pos.same_pos_as (SRuleCall (rov_id, name, List.rev stmts)) stmt
       in
       (stmt :: new_block, ctx)
   | SFunctionCall _ -> assert false


### PR DESCRIPTION
With this Mlang should generate the same files as the original compiler (modulo verifications for now).
Only in the DGFIP backend, I'm not sure this is something we want in the others.

I didn't notice a lot of change in compilation performances, though.