### PR TITLE
Fix guarding condition in accessing M table variable

### DIFF
--- a/examples/java/src/com/mlang/MValue.java
+++ b/examples/java/src/com/mlang/MValue.java
@@ -276,7 +276,7 @@ public class MValue {
     
     if (indexInteger < 0) {
       return zero;
-    } else if (indexInteger > size) {
+    } else if (indexInteger >= size) {
       return mUndefined;
     } else {
       return array[tableStart + indexInteger];

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -284,8 +284,8 @@ let rec generate_c_expr (e : expression Pos.marked)
         Dand
           ( Dand
               ( Dvar (Local idx_var, Def),
-                Dbinop
-                  ("<=", Dvar (Local idx_var, Val), Dlit (float_of_int size)) ),
+                Dbinop ("<", Dvar (Local idx_var, Val), Dlit (float_of_int size))
+              ),
             Daccess (Pos.unmark var, Def, idx_var) )
       in
       let value_comp =


### PR DESCRIPTION
C and Java backend include a condition checking than a M cell table reading is in the table bound. The reference behaviour is to output a M undefined value if the queried cell has an index greater than the table last cell.

The backends where checking for index strictly greater than table size (logically, in practice this or the symmetrical check), as M table are indexed from 0, the last cell has size-1 index and the check should be greater or equal to size. 