### PR TITLE
Rehabilitate partial evaluation as a per-function optimisation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,6 @@
 
 include Makefile.include
 
-ifeq ($(OPTIMIZE), 1)
-    OPTIMIZE_FLAG=-O --fast-math
-else
-    OPTIMIZE_FLAG=
-endif
-
 ifeq ($(CODE_COVERAGE), 1)
     CODE_COVERAGE_FLAG=--code_coverage
 else

--- a/Makefile.include
+++ b/Makefile.include
@@ -42,8 +42,8 @@ endif
 
 C_COMPILER?=clang
 
-ifeq ($(OPTIMIZE), 1)
-    OPTIMIZE_FLAG=-O
-else
+ifeq ($(OPTIMIZE), 0)
     OPTIMIZE_FLAG=
+else
+    OPTIMIZE_FLAG=-O
 endif

--- a/examples/dgfip_c/ml_primitif/build.sh
+++ b/examples/dgfip_c/ml_primitif/build.sh
@@ -49,7 +49,7 @@ else
   cd ./calc
 
   # Note: we MUST compile with -k1 (and its dependence -g, cf. how is defined NB_DEBUG01)
-  $MLANG -b dgfip_c --mpp_file=$MPP_FILE --mpp_function=$MPP_FUN --dgfip_options=-Ailiad,-m$YEAR,-M,-g,-k1 -o enchain.c $M_SOURCES/*.m >/dev/null
+  $MLANG -O -b dgfip_c --mpp_file=$MPP_FILE --mpp_function=$MPP_FUN --dgfip_options=-Ailiad,-m$YEAR,-M,-g,-k1 -o enchain.c $M_SOURCES/*.m >/dev/null
 
   if [ $? -ne 0 ]; then
     echo 'La compilation des fichiers M a échoué'

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -97,7 +97,7 @@ let rec format_dexpr (dgfip_flags : Dgfip_options.flags)
   match de with
   | Done -> Format.fprintf fmt "1"
   | Dzero -> Format.fprintf fmt "0"
-  | Dlit f -> Format.fprintf fmt "%f" f
+  | Dlit f -> Format.fprintf fmt "%.19g" f
   | Dvar (evar, dflag) -> format_expr_var dgfip_flags vm fmt (evar, dflag)
   | Dand (de1, de2) -> format_dexpr fmt (Dbinop ("&&", de1, de2))
   | Dor (de1, de2) -> format_dexpr fmt (Dbinop ("||", de1, de2))

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -97,7 +97,10 @@ let rec format_dexpr (dgfip_flags : Dgfip_options.flags)
   match de with
   | Done -> Format.fprintf fmt "1"
   | Dzero -> Format.fprintf fmt "0"
-  | Dlit f -> Format.fprintf fmt "%.19g" f
+  | Dlit f ->
+      (* Print literal floats as precisely as possible, without cluttering the
+         generated code *)
+      Format.fprintf fmt "%.19g" f
   | Dvar (evar, dflag) -> format_expr_var dgfip_flags vm fmt (evar, dflag)
   | Dand (de1, de2) -> format_dexpr fmt (Dbinop ("&&", de1, de2))
   | Dor (de1, de2) -> format_dexpr fmt (Dbinop ("||", de1, de2))

--- a/src/mlang/backend_ir/format_bir.ml
+++ b/src/mlang/backend_ir/format_bir.ml
@@ -38,7 +38,7 @@ let rec format_stmt fmt (stmt : stmt) =
       let cond_error_opt_var =
         Option.map var_to_mir (snd cond_data.cond_error)
       in
-      Format.fprintf fmt "assert (%a) or raise %a%a" format_expression
+      Format.fprintf fmt "assert (%a) or raise %a@,%a" format_expression
         (Pos.unmark cond_data.cond_expr)
         Format_mir.format_error (fst cond_data.cond_error)
         (Format.pp_print_option (fun fmt v ->

--- a/src/mlang/optimizing_ir/format_oir.ml
+++ b/src/mlang/optimizing_ir/format_oir.ml
@@ -37,9 +37,8 @@ let rec format_stmt fmt (stmt : stmt) =
              Format.fprintf fmt " (%s)" (Pos.unmark v.Mir.Variable.name)))
         cond_error_opt_var
   | SGoto b -> Format.fprintf fmt "goto %d@," b
-  | SRovCall (_rid, name, stmts) ->
-      Format.fprintf fmt "call(%s)@[<v 3>{@,%a@]}@," (Pos.unmark name)
-        format_stmts stmts
+  | SRovCall rid ->
+      Format.fprintf fmt "call(%d)@," (Mir.num_of_rule_or_verif_id rid)
   | SFunctionCall (func, args) ->
       Format.fprintf fmt "call_function: %s with args %a@," func
         (Format.pp_print_list (fun fmt arg ->

--- a/src/mlang/optimizing_ir/oir.mli
+++ b/src/mlang/optimizing_ir/oir.mli
@@ -25,26 +25,39 @@ and stmt_kind =
   | SConditional of Bir.expression * block_id * block_id * block_id
   | SVerif of Bir.condition_data
   | SGoto of block_id
-  | SRovCall of Bir.rov_id * string Pos.marked * stmt list
-  | SFunctionCall of Bir.function_name * Mir.variable list
+  | SRovCall of Bir.rov_id
+  | SFunctionCall of Bir.function_name * Mir.Variable.t list
 
 type block = stmt list
 
-type program = {
+type cfg = {
   blocks : block BlockMap.t;
   entry_block : block_id;
   exit_block : block_id;
+}
+
+type mpp_function = { cfg : cfg; is_verif : bool }
+
+type rov_code = Rule of cfg | Verif of cfg
+
+type rov = { id : Bir.rov_id; name : string Pos.marked; code : rov_code }
+
+type program = {
+  mpp_functions : mpp_function Bir.FunctionMap.t;
+  rules_and_verifs : rov Bir.ROVMap.t;
   idmap : Mir.idmap;
   mir_program : Mir.program;
   outputs : unit Bir.VariableMap.t;
   main_function : Bir.function_name;
 }
 
+val map_program_cfgs : (cfg -> cfg) -> program -> program
+
 val count_instr : program -> int
 
 module CFG : Graph.Sig.P with type V.t = int
 
-val get_cfg : program -> CFG.t
+val get_cfg : cfg -> CFG.t
 
 module Topological : sig
   val fold : (CFG.V.t -> 'a -> 'a) -> CFG.t -> 'a -> 'a

--- a/src/mlang/optimizing_ir/oir_optimizations.ml
+++ b/src/mlang/optimizing_ir/oir_optimizations.ml
@@ -16,8 +16,6 @@
 
 open Oir
 
-exception Exit
-
 let get_reduction_percent (init : int) (old : int) (new_ : int) : float =
   float_of_int (old - new_) /. float_of_int init *. 100.
 
@@ -37,30 +35,11 @@ let print_done ?msg (init : int) (old : int) (new_ : int) : unit =
 
 let optimize (p : program) : program =
   let start_instrs = count_instr p in
-  Cli.debug_print "Dead code removal...";
-  let p = Dead_code_removal.dead_code_removal p in
-  print_done start_instrs start_instrs (count_instr p);
-  let p = ref p in
-  (try
-     while true do
-       Cli.debug_print "Partial evaluation...";
-       let old_instrs = count_instr !p in
-       p := Partial_evaluation.partial_evaluation !p;
-       p := Dead_code_removal.dead_code_removal !p;
-       let intermediate_instrs = count_instr !p in
-       print_done start_instrs old_instrs intermediate_instrs;
-       if intermediate_instrs = old_instrs then raise Exit
-       else begin
-         Cli.debug_print "Inlining...";
-         p := Inlining.inlining !p;
-         p := Dead_code_removal.dead_code_removal !p;
-         let end_instrs = count_instr !p in
-         print_done start_instrs intermediate_instrs end_instrs;
-         if end_instrs = intermediate_instrs then raise Exit
-       end
-     done
-   with Exit -> ());
-  let p = !p in
+  Cli.debug_print "Partial evaluation...";
+  let old_instrs = count_instr p in
+  let p = Partial_evaluation.partial_evaluation p in
+  let intermediate_instrs = count_instr p in
+  print_done start_instrs old_instrs intermediate_instrs;
   let end_instrs = count_instr p in
   print_done ~msg:"Optimizations done! Total effect" start_instrs start_instrs
     end_instrs;

--- a/src/mlang/optimizing_ir/oir_optimizations.ml
+++ b/src/mlang/optimizing_ir/oir_optimizations.ml
@@ -34,6 +34,8 @@ let print_done ?msg (init : int) (old : int) (new_ : int) : unit =
        reduction_percent)
 
 let optimize (p : program) : program =
+  (* We only use partial evalutation for now, as the others are unmaintained and
+     not meant as function optimisations *)
   let start_instrs = count_instr p in
   Cli.debug_print "Partial evaluation...";
   let old_instrs = count_instr p in


### PR DESCRIPTION
This allow a few simplification in the generated code.

Dead code and inlining have gone through the same treatment but have been disabled completely as it would be difficult to test their correctness (not that I think it can be correct in this context).