### PR TITLE
Remove traces from CI job

### DIFF
--- a/examples/dgfip_c/ml_primitif/build.sh
+++ b/examples/dgfip_c/ml_primitif/build.sh
@@ -48,8 +48,8 @@ else
 
   cd ./calc
 
-  # Note: we MUST compile with -k1
-  $MLANG -b dgfip_c --mpp_file=$MPP_FILE --mpp_function=$MPP_FUN --dgfip_options=-Ailiad,-m$YEAR,-M,-t,-g,-k1 -o enchain.c $M_SOURCES/*.m >/dev/null
+  # Note: we MUST compile with -k1 (and its dependence -g, cf. how is defined NB_DEBUG01)
+  $MLANG -b dgfip_c --mpp_file=$MPP_FILE --mpp_function=$MPP_FUN --dgfip_options=-Ailiad,-m$YEAR,-M,-g,-k1 -o enchain.c $M_SOURCES/*.m >/dev/null
 
   if [ $? -ne 0 ]; then
     echo 'La compilation des fichiers M a échoué'

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -233,7 +233,7 @@ let rec generate_c_expr (dgfip_flags : Dgfip_options.flags)
       {
         def_test = generate_variable ~def_flag:true var_indexes None var;
         value_comp =
-          generate_variable var_indexes ~debug_flag:dgfip_flags.flg_debug None
+          generate_variable var_indexes ~debug_flag:dgfip_flags.flg_trace None
             var;
         locals = [];
       }
@@ -272,7 +272,7 @@ let generate_var_def (dgfip_flags : Dgfip_options.flags)
         se.def_test
         (generate_variable var_indexes None var)
         se.value_comp
-        (if dgfip_flags.flg_debug then
+        (if dgfip_flags.flg_trace then
          let var = Bir.var_to_mir var in
          Format.asprintf "aff2(\"%s\", irdata, %s);@\n"
            (Pos.unmark var.Mir.Variable.name)


### PR DESCRIPTION
This avoid generating debug macros in DGFIP backend test and should fix CI on master.

The flag used to trigger their generation was not the one used by the legacy compiler, counter-intuitively.