### PR TITLE
Ajoute le type de règle base_TLNUNV pour autotest sur anciens millésimes

### DIFF
--- a/src/mlang/dgfip_m.ml
+++ b/src/mlang/dgfip_m.ml
@@ -263,6 +263,7 @@ let string_to_rule_domain_id : string -> string list = function
   | "base_anterieure" -> [ "corrective"; "base_anterieure" ]
   | "base_anterieure_cor" -> [ "corrective"; "base_anterieure_cor" ]
   | "base_stratemajo" -> [ "corrective"; "base_stratemajo" ]
+  | "base_TLNUNV" -> [ "corrective"; "base_TLNUNV" ]
   | "horizontale" -> [ "horizontale" ]
   | "base_primitive_penalisee" -> [ "corrective"; "base_primitive_penalisee" ]
   | _ -> raise Not_found


### PR DESCRIPTION
Avec ça, on doit pouvoir faire manger à Mlang toutes les anciennes années jusqu’en 2013 au moins. Sous réserve qu’un cibles.m vide sois fourni puisque maintenant on se base sur Mlang 2 avec le primitif.