### PR TITLE
Fix CI failure on updated GH runners

### DIFF
--- a/examples/dgfip_c/ml_primitif/build.sh
+++ b/examples/dgfip_c/ml_primitif/build.sh
@@ -86,7 +86,7 @@ fi
 
 echo 'Compilation de la calculette primitive'
 
-ocamlopt -cc clang -ccopt -fbracket-depth=2048 unix.cmxa ./calc/*.o stubs.c common.ml m.ml read_test.ml main.ml -o prim
+ocamlopt -cc clang -ccopt -fno-common -ccopt -fbracket-depth=2048 unix.cmxa ./calc/*.o stubs.c common.ml m.ml read_test.ml main.ml -o prim
 
 if [ $? -ne 0 ]; then
   echo 'La compilation de la calculette primitive a échoué'

--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -367,8 +367,6 @@ let generate_header (oc : Format.formatter) () : unit =
 #include "const.h"
 #include "var.h"
 
-double my_var1;
-
 #ifndef FLG_MULTITHREAD
 #define add_erreur(a,b,c) add_erreur(b,c)
 #endif


### PR DESCRIPTION
@mdurero found out that some recent changes on github runners would break CI through some stricter clang default options.

The culprit is a single global variable in the C generated code.