### PR TITLE
Add config options for year 2023 in the Makefiles

### DIFF
--- a/m_ext/2023/cibles.m
+++ b/m_ext/2023/cibles.m
@@ -1,0 +1,824 @@
+# compir
+
+cible regle_1:
+application: iliad;
+BIDON = 1;
+APPLI_OCEANS = 0;
+APPLI_BATCH = 0;
+APPLI_ILIAD = 1;
+
+cible calcul_primitif:
+application: iliad;
+calculer domaine primitive;
+
+cible calcul_primitif_isf:
+application: iliad;
+calculer domaine isf;
+
+cible calcul_primitif_taux:
+application: iliad;
+calculer domaine taux;
+
+cible calcul_correctif:
+application: iliad;
+calculer domaine corrective;
+
+cible sauve_base_1728:
+application: iliad;
+calculer domaine base_1728 corrective;
+
+cible sauve_base_premier:
+application: iliad;
+calculer domaine base_premier corrective;
+
+cible sauve_base_stratemajo:
+application: iliad;
+calculer domaine base_stratemajo corrective;
+
+cible sauve_base_anterieure:
+application: iliad;
+calculer domaine base_anterieure corrective;
+
+cible sauve_base_anterieure_cor:
+application: iliad;
+calculer domaine base_anterieure_cor corrective;
+
+cible sauve_base_inr_tl:
+application: iliad;
+calculer domaine base_inr_tl corrective;
+
+cible sauve_base_inr_tl22:
+application: iliad;
+calculer domaine base_inr_tl22 corrective;
+
+cible sauve_base_inr_tl24:
+application: iliad;
+calculer domaine base_inr_tl24 corrective;
+
+cible sauve_base_inr_ntl:
+application: iliad;
+calculer domaine base_inr_ntl corrective;
+
+cible sauve_base_inr_ntl22:
+application: iliad;
+calculer domaine base_inr_ntl22 corrective;
+
+cible sauve_base_inr_ntl24:
+application: iliad;
+calculer domaine base_inr_ntl24 corrective;
+
+cible sauve_base_inr_ref:
+application: iliad;
+calculer domaine base_inr_ref corrective;
+
+cible sauve_base_inr_r9901:
+application: iliad;
+calculer domaine base_inr_r9901 corrective;
+
+cible sauve_base_inr_intertl:
+application: iliad;
+calculer domaine base_inr_intertl corrective;
+
+cible sauve_base_inr_inter22:
+application: iliad;
+calculer domaine base_inr_inter22 corrective;
+
+cible sauve_base_inr_cimr99:
+application: iliad;
+calculer domaine base_inr_cimr99 corrective;
+
+cible sauve_base_inr_cimr07:
+application: iliad;
+calculer domaine base_inr_cimr07 corrective;
+
+cible sauve_base_inr_cimr24:
+application: iliad;
+calculer domaine base_inr_cimr24 corrective;
+
+cible sauve_base_inr_tlcimr07:
+application: iliad;
+calculer domaine base_inr_tlcimr07 corrective;
+
+cible sauve_base_inr_tlcimr24:
+application: iliad;
+calculer domaine base_inr_tlcimr24 corrective;
+
+cible sauve_base_tlnunv:
+application: iliad;
+calculer domaine base_TLNUNV corrective;
+
+cible sauve_base_tl:
+application: iliad;
+calculer domaine base_tl corrective;
+
+cible sauve_base_tl_init:
+application: iliad;
+calculer domaine base_tl_init corrective;
+
+cible sauve_base_tl_rect:
+application: iliad;
+calculer domaine base_tl_rect corrective;
+
+cible sauve_base_initial:
+application: iliad;
+calculer domaine base_INITIAL corrective;
+
+cible sauve_base_abat98:
+application: iliad;
+calculer domaine base_ABAT98 corrective;
+
+cible sauve_base_abat99:
+application: iliad;
+calculer domaine base_ABAT99 corrective;
+
+cible sauve_base_majo:
+application: iliad;
+calculer domaine base_MAJO corrective;
+
+cible sauve_base_inr:
+application: iliad;
+calculer domaine base_INR corrective;
+
+cible sauve_base_HR:
+application: iliad;
+calculer domaine base_HR corrective;
+
+cible sauve_base_primitive_penalisee:
+application: iliad;
+calculer domaine base_primitive_penalisee corrective;
+
+cible ENCH_TL:
+application: iliad;
+calculer enchaineur ENCH_TL;
+
+cible verif_calcul_primitive_isf:
+application: iliad;
+nettoie_erreurs;
+verifier domaine isf : avec nb_categorie(calculee *) > 0;
+
+cible verif_calcul_primitive:
+application: iliad;
+calculer cible verif_calcul_primitive_isf;
+si nb_bloquantes() = 0 alors
+  verifier domaine primitive
+  : avec
+      nb_categorie(calculee *) > 0
+      ou numero_verif() = 1021;
+finsi
+
+cible verif_calcul_corrective:
+application: iliad;
+nettoie_erreurs;
+calculer cible calcul_primitif_isf;
+calculer cible verif_calcul_primitive_isf;
+si nb_bloquantes() = 0 alors
+  verifier domaine corrective
+  : avec
+      nb_categorie(calculee *) > 0
+      ou numero_verif() = 1021;
+finsi
+
+cible verif_saisie_cohe_primitive_isf_raw:
+application: iliad;
+nettoie_erreurs;
+verifier domaine isf
+: avec nb_categorie(saisie *) > 0 et nb_categorie(calculee *) = 0;
+
+cible verif_saisie_cohe_primitive:
+application: iliad;
+nettoie_erreurs;
+calculer cible verif_saisie_cohe_primitive_isf_raw;
+si nb_bloquantes() = 0 alors
+  calculer cible calcul_primitif_isf;
+  calculer cible verif_calcul_primitive_isf;
+  si nb_bloquantes() = 0 alors
+    verifier domaine primitive
+    : avec
+        nb_categorie(saisie *) > 0 et nb_categorie(calculee *) = 0
+        et numero_verif() != 1021;
+  finsi
+finsi
+
+cible verif_saisie_cohe_corrective:
+application: iliad;
+nettoie_erreurs;
+calculer cible verif_saisie_cohe_primitive_isf_raw;
+si nb_bloquantes() = 0 alors
+  verifier domaine corrective
+  : avec
+      nb_categorie(saisie *) > 0 et nb_categorie(calculee *) = 0
+      et numero_verif() != 1021;
+finsi
+
+cible verif_cohe_horizontale:
+application: iliad;
+nettoie_erreurs;
+verifier domaine horizontale corrective;
+
+cible verif_contexte_cohe_primitive:
+application: iliad;
+nettoie_erreurs;
+verifier domaine primitive
+: avec nb_categorie(saisie contexte) = nb_categorie(*);
+
+cible verif_contexte_cohe_corrective:
+application: iliad;
+nettoie_erreurs;
+verifier domaine corrective
+: avec nb_categorie(saisie contexte) = nb_categorie(*);
+
+cible verif_famille_cohe_primitive:
+application: iliad;
+nettoie_erreurs;
+verifier domaine primitive
+: avec
+    nb_categorie(saisie famille) > 0
+    et nb_categorie(*) = nb_categorie(saisie famille) + nb_categorie(saisie contexte)
+    et numero_verif() != 1021;
+
+cible verif_famille_cohe_corrective:
+application: iliad;
+nettoie_erreurs;
+verifier domaine corrective
+: avec
+    nb_categorie(saisie famille) > 0
+    et nb_categorie(*) = nb_categorie(saisie famille) + nb_categorie(saisie contexte)
+    et numero_verif() != 1021;
+
+cible verif_revenu_cohe_primitive:
+application: iliad;
+nettoie_erreurs;
+verifier domaine primitive
+: avec nb_categorie(saisie revenu) > 0 et nb_categorie(calculee *) = 0;
+
+cible verif_revenu_cohe_corrective:
+application: iliad;
+nettoie_erreurs;
+verifier domaine corrective
+: avec nb_categorie(saisie revenu) > 0 et nb_categorie(calculee *) = 0;
+
+# primitif ml
+
+cible trace_in:
+application: iliad;
+variable temporaire: TOTO;
+TOTO = 0;
+#afficher_erreur indenter(2);
+
+cible trace_out:
+application: iliad;
+variable temporaire: TOTO;
+TOTO = 0;
+#afficher_erreur indenter(-2);
+
+cible calcul_prim_corr:
+application: iliad;
+#afficher_erreur "calcul_prim_corr[\n";
+calculer cible trace_in;
+si V_IND_TRAIT = 4 alors # PRIMITIF
+  calculer cible calcul_primitif;
+sinon
+  calculer cible calcul_correctif;
+finsi
+calculer cible trace_out;
+#afficher_erreur "]calcul_prim_corr\n";
+
+cible effacer_base_etc:
+application : iliad;
+#afficher_erreur "effacer_base_etc[\n";
+calculer cible trace_in;
+iterer
+: variable ITBASE
+: categorie calculee base *
+: dans (
+  ITBASE = indefini;
+)
+calculer cible trace_out;
+#afficher_erreur "]effacer_base_etc\n";
+
+cible effacer_calculee_etc:
+application : iliad;
+#afficher_erreur "effacer_calculee_etc[\n";
+calculer cible trace_in;
+iterer
+: variable ITCAL
+: categorie calculee, calculee restituee
+: dans (
+  ITCAL = indefini;
+)
+calculer cible trace_out;
+#afficher_erreur "]effacer_calculee_etc\n";
+
+cible calcule_acomptes:
+application: iliad;
+variable temporaire: SAUV_ART1731BIS, SAUV_PREM8_11;
+#afficher_erreur "calcule_acomptes[\n";
+calculer cible trace_in;
+FLAG_ACO = 1;
+V_CALCUL_ACO = 1;
+calculer cible calcul_prim_corr;
+V_CALCUL_ACO = 0;
+FLAG_ACO = 2;
+SAUV_ART1731BIS = ART1731BIS + 0;
+SAUV_PREM8_11 = PREM8_11 + 0;
+calculer cible effacer_calculee_etc;
+si V_IND_TRAIT = 4 alors # PRIMITIF
+  calculer cible effacer_base_etc;
+  ART1731BIS = SAUV_ART1731BIS;
+  PREM8_11 = SAUV_PREM8_11;
+finsi
+calculer cible trace_out;
+#afficher_erreur "]calcule_acomptes\n";
+
+cible effacer_avfisc_1:
+application: iliad;
+#afficher_erreur "effacer_avfisc_1[\n";
+calculer cible trace_in;
+VARTMP1 = 0;
+iterer
+: variable REV_AV
+: categorie saisie revenu, saisie revenu corrective
+: avec attribut(REV_AV, avfisc) = 1 et present(REV_AV)
+: dans (
+  VARTMP1 = 1;
+  REV_AV = indefini;
+)
+calculer cible trace_out;
+#afficher_erreur "]effacer_avfisc_1\n";
+
+cible est_code_supp_avfisc:
+application: iliad;
+#afficher_erreur "est_code_supp_avfisc[\n";
+calculer cible trace_in;
+VARTMP1 = 0;
+#si
+#     present(COD7QD)  ou present(COD7QB)  ou present(COD7QC)
+#  ou present(RFORDI)  ou present(RFROBOR) ou present(RFDORD)
+#  ou present(RFDHIS)  ou present(REPSNO3_A)
+#  ou present(COD7QF)  ou present(COD7QH)  ou present(CELRREDLG_A)
+#  ou present(PINELQM_A) ou present(RCMABD)  ou present(COD7KM)
+#  ou present(PINELQP_A) ou present(COD7QS_A)  ou present(PINELQN_A)
+#  ou present(PINELQO_A)
+#alors
+#  VARTMP1 = 1;
+#sinon
+  iterer
+  : variable REV_AV
+  : categorie saisie revenu, saisie revenu corrective
+  : avec attribut(REV_AV, avfisc) = 2 et present(REV_AV)
+  : dans (
+    VARTMP1 = 1;
+  )
+#finsi
+calculer cible trace_out;
+#afficher_erreur "]est_code_supp_avfisc\n";
+
+cible calcule_avfiscal:
+application: iliad;
+variable temporaire: EXISTE_AVFISC, SAUV_IAD11, SAUV_INE, SAUV_IRE, SAUV_ART1731BIS, SAUV_PREM8_11;
+#afficher_erreur "calcule_avfiscal[\n";
+calculer cible trace_in;
+EXISTE_AVFISC = 0;
+iterer
+: variable REV_AV
+: categorie saisie revenu, saisie revenu corrective
+  : avec attribut(REV_AV, avfisc) dans (1, 2) et present(REV_AV)  
+: dans (
+  EXISTE_AVFISC = 1;
+)
+calculer cible est_code_supp_avfisc;
+si VARTMP1 = 0 alors
+  EXISTE_AVFISC = 1;
+finsi
+si EXISTE_AVFISC = 1 alors
+  restaurer
+  : variable REV_AV
+  : categorie saisie revenu, saisie revenu corrective
+  : avec attribut(REV_AV, avfisc) = 1 et present(REV_AV)
+  : apres (
+    calculer cible effacer_avfisc_1;
+    V_INDTEO = 1;
+    V_CALCUL_NAPS = 1;
+    calculer cible calcul_prim_corr;
+    V_CALCUL_NAPS = 0;
+    SAUV_IAD11 = IAD11;
+    SAUV_INE = INE;
+    SAUV_IRE = IRE;
+    SAUV_ART1731BIS = ART1731BIS + 0;
+    SAUV_PREM8_11 = PREM8_11 + 0;
+    calculer cible effacer_calculee_etc;
+    si V_IND_TRAIT = 4 alors # PRIMITIF
+      calculer cible effacer_base_etc;
+      ART1731BIS = SAUV_ART1731BIS;
+      PREM8_11 = SAUV_PREM8_11;
+    finsi
+  )
+  V_IAD11TEO = SAUV_IAD11;
+  V_IRETEO = SAUV_IRE;
+  V_INETEO = SAUV_INE;
+sinon
+  calculer cible effacer_avfisc_1;
+finsi
+calculer cible trace_out;
+#afficher_erreur "]calcule_avfiscal\n";
+
+cible article_1731_bis:
+application : iliad;
+#afficher_erreur "article_1731_bis[\n";
+calculer cible trace_in;
+si V_IND_TRAIT = 4 alors # PRIMITIF
+  si CMAJ dans (8, 11) alors
+    ART1731BIS = 1;
+    PREM8_11 = 1;
+  sinon
+    ART1731BIS = 0;
+  finsi
+finsi
+calculer cible trace_out;
+#afficher_erreur "]article_1731_bis\n";
+
+cible calcule_acomptes_avfisc:
+application: iliad;
+variable temporaire: NAP_SANS_PENA_REEL, SAUV_ART1731BIS, SAUV_PREM8_11;
+#afficher_erreur "calcule_acomptes_avfisc[\n";
+calculer cible trace_in;
+NAP_SANS_PENA_REEL = 0; # toujours 0 ?
+FLAG_ACO = 1;
+calculer cible calcule_avfiscal;
+V_INDTEO = 0;
+V_NEGREEL = si (NAP_SANS_PENA_REEL > 0.0) alors (0) sinon (1) finsi;
+V_NAPREEL = abs(NAP_SANS_PENA_REEL);
+V_CALCUL_ACO = 1;
+calculer cible calcul_prim_corr;
+SAUV_ART1731BIS = ART1731BIS + 0;
+SAUV_PREM8_11 = PREM8_11 + 0;
+calculer cible effacer_calculee_etc;
+si V_IND_TRAIT = 4 alors # PRIMITIF
+  ART1731BIS = SAUV_ART1731BIS;
+  PREM8_11 = SAUV_PREM8_11;
+finsi
+calculer cible trace_out;
+#afficher_erreur "]calcule_acomptes_avfisc\n";
+
+cible est_calcul_acomptes:
+application: iliad;
+#afficher_erreur "est_calcul_acomptes[\n";
+calculer cible trace_in;
+VARTMP1 = 0;
+iterer
+: variable REV_AC
+: categorie saisie revenu, saisie revenu corrective
+: avec attribut(REV_AC, acompte) = 0 et present(REV_AC)
+: dans (
+  VARTMP1 = 1;
+)
+calculer cible trace_out;
+#afficher_erreur "]est_calcul_acomptes\n";
+
+cible est_calcul_avfisc:
+application: iliad;
+#afficher_erreur "est_calcul_avfisc[\n";
+calculer cible trace_in;
+VARTMP1 = 0;
+iterer
+: variable REV_AV
+: categorie saisie revenu, saisie revenu corrective
+: avec attribut(REV_AV, avfisc) = 1 et present(REV_AV)
+: dans (
+  VARTMP1 = 1;
+)
+si VARTMP1 = 0 alors
+  calculer cible est_code_supp_avfisc; 
+finsi
+calculer cible trace_out;
+#afficher_erreur "]est_calcul_avfisc\n";
+
+cible traite_double_liquidation3:
+application: iliad;
+variable temporaire: P_EST_CALCUL_ACOMPTES, CALCUL_ACOMPTES, CALCUL_AVFISC, SAUV_IRANT;
+#afficher_erreur "traite_double_liquidation3[\n";
+calculer cible trace_in;
+P_EST_CALCUL_ACOMPTES = VARTMP1;
+FLAG_ACO = 0;
+V_NEGACO = 0;
+V_AVFISCOPBIS = 0;
+V_DIFTEOREEL = 0;
+si V_IND_TRAIT = 4 alors # primitif
+  PREM8_11 = 0;
+  calculer cible article_1731_bis;
+finsi
+calculer cible est_calcul_acomptes;
+CALCUL_ACOMPTES = VARTMP1;
+calculer cible est_calcul_avfisc;
+CALCUL_AVFISC = VARTMP1;
+si CALCUL_AVFISC = 1 alors
+  SAUV_IRANT = IRANT + 0 ;
+  IRANT = indefini;
+sinon
+  SAUV_IRANT = 0;
+finsi
+si CALCUL_ACOMPTES = 1 et P_EST_CALCUL_ACOMPTES != 0 alors
+  restaurer
+  : variable REV_AC
+  : categorie saisie revenu, saisie revenu corrective
+  : avec attribut(REV_AC, acompte) = 0
+  : apres (
+    iterer
+    : variable REV_AC
+    : categorie saisie revenu, saisie revenu corrective
+    : avec attribut(REV_AC, acompte) = 0
+    : dans (
+      REV_AC = indefini;
+    )
+    si CALCUL_AVFISC = 1 alors
+      calculer cible calcule_acomptes_avfisc;
+    sinon
+      calculer cible calcule_acomptes;
+    finsi
+  )
+finsi
+si CALCUL_AVFISC = 1 alors
+  V_AVFISCOPBIS = 0;
+  V_DIFTEOREEL = 0;
+  V_INDTEO = 1;
+  calculer cible calcule_avfiscal;
+  V_INDTEO = 0;
+  V_NEGREEL = 1;
+  V_NAPREEL = 0;
+finsi
+si CALCUL_AVFISC = 1 et SAUV_IRANT != 0 alors
+  IRANT = SAUV_IRANT;
+finsi
+V_ACO_MTAP = 0;
+V_NEGACO = 0;
+calculer cible calcul_primitif_isf;
+calculer cible calcul_prim_corr;
+#afficher_erreur "calcul_primitif_taux[\n";
+calculer cible trace_in;
+calculer cible calcul_primitif_taux;
+calculer cible trace_out;
+#afficher_erreur "]calcul_primitif_taux\n";
+si V_IND_TRAIT = 4 alors # primitif
+  calculer cible verif_calcul_primitive;
+finsi
+calculer cible trace_out;
+#afficher_erreur "]traite_double_liquidation3\n";
+
+cible traite_double_liquidation_exit_taxe:
+application: iliad;
+#afficher_erreur "traite_double_liquidation_exit_taxe[\n";
+calculer cible trace_in;
+si present(PVIMPOS) ou present(CODRWB) alors
+  FLAG_3WBNEG = 0;
+  FLAG_EXIT = 1;
+  VARTMP1 = 0;
+  calculer cible traite_double_liquidation3;
+  si present(NAPTIR) alors
+    FLAG_3WBNEG = (NAPTIR < 0);
+    V_NAPTIR3WB = abs(NAPTIR);
+    NAPTIR = V_NAPTIR3WB;
+  finsi
+  si present(IHAUTREVT) alors
+    V_CHR3WB = IHAUTREVT;
+  finsi
+  si present(IAD11) alors
+    V_ID113WB = IAD11;
+  finsi
+  FLAG_EXIT = 0;
+finsi
+si present(PVSURSI) ou present(CODRWA) alors
+  FLAG_3WANEG = 0;
+  FLAG_EXIT = 2;
+  VARTMP1 = 0;
+  calculer cible traite_double_liquidation3;
+  si present(NAPTIR) alors
+    FLAG_3WANEG = (NAPTIR < 0);
+    V_NAPTIR3WA = abs(NAPTIR);
+    NAPTIR = V_NAPTIR3WA;
+  finsi
+  si present(IHAUTREVT) alors
+    V_CHR3WA = IHAUTREVT;
+  finsi
+  si present(IAD11) alors
+    V_ID113WA = IAD11;
+  finsi
+  FLAG_EXIT = 0;
+finsi
+FLAG_BAREM = 1;
+VARTMP1 = 1;
+calculer cible traite_double_liquidation3;
+si present(RASTXFOYER) alors
+  V_BARTXFOYER = RASTXFOYER;
+finsi
+si present(RASTXDEC1) alors
+  V_BARTXDEC1 = RASTXDEC1;
+finsi
+si present(RASTXDEC2) alors
+  V_BARTXDEC2 = RASTXDEC2;
+finsi
+si present(INDTAZ) alors
+  si INDTAZ >= 0 alors
+    V_BARINDTAZ = INDTAZ;
+## Segfault !!! ##
+#  sinon
+#    leve_erreur A000;
+  finsi
+finsi
+si present(IITAZIR) alors
+  FLAG_BARIITANEG = (IITAZIR < 0);
+  V_BARIITAZIR = abs(IITAZIR);
+  IITAZIR = V_BARIITAZIR;
+finsi
+si present(IRTOTAL) alors
+  V_BARIRTOTAL = IRTOTAL;
+finsi
+FLAG_BAREM = 0;
+VARTMP1 = 1;
+calculer cible traite_double_liquidation3;
+calculer cible trace_out;
+#afficher_erreur "]traite_double_liquidation_exit_taxe\n";
+
+cible traite_double_liquidation_pvro:
+application: iliad;
+#afficher_erreur "traite_double_liquidation_pvro[\n";
+calculer cible trace_in;
+si present(COD3WG) alors
+  FLAG_PVRO = 1;
+  calculer cible traite_double_liquidation_exit_taxe;
+  si present(IAD11) alors
+    V_IPVRO = IAD11;
+  finsi
+finsi
+FLAG_PVRO = 0;
+calculer cible traite_double_liquidation_exit_taxe;
+calculer cible trace_out;
+#afficher_erreur "]traite_double_liquidation_pvro\n";
+
+cible ir_verif_saisie_isf:
+application: iliad;
+calculer cible regle_1;
+calculer cible verif_saisie_cohe_primitive_isf_raw;
+
+cible ir_verif_contexte:
+application: iliad;
+calculer cible regle_1;
+calculer cible verif_contexte_cohe_primitive;
+
+cible ir_verif_famille:
+application: iliad;
+calculer cible regle_1;
+calculer cible verif_famille_cohe_primitive;
+
+cible ir_verif_revenu:
+application: iliad;
+#afficher_erreur "ir_verif_revenu[\n";
+calculer cible trace_in;
+si
+  present(COD9AA) ou present(COD9AB) ou present(COD9AC) ou present(COD9AD)
+  ou present(COD9AE) ou present(COD9BA) ou present(COD9BB) ou present(COD9CA)
+  ou present(COD9GF) ou present(COD9GH) ou present(COD9GL) ou present(COD9GM)
+  ou present(COD9GN) ou present(COD9GY) ou present(COD9NC) ou present(COD9NG)
+  ou present(COD9PR) ou present(COD9PX) ou present(COD9RS) ou present(CMAJ_ISF)
+  ou present(MOISAN_ISF)
+alors
+  si V_REGCO + 0 = 0 alors
+    V_REGCO = 1;
+  finsi
+  si V_0DA + 0 = 0 alors
+    V_0DA = 1980;
+  finsi
+finsi
+calculer cible regle_1;
+calculer cible verif_revenu_cohe_primitive;
+calculer cible trace_out;
+#afficher_erreur "]ir_verif_revenu\n";
+
+cible ir_calcul_primitif_isf:
+application: iliad;
+#afficher_erreur "ir_calcul_primitif_isf[\n";
+calculer cible trace_in;
+calculer cible calcul_primitif_isf;
+nettoie_erreurs;
+calculer cible verif_calcul_primitive_isf;
+calculer cible trace_out;
+#afficher_erreur "]ir_calcul_primitif_isf\n";
+
+cible modulation_taxation:
+application: iliad;
+#afficher_erreur "modulation_taxation[\n";
+calculer cible trace_in;
+si V_MODUL = 1 alors
+  iterer
+  : variable IT_MOD
+  : categorie saisie revenu, saisie revenu corrective, saisie famille
+  : avec present(IT_MOD) et attribut(IT_MOD, modcat) < 1
+  : dans (
+    IT_MOD = indefini;
+    leve_erreur DD40 IT_MOD;
+  )
+  iterer
+  : variable IT_MOD
+  : categorie saisie contexte
+  : avec present(IT_MOD) et attribut(IT_MOD, modcat) < 1
+  : dans (
+    IT_MOD = indefini;
+  )
+finsi
+si (non present(V_MODUL)) ou V_MODUL != 1 alors
+  iterer
+  : variable IT_MOD
+  : categorie saisie revenu, saisie revenu corrective, saisie famille
+  : avec present(IT_MOD) et attribut(IT_MOD, modcat) > 1
+  : dans (
+    IT_MOD = indefini;
+  )
+  iterer
+  : variable IT_MOD
+  : categorie saisie contexte
+  : avec present(IT_MOD) et attribut(IT_MOD, modcat) > 1
+  : dans (
+    IT_MOD = indefini;
+    leve_erreur DD40 IT_MOD;
+  )
+finsi
+calculer cible trace_out;
+#afficher_erreur "]modulation_taxation\n";
+
+cible traite_double_liquidation_2:
+application: iliad;
+calculer cible modulation_taxation;
+calculer cible traite_double_liquidation_pvro;
+
+cible enchaine_calcul:
+application: iliad;
+si V_IND_TRAIT = 4 alors # primitif
+  calculer cible effacer_base_etc;
+  calculer cible traite_double_liquidation_2;
+  calculer cible sauve_base_initial;
+  calculer cible sauve_base_1728;
+  calculer cible sauve_base_anterieure;
+  calculer cible sauve_base_anterieure_cor;
+  calculer cible sauve_base_inr_inter22;
+sinon
+  V_ACO_MTAP = 0;
+  V_NEGACO = 0;
+#  VARTMP1 = si (present(FLAGDERNIE)) alors (1) sinon (0) finsi;
+#  calculer cible traite_double_liquidation3;
+  calculer cible traite_double_liquidation_pvro;
+finsi
+
+cible enchainement_primitif:
+application: iliad;
+#afficher_erreur "traite_double_liquidation2[\n";
+calculer cible trace_in;
+calculer cible ir_verif_saisie_isf;
+finalise_erreurs;
+si nb_anomalies() > 0 alors
+  exporte_erreurs;
+sinon_si nb_discordances() + nb_informatives() = 0 alors
+  calculer cible ir_verif_contexte;
+  finalise_erreurs;
+  si nb_anomalies() = 0 alors
+    si nb_discordances() + nb_informatives() > 0 alors
+      exporte_erreurs;
+    finsi
+    calculer cible ir_verif_famille;
+    finalise_erreurs;
+    si nb_anomalies() = 0 alors
+      si nb_discordances() + nb_informatives() > 0 alors
+        exporte_erreurs;
+      finsi
+      calculer cible ir_verif_revenu;
+      finalise_erreurs;
+      si nb_anomalies() > 0 alors
+        exporte_erreurs;
+      sinon
+        si nb_discordances() + nb_informatives() > 0 alors
+          exporte_erreurs;
+        finsi
+        calculer cible ir_calcul_primitif_isf;
+        finalise_erreurs;
+        calculer cible enchaine_calcul;
+        finalise_erreurs;
+        si nb_discordances() + nb_informatives() > 0 alors
+          exporte_erreurs;
+        finsi
+      finsi
+    finsi
+  finsi
+finsi
+calculer cible trace_out;
+#afficher_erreur "]traite_double_liquidation2\n";
+
+# primitif iterpréteur
+
+cible enchainement_primitif_interpreteur:
+application: iliad;
+V_IND_TRAIT = 4; # primitif
+calculer cible enchainement_primitif;
+
+#{
+
+
+
+}#

--- a/m_ext/2023/cibles.m
+++ b/m_ext/2023/cibles.m
@@ -289,7 +289,7 @@ application : iliad;
 calculer cible trace_in;
 iterer
 : variable ITBASE
-: categorie calculee base *
+: categorie calculee base
 : dans (
   ITBASE = indefini;
 )
@@ -302,7 +302,7 @@ application : iliad;
 calculer cible trace_in;
 iterer
 : variable ITCAL
-: categorie calculee, calculee restituee
+: categorie calculee
 : dans (
   ITCAL = indefini;
 )
@@ -334,13 +334,11 @@ cible effacer_avfisc_1:
 application: iliad;
 #afficher_erreur "effacer_avfisc_1[\n";
 calculer cible trace_in;
-VARTMP1 = 0;
 iterer
 : variable REV_AV
 : categorie saisie revenu, saisie revenu corrective
 : avec attribut(REV_AV, avfisc) = 1 et present(REV_AV)
 : dans (
-  VARTMP1 = 1;
   REV_AV = indefini;
 )
 calculer cible trace_out;
@@ -348,9 +346,10 @@ calculer cible trace_out;
 
 cible est_code_supp_avfisc:
 application: iliad;
+argument: EXISTE_CODE_SUPP;
 #afficher_erreur "est_code_supp_avfisc[\n";
 calculer cible trace_in;
-VARTMP1 = 0;
+EXISTE_CODE_SUPP = 0;
 #si
 #     present(COD7QD)  ou present(COD7QB)  ou present(COD7QC)
 #  ou present(RFORDI)  ou present(RFROBOR) ou present(RFDORD)
@@ -360,14 +359,14 @@ VARTMP1 = 0;
 #  ou present(PINELQP_A) ou present(COD7QS_A)  ou present(PINELQN_A)
 #  ou present(PINELQO_A)
 #alors
-#  VARTMP1 = 1;
+#  EXISTE_CODE_SUPP = 1;
 #sinon
   iterer
   : variable REV_AV
   : categorie saisie revenu, saisie revenu corrective
   : avec attribut(REV_AV, avfisc) = 2 et present(REV_AV)
   : dans (
-    VARTMP1 = 1;
+    EXISTE_CODE_SUPP = 1;
   )
 #finsi
 calculer cible trace_out;
@@ -375,19 +374,21 @@ calculer cible trace_out;
 
 cible calcule_avfiscal:
 application: iliad;
-variable temporaire: EXISTE_AVFISC, SAUV_IAD11, SAUV_INE, SAUV_IRE, SAUV_ART1731BIS, SAUV_PREM8_11;
+variable temporaire:
+  EXISTE_AVFISC, EXISTE_CODE_SUPP,
+  SAUV_IAD11, SAUV_INE, SAUV_IRE, SAUV_ART1731BIS, SAUV_PREM8_11;
 #afficher_erreur "calcule_avfiscal[\n";
 calculer cible trace_in;
 EXISTE_AVFISC = 0;
 iterer
 : variable REV_AV
 : categorie saisie revenu, saisie revenu corrective
-  : avec attribut(REV_AV, avfisc) dans (1, 2) et present(REV_AV)  
+: avec attribut(REV_AV, avfisc) dans (1, 2) et present(REV_AV)  
 : dans (
   EXISTE_AVFISC = 1;
 )
-calculer cible est_code_supp_avfisc;
-si VARTMP1 = 0 alors
+calculer cible est_code_supp_avfisc : avec EXISTE_CODE_SUPP;
+si EXISTE_CODE_SUPP = 0 alors
   EXISTE_AVFISC = 1;
 finsi
 si EXISTE_AVFISC = 1 alors
@@ -462,43 +463,45 @@ calculer cible trace_out;
 
 cible est_calcul_acomptes:
 application: iliad;
+argument: EXISTE_ACOMPTES;
 #afficher_erreur "est_calcul_acomptes[\n";
 calculer cible trace_in;
-VARTMP1 = 0;
+EXISTE_ACOMPTES = 0;
 iterer
 : variable REV_AC
 : categorie saisie revenu, saisie revenu corrective
 : avec attribut(REV_AC, acompte) = 0 et present(REV_AC)
 : dans (
-  VARTMP1 = 1;
+  EXISTE_ACOMPTES = 1;
 )
 calculer cible trace_out;
 #afficher_erreur "]est_calcul_acomptes\n";
 
 cible est_calcul_avfisc:
 application: iliad;
+argument: EXISTE_AVFISC;
 #afficher_erreur "est_calcul_avfisc[\n";
 calculer cible trace_in;
-VARTMP1 = 0;
+EXISTE_AVFISC = 0;
 iterer
 : variable REV_AV
 : categorie saisie revenu, saisie revenu corrective
 : avec attribut(REV_AV, avfisc) = 1 et present(REV_AV)
 : dans (
-  VARTMP1 = 1;
+  EXISTE_AVFISC = 1;
 )
-si VARTMP1 = 0 alors
-  calculer cible est_code_supp_avfisc; 
+si EXISTE_AVFISC = 0 alors
+  calculer cible est_code_supp_avfisc : avec EXISTE_AVFISC; 
 finsi
 calculer cible trace_out;
 #afficher_erreur "]est_calcul_avfisc\n";
 
 cible traite_double_liquidation3:
 application: iliad;
-variable temporaire: P_EST_CALCUL_ACOMPTES, CALCUL_ACOMPTES, CALCUL_AVFISC, SAUV_IRANT;
+argument: P_EST_CALCUL_ACOMPTES;
+variable temporaire: CALCUL_ACOMPTES, CALCUL_AVFISC, SAUV_IRANT;
 #afficher_erreur "traite_double_liquidation3[\n";
 calculer cible trace_in;
-P_EST_CALCUL_ACOMPTES = VARTMP1;
 FLAG_ACO = 0;
 V_NEGACO = 0;
 V_AVFISCOPBIS = 0;
@@ -507,10 +510,8 @@ si V_IND_TRAIT = 4 alors # primitif
   PREM8_11 = 0;
   calculer cible article_1731_bis;
 finsi
-calculer cible est_calcul_acomptes;
-CALCUL_ACOMPTES = VARTMP1;
-calculer cible est_calcul_avfisc;
-CALCUL_AVFISC = VARTMP1;
+calculer cible est_calcul_acomptes : avec CALCUL_ACOMPTES;
+calculer cible est_calcul_avfisc : avec CALCUL_AVFISC;
 si CALCUL_AVFISC = 1 alors
   SAUV_IRANT = IRANT + 0 ;
   IRANT = indefini;
@@ -564,20 +565,26 @@ finsi
 calculer cible trace_out;
 #afficher_erreur "]traite_double_liquidation3\n";
 
+cible abs_flag:
+application: iliad;
+argument: VAR, ABS, FLAG;
+si present(VAR) alors
+  FLAG = (VAR < 0);
+  ABS = abs(VAR);
+  VAR = ABS;
+finsi
+
 cible traite_double_liquidation_exit_taxe:
 application: iliad;
+variable temporaire: CALCULER_ACOMPTES;
 #afficher_erreur "traite_double_liquidation_exit_taxe[\n";
 calculer cible trace_in;
 si present(PVIMPOS) ou present(CODRWB) alors
   FLAG_3WBNEG = 0;
   FLAG_EXIT = 1;
-  VARTMP1 = 0;
-  calculer cible traite_double_liquidation3;
-  si present(NAPTIR) alors
-    FLAG_3WBNEG = (NAPTIR < 0);
-    V_NAPTIR3WB = abs(NAPTIR);
-    NAPTIR = V_NAPTIR3WB;
-  finsi
+  CALCULER_ACOMPTES = 0;
+  calculer cible traite_double_liquidation3 : avec CALCULER_ACOMPTES;
+  calculer cible abs_flag : avec NAPTIR, V_NAPTIR3WB, FLAG_3WBNEG;
   si present(IHAUTREVT) alors
     V_CHR3WB = IHAUTREVT;
   finsi
@@ -589,13 +596,9 @@ finsi
 si present(PVSURSI) ou present(CODRWA) alors
   FLAG_3WANEG = 0;
   FLAG_EXIT = 2;
-  VARTMP1 = 0;
-  calculer cible traite_double_liquidation3;
-  si present(NAPTIR) alors
-    FLAG_3WANEG = (NAPTIR < 0);
-    V_NAPTIR3WA = abs(NAPTIR);
-    NAPTIR = V_NAPTIR3WA;
-  finsi
+  CALCULER_ACOMPTES = 0;
+  calculer cible traite_double_liquidation3 : avec CALCULER_ACOMPTES;
+  calculer cible abs_flag : avec NAPTIR, V_NAPTIR3WA, FLAG_3WANEG;  
   si present(IHAUTREVT) alors
     V_CHR3WA = IHAUTREVT;
   finsi
@@ -605,8 +608,8 @@ si present(PVSURSI) ou present(CODRWA) alors
   FLAG_EXIT = 0;
 finsi
 FLAG_BAREM = 1;
-VARTMP1 = 1;
-calculer cible traite_double_liquidation3;
+CALCULER_ACOMPTES = 1;
+calculer cible traite_double_liquidation3 : avec CALCULER_ACOMPTES;
 si present(RASTXFOYER) alors
   V_BARTXFOYER = RASTXFOYER;
 finsi
@@ -624,17 +627,13 @@ si present(INDTAZ) alors
 #    leve_erreur A000;
   finsi
 finsi
-si present(IITAZIR) alors
-  FLAG_BARIITANEG = (IITAZIR < 0);
-  V_BARIITAZIR = abs(IITAZIR);
-  IITAZIR = V_BARIITAZIR;
-finsi
+calculer cible abs_flag : avec IITAZIR, V_BARIITAZIR, FLAG_BARIITANEG;  
 si present(IRTOTAL) alors
   V_BARIRTOTAL = IRTOTAL;
 finsi
 FLAG_BAREM = 0;
-VARTMP1 = 1;
-calculer cible traite_double_liquidation3;
+CALCULER_ACOMPTES = 1;
+calculer cible traite_double_liquidation3 : avec CALCULER_ACOMPTES;
 calculer cible trace_out;
 #afficher_erreur "]traite_double_liquidation_exit_taxe\n";
 
@@ -751,6 +750,7 @@ calculer cible traite_double_liquidation_pvro;
 
 cible enchaine_calcul:
 application: iliad;
+# variable temporaire: CALCULER_ACOMPTES;
 si V_IND_TRAIT = 4 alors # primitif
   calculer cible effacer_base_etc;
   calculer cible traite_double_liquidation_2;
@@ -762,51 +762,52 @@ si V_IND_TRAIT = 4 alors # primitif
 sinon
   V_ACO_MTAP = 0;
   V_NEGACO = 0;
-#  VARTMP1 = si (present(FLAGDERNIE)) alors (1) sinon (0) finsi;
-#  calculer cible traite_double_liquidation3;
+#  CALCULER_ACOMPTES = si (present(FLAGDERNIE)) alors (1) sinon (0) finsi;
+#  calculer cible traite_double_liquidation3 : avec CALCULER_ACOMPTES;
   calculer cible traite_double_liquidation_pvro;
+finsi
+
+cible exporte_si_non_bloquantes:
+application: iliad;
+si nb_discordances() + nb_informatives() > 0 alors
+  exporte_erreurs;
 finsi
 
 cible enchainement_primitif:
 application: iliad;
+variable temporaire: EXPORTE_ERREUR;
 #afficher_erreur "traite_double_liquidation2[\n";
 calculer cible trace_in;
 calculer cible ir_verif_saisie_isf;
 finalise_erreurs;
-si nb_anomalies() > 0 alors
-  exporte_erreurs;
-sinon_si nb_discordances() + nb_informatives() = 0 alors
+EXPORTE_ERREUR = 1;
+quand nb_anomalies() = 0 faire
+  EXPORTE_ERREUR = 0;
+puis_quand nb_discordances() + nb_informatives() = 0 faire
   calculer cible ir_verif_contexte;
   finalise_erreurs;
-  si nb_anomalies() = 0 alors
-    si nb_discordances() + nb_informatives() > 0 alors
-      exporte_erreurs;
-    finsi
-    calculer cible ir_verif_famille;
-    finalise_erreurs;
-    si nb_anomalies() = 0 alors
-      si nb_discordances() + nb_informatives() > 0 alors
-        exporte_erreurs;
-      finsi
-      calculer cible ir_verif_revenu;
-      finalise_erreurs;
-      si nb_anomalies() > 0 alors
-        exporte_erreurs;
-      sinon
-        si nb_discordances() + nb_informatives() > 0 alors
-          exporte_erreurs;
-        finsi
-        calculer cible ir_calcul_primitif_isf;
-        finalise_erreurs;
-        calculer cible enchaine_calcul;
-        finalise_erreurs;
-        si nb_discordances() + nb_informatives() > 0 alors
-          exporte_erreurs;
-        finsi
-      finsi
-    finsi
+  EXPORTE_ERREUR = 0;
+puis_quand nb_anomalies() = 0 faire
+  calculer cible exporte_si_non_bloquantes;
+  calculer cible ir_verif_famille;
+  finalise_erreurs;
+puis_quand nb_anomalies() = 0 faire
+  EXPORTE_ERREUR = 1;
+puis_quand nb_discordances() + nb_informatives() = 0 faire
+  calculer cible ir_verif_revenu;
+  finalise_erreurs;
+puis_quand nb_anomalies() = 0 faire
+  calculer cible exporte_si_non_bloquantes;
+  calculer cible ir_calcul_primitif_isf;
+  finalise_erreurs;
+  calculer cible enchaine_calcul;
+  finalise_erreurs;
+  calculer cible exporte_si_non_bloquantes;
+sinon_faire
+  si EXPORTE_ERREUR = 1 alors
+    exporte_erreurs;
   finsi
-finsi
+finquand
 calculer cible trace_out;
 #afficher_erreur "]traite_double_liquidation2\n";
 
@@ -817,8 +818,3 @@ application: iliad;
 V_IND_TRAIT = 4; # primitif
 calculer cible enchainement_primitif;
 
-#{
-
-
-
-}#

--- a/makefiles/functions.mk
+++ b/makefiles/functions.mk
@@ -53,7 +53,7 @@ $(if $(call not,$(call is_in,$(1))), \
 endef
 
 define source_dir
-$(1)tgvI.m $(1)errI.m $(shell find $(1) -name \*.m ! -name err\*.m ! -name tgv\*.m | sort)
+$(shell find $(1) -name tgvI.m) $(shell find $(1) -name errI.m) $(shell find $(1) -name \*.m ! -name err\*.m ! -name tgv\*.m | sort)
 endef
 
 define source_dir_ext

--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -13,7 +13,14 @@ MUSL_HOME?=/usr/local/musl
 # Tax computation configuration
 ##################################################
 
-ifeq ($(YEAR), 2022)
+ifeq ($(YEAR), 2023)
+    $(warning WARNING: the source M files and fuzzer tests have not yet been published for year: 2023)
+	SOURCE_FILES?=$(call source_dir,$(ROOT_DIR)/ir-calcul/M_SVN/$(YEAR)/)
+	SOURCE_EXT_FILES?=$(call source_dir_ext,$(ROOT_DIR)/m_ext/2023/)
+# Add a TESTS_DIR when available
+	MPP_FUNCTION_BACKEND?=enchainement_primitif
+	MPP_FUNCTION?=enchainement_primitif_interpreteur
+else ifeq ($(YEAR), 2022)
 	SOURCE_FILES?=$(call source_dir,$(ROOT_DIR)/ir-calcul/sources2022m_6_1/)
 	SOURCE_EXT_FILES?=$(call source_dir_ext,$(ROOT_DIR)/m_ext/2022/)
 	TESTS_DIR?=$(ROOT_DIR)/tests/2022/fuzzing

--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -13,41 +13,16 @@ MUSL_HOME?=/usr/local/musl
 # Tax computation configuration
 ##################################################
 
+MPP_FUNCTION_BACKEND?=enchainement_primitif
+MPP_FUNCTION?=enchainement_primitif_interpreteur
+SOURCE_EXT_FILES?=$(call source_dir_ext,$(ROOT_DIR)/m_ext/$(YEAR)/)
+# Add a TESTS_DIR for 2023 when available
 ifeq ($(YEAR), 2023)
-    $(warning WARNING: the source M files and fuzzer tests have not yet been published for year: 2023)
+    $(warning WARNING: the source M files and fuzzer tests have not yet been published for year: $(YEAR). Should you choose to provide your own source files, you can create a directory ir-calcul/M_SVN/$(YEAR) and put them in there)
 	SOURCE_FILES?=$(call source_dir,$(ROOT_DIR)/ir-calcul/M_SVN/$(YEAR)/)
-	SOURCE_EXT_FILES?=$(call source_dir_ext,$(ROOT_DIR)/m_ext/2023/)
-# Add a TESTS_DIR when available
-	MPP_FUNCTION_BACKEND?=enchainement_primitif
-	MPP_FUNCTION?=enchainement_primitif_interpreteur
-else ifeq ($(YEAR), 2022)
-	SOURCE_FILES?=$(call source_dir,$(ROOT_DIR)/ir-calcul/sources2022m_6_1/)
-	SOURCE_EXT_FILES?=$(call source_dir_ext,$(ROOT_DIR)/m_ext/2022/)
-	TESTS_DIR?=$(ROOT_DIR)/tests/2022/fuzzing
-	M_SPEC_FILE?=$(ROOT_DIR)/m_specs/complex_case_with_ins_outs_2020.m_spec
-	MPP_FUNCTION_BACKEND?=enchainement_primitif
-	MPP_FUNCTION?=enchainement_primitif_interpreteur
-else ifeq ($(YEAR), 2021)
-	SOURCE_FILES?=$(call source_dir,$(ROOT_DIR)/ir-calcul/sources2021m_20_6/)
-	SOURCE_EXT_FILES?=$(call source_dir_ext,$(ROOT_DIR)/m_ext/2021/)
-	TESTS_DIR?=$(ROOT_DIR)/tests/2021/fuzzing
-	M_SPEC_FILE?=$(ROOT_DIR)/m_specs/complex_case_with_ins_outs_2020.m_spec
-	MPP_FUNCTION_BACKEND?=enchainement_primitif
-	MPP_FUNCTION?=enchainement_primitif_interpreteur
-else ifeq ($(YEAR), 2020)
-	SOURCE_FILES?=$(call source_dir,$(ROOT_DIR)/ir-calcul/sources2020m_6_5/)
-	SOURCE_EXT_FILES?=$(call source_dir_ext,$(ROOT_DIR)/m_ext/2020/)
-	TESTS_DIR?=$(ROOT_DIR)/tests/2020/fuzzing
-	M_SPEC_FILE?=$(ROOT_DIR)/m_specs/complex_case_with_ins_outs_2020.m_spec
-	MPP_FUNCTION_BACKEND?=enchainement_primitif
-	MPP_FUNCTION?=enchainement_primitif_interpreteur
-else ifeq ($(YEAR), 2019)
-	SOURCE_FILES?=$(call source_dir,$(ROOT_DIR)/ir-calcul/sources2019m_8_0/)
-	SOURCE_EXT_FILES?=$(call source_dir_ext,$(ROOT_DIR)/m_ext/2019/)
-	TESTS_DIR?=$(ROOT_DIR)/tests/2019/fuzzing
-	M_SPEC_FILE?=m_specs/complex_case_with_ins_outs_2019.m_spec
-	MPP_FUNCTION_BACKEND?=enchainement_primitif
-	MPP_FUNCTION?=enchainement_primitif_interpreteur
+else ifeq ($(filter $(YEAR), 2019 2020 2021 2022), $(YEAR))
+	SOURCE_FILES?=$(call source_dir,$(ROOT_DIR)/ir-calcul/sources$(YEAR)*/)
+	TESTS_DIR?=$(ROOT_DIR)/tests/$(YEAR)/fuzzing
 else
     $(warning WARNING: there is no default configuration for year: $(YEAR))
     $(warning WARNING: example specification files and fuzzer tests are not included for year: $(YEAR))


### PR DESCRIPTION
Should we have a "default" m_ext source file that will be updated following the latest changes?
For now, using the same m_ext file (`cibles.m`) as for 2022. We should make that cleaner, even if it simply consists of copying & pasting in a 2023 directory