### PR TITLE
Automatise un marquage de la version de l’exécutable par git-describe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ default: FORCE build
 
 all: FORCE quick_test tests test_dgfip_c_backend
 
-clean: FORCE
+clean: FORCE remise_a_zero_versionnage
 	$(call make_in,$(DGFIP_DIR),clean_backend_all)
 	rm -f doc/doc.html
 	dune clean

--- a/dune-project
+++ b/dune-project
@@ -2,7 +2,7 @@
 
 (name mlang)
 
-(version 1.1.0)
+(version %%VERSION%%)
 
 (generate_opam_files true)
 

--- a/makefiles/functions.mk
+++ b/makefiles/functions.mk
@@ -44,7 +44,7 @@ $(if $(call not,$(call is_in,$(1))), \
 endef
 
 define make_in_raw
-$(MAKE) --no-print-directory -f $(ROOT_DIR)/Makefile -C $(ROOT_DIR)/$(1) ROOT_DIR=$(ROOT_DIR) $(2)
+@$(MAKE) --no-print-directory -f $(ROOT_DIR)/Makefile -C $(ROOT_DIR)/$(1) ROOT_DIR=$(ROOT_DIR) $(2)
 endef
 
 define check_in

--- a/makefiles/mlang.mk
+++ b/makefiles/mlang.mk
@@ -34,6 +34,10 @@ else
 	git submodule update ir-calcul
 endif
 
+remise_a_zero_versionnage: FORCE
+	sed -i 's/(version .*)/(version %%VERSION%%)/' dune-project
+	git checkout -- *.opam
+
 ##################################################
 # Building the compiler
 ##################################################
@@ -49,7 +53,10 @@ dune: FORCE
 ifeq ($(call is_in,),)
 	$(call make_in,,$@)
 else
+	echo $(shell pwd)
+	sed -i 's/(version %%VERSION%%)/(version ${shell git describe --always --dirty --tag})/' dune-project
 	LINKING_MODE=$(LINKING_MODE) dune build $(DUNE_OPTIONS)
+	$(call make_in_raw,,remise_a_zero_versionnage)
 endif
 
 build: FORCE | format dune


### PR DESCRIPTION
C’est le plus propre que j’ai pondu avec l’aide de David pour se brancher à ses makefiles.