### PR TITLE
Allow for selection of diversly contextualized main functions in Bir

### DIFF
--- a/src/mlang/backend_ir/bir.ml
+++ b/src/mlang/backend_ir/bir.ml
@@ -127,12 +127,19 @@ type program = {
   mpp_functions : mpp_function FunctionMap.t;
   rules_and_verifs : rule_or_verif ROVMap.t;
   main_function : function_name;
+  context_function : function_name;
   idmap : Mir.idmap;
   mir_program : Mir.program;
   outputs : unit VariableMap.t;
 }
 
 let main_statements (p : program) : stmt list =
+  try (FunctionMap.find p.context_function p.mpp_functions).mppf_stmts
+  with Not_found ->
+    Errors.raise_error
+      "Unable to find contextualized main function of Bir program"
+
+let main_statements_no_context (p : program) : stmt list =
   try (FunctionMap.find p.main_function p.mpp_functions).mppf_stmts
   with Not_found ->
     Errors.raise_error "Unable to find main function of Bir program"

--- a/src/mlang/backend_ir/bir.mli
+++ b/src/mlang/backend_ir/bir.mli
@@ -61,6 +61,7 @@ type program = {
   mpp_functions : mpp_function FunctionMap.t;
   rules_and_verifs : rule_or_verif ROVMap.t;
   main_function : function_name;
+  context_function : function_name;
   idmap : Mir.idmap;
   mir_program : Mir.program;
   outputs : unit VariableMap.t;
@@ -83,6 +84,8 @@ val set_from_mir_dict : tgv_id -> Mir.VariableDict.t -> VariableSet.t
 val rule_or_verif_as_statements : rule_or_verif -> stmt list
 
 val main_statements : program -> stmt list
+
+val main_statements_no_context : program -> stmt list
 
 val get_all_statements : program -> stmt list
 

--- a/src/mlang/backend_ir/bir_interface.ml
+++ b/src/mlang/backend_ir/bir_interface.ml
@@ -342,7 +342,7 @@ let adapt_program_to_function (p : Bir.program) (f : bir_function) :
   ( {
       p with
       mpp_functions;
-      main_function = context_function;
+      context_function;
       outputs = f.func_outputs;
     },
     List.length unused_input_stmts + List.length const_input_stmts )

--- a/src/mlang/mpp_ir/mpp_ir_to_bir.ml
+++ b/src/mlang/mpp_ir/mpp_ir_to_bir.ml
@@ -553,6 +553,8 @@ let create_combined_program (m_program : Mir_interface.full_program)
       rules_and_verifs;
       mpp_functions;
       main_function = mpp_function_to_extract;
+      (* Really just placeholders, as context will be computed in Bir_interface *)
+      context_function = mpp_function_to_extract;
       idmap = m_program.program.program_idmap;
       mir_program = m_program.program;
       outputs = Bir.VariableMap.empty;

--- a/src/mlang/optimizing_ir/bir_to_oir.ml
+++ b/src/mlang/optimizing_ir/bir_to_oir.ml
@@ -203,6 +203,7 @@ and re_translate_block (block_id : Oir.block_id)
       let stmts = List.rev stmts in
       (next_block_id, stmts, rules)
 
+(*WARNING : OIR is not tested, but change in Bir interface to main/context functions has probably broken it.*)
 let oir_program_to_bir (p : Oir.program) : Bir.program =
   let statements, rules_and_verifs =
     re_translate_blocks_until p.entry_block p.blocks Bir.ROVMap.empty None
@@ -222,4 +223,5 @@ let oir_program_to_bir (p : Oir.program) : Bir.program =
     mir_program = p.mir_program;
     outputs = p.outputs;
     main_function = p.main_function;
+    context_function = p.main_function;
   }

--- a/src/mlang/test_framework/test_interpreter.ml
+++ b/src/mlang/test_framework/test_interpreter.ml
@@ -159,7 +159,7 @@ let add_test_conds_to_combined_program (p : Bir.program)
       conds []
   in
   let mpp_functions =
-    Bir.FunctionMap.add p.Bir.main_function
+    Bir.FunctionMap.add p.Bir.context_function
       Bir.{ mppf_stmts = new_stmts @ conditions_stmts; mppf_is_verif = false }
       p.mpp_functions
   in


### PR DESCRIPTION
Bir_interface currently overwrites silently MPP-declared main function by a "context_function", adding reset of input variables and valuation of constants and conditional statements to verify according to m_spec file used. If no m_spec is used, a reset of the whole input table is added.

This results in unwanted behaviour for some backends and obfuscates which part of the statements originates from MPP files or M_spec files.

Target for this PR as for now is : 
- Bir module public interface should provide access to all three of bare main_function, main_function with context from a m_spec (context_function) and context_function providing a reset of the input table (needed for the Mlang built-in interpreter)
- Bir.program function map should stay untouched by Bir_interface, reflecting the computation as described in M and MPP, that's why statements for context_function and Co. should be stored in specific fields of the program record.