### PR TITLE
Fix minmax result definition

### DIFF
--- a/examples/dgfip_c/backend_tests/Makefile
+++ b/examples/dgfip_c/backend_tests/Makefile
@@ -132,7 +132,10 @@ clean_fuzz_findings:
 clean_fuzz_tests:
 	rm -rf fuzz_tests/*.m_crash
 
-clean:
+clean_ml_primitif:
+	rm -rf ../ml_primitif/calc/* ../ml_primitif/*.o ../ml_primitif/*.cmx ../ml_primitif/*.cmi ../ml_primitif/prim
+
+clean: clean_ml_primitif
 	rm -f ir_tests.* *.o tests.m_spec *.exe *.tmp \
 	$(M_C_FILES) $(M_C_FILES:.c=.o) \
 	contexte.* famille.* penalite.* restitue.* revcor.* \

--- a/examples/java/backend_tests/src/com/mlang/TestHarness.java
+++ b/examples/java/backend_tests/src/com/mlang/TestHarness.java
@@ -95,7 +95,7 @@ public class TestHarness {
   private static List<String> extractTestErrorsFromData(TestData test, Map<String, MValue> realOutputs) {
     List<String> errorsWithVars = new ArrayList<>();
     test.getExceptedVariables().forEach((name, value) -> {
-      if (!realOutputs.get(name).equals(value)) {
+      if (!(realOutputs.get(name).getValue() == value.getValue())) {
         errorsWithVars.add("Code " + name + ", expected: " + value + ", got: " + realOutputs.get(name));
       }
     });

--- a/examples/java/src/com/mlang/MValue.java
+++ b/examples/java/src/com/mlang/MValue.java
@@ -199,11 +199,21 @@ public class MValue {
   }
 
   static MValue m_max(MValue x, MValue y) {
+    
+    if (x.isUndefined() && y.isUndefined()) {
+      return mUndefined;
+    }
+
     return new MValue(Math.max(x.getValue(), y.getValue()));
   }
 
   static MValue m_min(MValue x, MValue y) {
-    return new MValue(Math.min(x.getValue(), y.getValue()));
+ 
+    if (x.isUndefined() && y.isUndefined()) {
+      return mUndefined;
+    }
+
+   return new MValue(Math.min(x.getValue(), y.getValue()));
   }
 
   static MValue mNeg(MValue x) {

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -341,14 +341,14 @@ let rec generate_c_expr (e : expression Pos.marked)
       let se1 = generate_c_expr e1 var_indexes in
       let se2 = generate_c_expr e2 var_indexes in
       let def_test = Dor (se1.def_test, se2.def_test) in
-      let value_comp = Dfun ("_fmax", [ se1.value_comp; se2.value_comp ]) in
+      let value_comp = Dfun ("max", [ se1.value_comp; se2.value_comp ]) in
       build_transitive_composition
         { def_test; value_comp; subs = se1.subs @ se2.subs }
   | FunctionCall (MinFunc, [ e1; e2 ]) ->
       let se1 = generate_c_expr e1 var_indexes in
       let se2 = generate_c_expr e2 var_indexes in
       let def_test = Dor (se1.def_test, se2.def_test) in
-      let value_comp = Dfun ("_fmin", [ se1.value_comp; se2.value_comp ]) in
+      let value_comp = Dfun ("min", [ se1.value_comp; se2.value_comp ]) in
       build_transitive_composition
         { def_test; value_comp; subs = se1.subs @ se2.subs }
   | FunctionCall (Multimax, [ e1; (Var v2, _) ]) ->
@@ -819,13 +819,6 @@ let generate_rovs_files (dgfip_flags : Dgfip_options.flags) (program : program)
 #define add_erreur(a,b,c) add_erreur(b,c)
 #endif
 
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
-#define _fmax(x,y) fmax((x),(y))
-#define _fmin(x,y) fmin((x),(y))
-#else
-double _fmax(double x, double y);
-double _fmin(double x, double y);
-#endif
 |};
         generate_rov_functions dgfip_flags program vm fmt rovs;
         Format.pp_print_flush fmt ();
@@ -843,15 +836,6 @@ let generate_implem_header oc header_filename =
 
 #include "%s"
 
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
-#define _fmax(x,y) fmax((x),(y))
-#define _fmin(x,y) fmin((x),(y))
-#else
-double _fmax(double x, double y)
-{ return (x > y) ? x : y; }
-double _fmin(double x, double y)
-{ return (x < y) ? x : y; }
-#endif
 
 |}
     Prelude.message header_filename

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -337,14 +337,14 @@ let rec generate_c_expr (e : expression Pos.marked)
   | FunctionCall (MaxFunc, [ e1; e2 ]) ->
       let se1 = generate_c_expr e1 var_indexes in
       let se2 = generate_c_expr e2 var_indexes in
-      let def_test = Done in
+      let def_test = Dor (se1.def_test, se2.def_test) in
       let value_comp = Dfun ("_fmax", [ se1.value_comp; se2.value_comp ]) in
       build_transitive_composition
         { def_test; value_comp; subs = se1.subs @ se2.subs }
   | FunctionCall (MinFunc, [ e1; e2 ]) ->
       let se1 = generate_c_expr e1 var_indexes in
       let se2 = generate_c_expr e2 var_indexes in
-      let def_test = Done in
+      let def_test = Dor (se1.def_test, se2.def_test) in
       let value_comp = Dfun ("_fmin", [ se1.value_comp; se2.value_comp ]) in
       build_transitive_composition
         { def_test; value_comp; subs = se1.subs @ se2.subs }

--- a/src/mlang/backend_ir/bir_interpreter.ml
+++ b/src/mlang/backend_ir/bir_interpreter.ml
@@ -527,13 +527,13 @@ module Make (N : Bir_number.NumberInterface) = struct
             | Number f -> if N.is_zero f then true_value () else false_value ())
         | FunctionCall (MinFunc, [ arg1; arg2 ]) -> (
             match (evaluate_expr ctx p arg1, evaluate_expr ctx p arg2) with
+            | Undefined, Undefined -> Undefined
             | Undefined, Number f | Number f, Undefined ->
                 Number (N.min (N.zero ()) f)
-            | Undefined, Undefined -> Number (N.zero ())
             | Number fl, Number fr -> Number (N.min fl fr))
         | FunctionCall (MaxFunc, [ arg1; arg2 ]) -> (
             match (evaluate_expr ctx p arg1, evaluate_expr ctx p arg2) with
-            | Undefined, Undefined -> Number (N.zero ())
+            | Undefined, Undefined -> Undefined
             | Undefined, Number f | Number f, Undefined ->
                 Number (N.max (N.zero ()) f)
             | Number fl, Number fr -> Number (N.max fl fr))

--- a/src/mlang/optimizing_ir/partial_evaluation.ml
+++ b/src/mlang/optimizing_ir/partial_evaluation.ml
@@ -618,27 +618,13 @@ let rec partially_evaluate_expr (ctx : partial_ev_ctx) (p : Mir.program)
             from_literal (Bir_interpreter.evaluate_expr p new_e RegularFloat)
           else
             match func with
-            | ArrFunc | InfFunc -> (Pos.unmark new_e, List.hd new_ds)
+            | ArrFunc | InfFunc | MinFunc | MaxFunc | Multimax ->
+                (Pos.unmark new_e, List.hd new_ds)
             | PresentFunc -> (
                 match List.hd new_ds with
                 | Undefined -> from_literal Mir.false_literal
                 | Float -> from_literal Mir.true_literal
                 | _ -> (Pos.unmark new_e, Float))
-            | MinFunc | MaxFunc | Multimax ->
-                (* in the functions, undef is implicitly cast to 0, so let's
-                   cast it! *)
-                let new_args =
-                  List.map2
-                    (fun a d ->
-                      if Pos.unmark a = Mir.Literal Undefined || d = Undefined
-                      then Pos.same_pos_as (Mir.Literal (Float 0.)) a
-                      else a)
-                    new_args new_ds
-                in
-                let new_e =
-                  Pos.same_pos_as (Mir.FunctionCall (func, new_args)) e
-                in
-                (Pos.unmark new_e, Float)
             | _ -> assert false
         in
         (Pos.same_pos_as new_e e, d)


### PR DESCRIPTION
M functions min & max should return an undefined M value if both arguments are undefined, as it is the behaviour of the old tax system compiler.