### PR TITLE
Renaming and prototype change for the Calculette memory refactor

### DIFF
--- a/src/mlang/backend_compilers/bir_to_dgfip_c.ml
+++ b/src/mlang/backend_compilers/bir_to_dgfip_c.ml
@@ -394,15 +394,9 @@ let generate_mpp_function (dgfip_flags : Dgfip_options.flags)
     f
     (generate_stmts dgfip_flags program var_indexes)
     mppf_stmts
-    (if ret_type then
-     {|
-#ifdef FLG_MULTITHREAD
-      return irdata->discords;
-#else
-      return discords;
-#endif
-|}
-    else "")
+    (if ret_type then {|
+      return irdata->tEnvDiscord.discords;
+|} else "")
 
 let generate_mpp_functions (dgfip_flags : Dgfip_options.flags)
     (program : Bir.program) (oc : Format.formatter)

--- a/src/mlang/backend_compilers/dgfip_gen_files.ml
+++ b/src/mlang/backend_compilers/dgfip_gen_files.ml
@@ -972,7 +972,6 @@ let gen_var_h fmt flags vars vars_debug rules verifs chainings errors =
   let taille_saisie = count vars (Input None) in
   let taille_calculee = count vars (Computed (Some Computed)) in
   let taille_base = count vars (Computed (Some Base)) in
-  let taille_totale = taille_saisie + taille_calculee + taille_base in
   let nb_contexte = count vars (Input (Some Context)) in
   let nb_famille = count vars (Input (Some Family)) in
   let nb_revenu = count vars (Input (Some Income)) in
@@ -988,10 +987,9 @@ let gen_var_h fmt flags vars vars_debug rules verifs chainings errors =
 
   Format.fprintf fmt
     {|
-#define TAILLE_SAISIE %d
-#define TAILLE_CALCULEE %d
-#define TAILLE_BASE %d
-#define TAILLE_TOTALE %d
+#define NB_SAISIE %d
+#define NB_CALCULEE %d
+#define NB_BASE %d
 #define NB_CONTEXTE %d
 #define NB_FAMILLE %d
 #define NB_REVENU %d
@@ -1000,10 +998,17 @@ let gen_var_h fmt flags vars vars_debug rules verifs chainings errors =
 #define NB_PENALITE %d
 #define NB_RESTITUEE %d
 #define NB_ENCH %d
+
+extern double arr_g(double);
+extern double floor_g(double);
+extern double ceil_g(double);
+extern int multimax_def(int, char *);
+extern double multimax(double, double *);
+extern int modulo_def(int, int);
+extern double modulo(double, double);
 |}
-    taille_saisie taille_calculee taille_base taille_totale nb_contexte
-    nb_famille nb_revenu nb_revenu_correc nb_variation nb_penalite nb_restituee
-    nb_ench;
+    taille_saisie taille_calculee taille_base nb_contexte nb_famille nb_revenu
+    nb_revenu_correc nb_variation nb_penalite nb_restituee nb_ench;
 
   if flags.Dgfip_options.flg_debug then begin
     Format.fprintf fmt "#define NB_ERR %d\n" nb_err;
@@ -1026,14 +1031,11 @@ let gen_var_h fmt flags vars vars_debug rules verifs chainings errors =
     Format.fprintf fmt "#define NB_VERIF %d\n" nb_verif;
 
   List.iter
-    (fun rn ->
-      Format.fprintf fmt "extern int regle_%d _PROTS((struct S_irdata *));\n" rn)
+    (fun rn -> Format.fprintf fmt "extern int regle_%d (T_irdata *);\n" rn)
     rules;
 
   List.iter
-    (fun vn ->
-      Format.fprintf fmt "extern void verif_%d _PROTS((struct S_irdata *));\n"
-        vn)
+    (fun vn -> Format.fprintf fmt "extern void verif_%d (T_irdata *);\n" vn)
     verifs;
 
   (* TODO external declaration of individual control rules (seems to be no

--- a/src/mlang/dgfip_m.ml
+++ b/src/mlang/dgfip_m.ml
@@ -259,5 +259,6 @@ let string_to_rule_domain_id : string -> string list = function
   | "base_anterieure" -> [ "corrective"; "base_anterieure" ]
   | "base_anterieure_cor" -> [ "corrective"; "base_anterieure_cor" ]
   | "base_stratemajo" -> [ "corrective"; "base_stratemajo" ]
+  | "base_TLNUNV" -> [ "corrective"; "base_TLNUNV" ]
   | "horizontale" -> [ "horizontale" ]
   | _ -> raise Not_found

--- a/src/mlang/driver.ml
+++ b/src/mlang/driver.ml
@@ -60,11 +60,15 @@ let patch_rule_1 (backend : string option) (dgfip_flags : Dgfip_options.flags)
       match Pos.unmark item with
       | Rule r when Pos.unmark r.rule_number = 1 ->
           let fl =
-            [
-              mk_assign "APPLI_OCEANS" oceans;
-              mk_assign "APPLI_BATCH" batch;
-              mk_assign "APPLI_ILIAD" iliad;
-            ]
+            match dgfip_flags.annee_revenu with
+            | 2024 ->
+                [ mk_assign "APPLI_BATCH" batch; mk_assign "APPLI_ILIAD" iliad ]
+            | _ ->
+                [
+                  mk_assign "APPLI_OCEANS" oceans;
+                  mk_assign "APPLI_BATCH" batch;
+                  mk_assign "APPLI_ILIAD" iliad;
+                ]
           in
           ( Rule { r with rule_formulaes = r.rule_formulaes @ fl },
             Pos.get_position item )


### PR DESCRIPTION
Basically:

- some constant renaming,
- ditch one FLG_MULTITHREAD in enchain generated code,
- new names for irdata members with context,
- add extern mathematical function in var.h,
- remove TAILLE_TOTALE,
- remove some _PROTS.