### PR TITLE
Multimax semantics fix

### DIFF
--- a/examples/java/src/com/mlang/MValue.java
+++ b/examples/java/src/com/mlang/MValue.java
@@ -231,10 +231,10 @@ public class MValue {
 
     int bound = (int)Math.floor(boundMValue.getValue());
 
-    MValue max = mAdd(array[position], zero);
+    MValue max = array[position];
     for (int i = 0; i <= bound; i++) {
-      MValue challenger = mAdd(array[position + i], zero);
-      if (challenger.getValue() > max.getValue()) {
+      MValue challenger = array[position + i];
+      if (challenger.getValue() > max.getValue() || max.isUndefined()) {
         max = challenger;
       }
     }

--- a/src/mlang/backend_compilers/dgfip_varid.ml
+++ b/src/mlang/backend_compilers/dgfip_varid.ml
@@ -41,6 +41,13 @@ let gen_access_pointer vm v =
   | VarBase i -> Printf.sprintf "(B_ + %d/*%s*/)" i vn
   | VarComputed i -> Printf.sprintf "(C_ + %d/*%s*/)" i vn
 
+let gen_access_def_pointer vm v =
+  let vn = Pos.unmark v.Mir.Variable.name in
+  match Mir.VariableMap.find v vm with
+  | VarInput i -> Printf.sprintf "(DS_ + %d/*%s*/)" i vn
+  | VarBase i -> Printf.sprintf "(DB_ + %d/*%s*/)" i vn
+  | VarComputed i -> Printf.sprintf "(DC_ + %d/*%s*/)" i vn
+
 let gen_access_pos_from_start vm v =
   match Mir.VariableMap.find v vm with
   | VarInput i -> Printf.sprintf "EST_SAISIE | %d" i

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -571,8 +571,13 @@ module Make (N : Bir_number.NumberInterface) = struct
             in
             let maxi = ref (access_index 0) in
             for i = 0 to Int64.to_int up do
-              (* Fragile: rely on polymorphic compare where None < Some _ *)
-              maxi := max !maxi (access_index i)
+              match access_index i with
+              | None -> ()
+              | Some n ->
+                  maxi :=
+                    Option.fold ~none:(Some n)
+                      ~some:(fun m -> Some (max n m))
+                      !maxi
             done;
             match !maxi with None -> Undefined | Some f -> Number (N.of_int f))
         | FunctionCall (func, _) ->

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -559,7 +559,7 @@ module Make (N : Bir_number.NumberInterface) = struct
             let cast_to_int (v : value) : Int64.t option =
               match v with
               | Number f -> Some (N.to_int (roundf f))
-              | Undefined -> Some Int64.zero
+              | Undefined -> None
             in
             let pos = Pos.get_position arg2 in
             let access_index (i : int) : Int64.t option =
@@ -571,6 +571,7 @@ module Make (N : Bir_number.NumberInterface) = struct
             in
             let maxi = ref (access_index 0) in
             for i = 0 to Int64.to_int up do
+              (* Fragile: rely on polymorphic compare where None < Some _ *)
               maxi := max !maxi (access_index i)
             done;
             match !maxi with None -> Undefined | Some f -> Number (N.of_int f))


### PR DESCRIPTION
Closes #142 

`multimax` was though to be always defined, but it turns out it's only if any of its component is too.

Patched on top of #165 for simplicity, and silently dependent of #178.