### PR TITLE
New errors and warnings

### DIFF
--- a/makefiles/mlang.mk
+++ b/makefiles/mlang.mk
@@ -61,8 +61,14 @@ endif
 
 build: FORCE | format dune
 
+build-ci: DUNE_OPTIONS=--profile ci
+build-ci: FORCE | dune
+
+build-release: DUNE_OPTIONS=--profile release
+build-release: FORCE | dune
+
 build-static: LINKING_MODE=static
-build-static: FORCE build
+build-static: FORCE build-release
 
 ##################################################
 # Testing the compiler

--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -33,7 +33,7 @@ endif
 # Mlang configuration
 ##################################################
 
-MLANG_BIN=dune exec $(ROOT_DIR)/_build/default/src/main.exe --
+MLANG_BIN=OCAMLRUNPARAM=$(OCAMLRUNPARAM) dune exec $(ROOT_DIR)/_build/default/src/main.exe --
 
 PRECISION?=double
 MLANG_DEFAULT_OPTS=\

--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -33,7 +33,7 @@ endif
 # Mlang configuration
 ##################################################
 
-MLANG_BIN=OCAMLRUNPARAM=$(OCAMLRUNPARAM) dune exec $(ROOT_DIR)/_build/default/src/main.exe --
+MLANG_BIN=dune exec $(ROOT_DIR)/_build/default/src/main.exe --
 
 PRECISION?=double
 MLANG_DEFAULT_OPTS=\

--- a/src/dune
+++ b/src/dune
@@ -1,13 +1,13 @@
 (env
  (dev
   (flags
-   (:standard -g -warn-error -a)))
+   (:standard -warn-error -a)))
  (ci
   (flags
-   (:standard -warn-error +a)))
+   (:standard -w +a-4-40..42-44-45-70 -warn-error +a)))
  (release
   (flags
-   (:standard -warn-error -a))))
+   (:standard -w +a-4-40..42-44-45-70 -warn-error -a))))
 
 (rule
  (with-stdout-to

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,13 @@
 (env
  (dev
   (flags
-   (:standard -warn-error -A))))
+   (:standard -g -warn-error -a)))
+ (ci
+  (flags
+   (:standard -warn-error +a)))
+ (release
+  (flags
+   (:standard -warn-error -a))))
 
 (rule
  (with-stdout-to

--- a/src/dune
+++ b/src/dune
@@ -2,9 +2,11 @@
  (dev
   (flags
    (:standard -warn-error -a)))
+ ;; fail on warnings in CI mode
  (ci
   (flags
    (:standard -w +a-4-40..42-44-45-70 -warn-error +a)))
+ ;; show warnings but still allow release in release mode
  (release
   (flags
    (:standard -w +a-4-40..42-44-45-70 -warn-error -a))))

--- a/src/main.ml
+++ b/src/main.ml
@@ -14,12 +14,4 @@
    You should have received a copy of the GNU General Public License along with
    this program. If not, see <https://www.gnu.org/licenses/>. *)
 
-open Mlang
-
-let () =
-  Printexc.record_backtrace true;
-  try ignore (Driver.main ()) with
-  | Exit -> ()
-  | e ->
-      Format.eprintf "Uncaught exception: %s@." (Printexc.to_string e);
-      Format.eprintf "%s@." (Printexc.get_backtrace ())
+let () = Mlang.Driver.main ()

--- a/src/mlang/backend_compilers/dgfip_compir_files.ml
+++ b/src/mlang/backend_compilers/dgfip_compir_files.ml
@@ -216,7 +216,7 @@ let get_vars (cprog : Mir.program) is_ebcdic =
                 idxo_opt,
                 name,
                 Option.map Pos.unmark tgv.alias,
-                Strings.sanitize_str tgv.descr,
+                Pos.unmark tgv.descr,
                 tgv.typ,
                 tgv.attrs,
                 size )

--- a/src/mlang/backend_compilers/dgfip_gen_files.ml
+++ b/src/mlang/backend_compilers/dgfip_gen_files.ml
@@ -225,10 +225,8 @@ let gen_erreurs_c fmt flags (cprog : Mir.program) =
         "T_erreur erreur_%s = { \"%s%s%s / %s\", \"%s\", \"%s\", \"%s\", \
          \"%s\", %d };\n"
         (Pos.unmark e.name) (Pos.unmark e.famille) (Pos.unmark e.code_bo)
-        sous_code_suffix
-        (Strings.sanitize_str e.libelle)
-        (Pos.unmark e.code_bo) (Pos.unmark e.sous_code) (Pos.unmark e.is_isf)
-        (Pos.unmark e.name) terr)
+        sous_code_suffix (Pos.unmark e.libelle) (Pos.unmark e.code_bo)
+        (Pos.unmark e.sous_code) (Pos.unmark e.is_isf) (Pos.unmark e.name) terr)
     cprog.program_errors;
 
   if flags.Dgfip_options.flg_pro || flags.flg_iliad then begin

--- a/src/mlang/driver.ml
+++ b/src/mlang/driver.ml
@@ -235,10 +235,10 @@ let driver (files : string list) (application_names : string list)
             Errors.raise_error (Format.asprintf "Unknown backend: %s" backend)
       | None -> Errors.raise_error "No backend specified!"
     end
-  with Errors.StructuredError (msg, pos_list, kont) ->
+  with Errors.StructuredError (msg, pos_list, kont) as e ->
     Cli.error_print "%a" Errors.format_structured_error (msg, pos_list);
     (match kont with None -> () | Some kont -> kont ());
-    exit (-1)
+    raise e
 
 let main () =
   exit @@ Cmdliner.Cmd.eval @@ Cmdliner.Cmd.v Cli.info (Cli.mlang_t driver)

--- a/src/mlang/driver.ml
+++ b/src/mlang/driver.ml
@@ -236,15 +236,9 @@ let driver (files : string list) (application_names : string list)
       | None -> Errors.raise_error "No backend specified!"
     end
   with Errors.StructuredError (msg, pos_list, kont) ->
-    let pp_pos fmt (s_opt, p) =
-      match s_opt with
-      | Some s -> Format.fprintf fmt "(%s, %a)" s Pos.format_position_gnu p
-      | None -> Pos.format_position_gnu fmt p
-    in
-    Cli.error_print "Uncaught exception: Errors.StructuredError(\"%s\")@."
-      (String.escaped msg);
-    Cli.error_print "%a@." (Pp.list_endline pp_pos) pos_list;
+    Cli.error_print "%a" Errors.format_structured_error (msg, pos_list);
     (match kont with None -> () | Some kont -> kont ());
-    Format.eprintf "%s@." (Printexc.get_backtrace ())
+    exit (-1)
 
-let main () = Cmdliner.Cmd.eval @@ Cmdliner.Cmd.v Cli.info (Cli.mlang_t driver)
+let main () =
+  exit @@ Cmdliner.Cmd.eval @@ Cmdliner.Cmd.v Cli.info (Cli.mlang_t driver)

--- a/src/mlang/m_frontend/check_validity.ml
+++ b/src/mlang/m_frontend/check_validity.ml
@@ -2004,7 +2004,7 @@ let check_no_variable_duplicates (rdom_rules : rule IntMap.t)
         else boo)
       rule_defined false
   in
-  if duplicate then exit 1
+  if duplicate then exit (-1)
 
 let complete_rule_domains (prog : program) : program =
   let prog_targets =

--- a/src/mlang/m_frontend/check_validity.ml
+++ b/src/mlang/m_frontend/check_validity.ml
@@ -1939,8 +1939,10 @@ let rule_graph_to_instrs (rdom_chain : rdom_or_chain) (prog : program)
     Some
       (function
       | id, var ->
-          Cli.debug_print "warning: auto-cycle in rule %d with variable %s" id
-            var)
+          Errors.print_spanned_warning
+            (Format.asprintf
+               "Rule %d needs variable %s as both input and output" id var)
+            Pos.no_pos)
   in
   let sorted_rules =
     try RulesSorting.sort ~auto_cycle rule_graph with

--- a/src/mlang/m_frontend/check_validity.ml
+++ b/src/mlang/m_frontend/check_validity.ml
@@ -1632,15 +1632,16 @@ let rec check_instructions (instrs : Mast.instruction Pos.marked list)
   let env, res, in_vars, out_vars, def_vars =
     aux (env, [], StrSet.empty, StrSet.empty, StrMap.empty) instrs
   in
-  StrMap.iter
-    (fun vn l ->
-      if List.length l > 1 && not (is_vartmp vn) then
-        Errors.print_multispanned_warning
-          (Format.asprintf
-             "Variable %s is defined more than once in the same rule" vn)
-          (List.map (fun pos -> (None, pos)) (List.rev l)))
-    (* List.rev for purely cosmetic reasons *)
-    def_vars;
+  if is_rule then
+    StrMap.iter
+      (fun vn l ->
+        if List.length l > 1 && not (is_vartmp vn) then
+          Errors.print_multispanned_warning
+            (Format.asprintf
+               "Variable %s is defined more than once in the same rule" vn)
+            (List.map (fun pos -> (None, pos)) (List.rev l)))
+      (* List.rev for purely cosmetic reasons *)
+      def_vars;
   let tmp_vars =
     StrMap.fold (fun vn _ s -> StrSet.add vn s) env.tmp_vars StrSet.empty
   in

--- a/src/mlang/m_frontend/check_validity.ml
+++ b/src/mlang/m_frontend/check_validity.ml
@@ -17,15 +17,13 @@ type rdom_or_chain = RuleDomain of Com.DomainId.t | Chaining of string
 module MarkedVarNames = struct
   type t = string Pos.marked
 
-  type t_marked = t
-
   let compare a b = compare (Pos.unmark a) (Pos.unmark b)
 
   let pp_marked fmt elt = Format.fprintf fmt "%s" (Pos.unmark elt)
 
   module Set = struct
     include SetExt.Make (struct
-      type t = t_marked
+      type nonrec t = t
 
       let compare = compare
     end)
@@ -37,7 +35,7 @@ module MarkedVarNames = struct
 
   module Map = struct
     include MapExt.Make (struct
-      type t = t_marked
+      type nonrec t = t
 
       let compare = compare
     end)

--- a/src/mlang/m_frontend/check_validity.ml
+++ b/src/mlang/m_frontend/check_validity.ml
@@ -1988,23 +1988,21 @@ let check_no_variable_duplicates (rdom_rules : rule IntMap.t)
           out rule_defined)
       rdom_rules StrMap.empty
   in
-  let duplicate =
-    StrMap.fold
-      (fun var_name rule_list boo ->
-        if (not (is_vartmp var_name)) && List.length rule_list > 1 then (
-          Cli.error_print
+  StrMap.iter
+    (fun var_name rule_list ->
+      if (not (is_vartmp var_name)) && List.length rule_list > 1 then
+        let msg =
+          Format.asprintf
             "Variable %s is defined in %d different rules in rule domain %a: %a"
             var_name (List.length rule_list) (Com.DomainId.pp ()) rdom_id
             (Format.pp_print_list
                ?pp_sep:(Some (fun fmt () -> Format.fprintf fmt ","))
                (fun fmt id -> Format.fprintf fmt "%d" id))
-            (List.rev rule_list);
+            (List.rev rule_list)
           (* List.rev for cosmetic reasons *)
-          true)
-        else boo)
-      rule_defined false
-  in
-  if duplicate then exit (-1)
+        in
+        Errors.raise_error msg)
+    rule_defined
 
 let complete_rule_domains (prog : program) : program =
   let prog_targets =

--- a/src/mlang/m_frontend/check_validity.mli
+++ b/src/mlang/m_frontend/check_validity.mli
@@ -12,6 +12,18 @@
 
 type rule_or_verif = Rule | Verif
 
+module MarkedVarNames : sig
+  type t
+
+  val compare : t -> t -> int
+
+  val pp_marked : Format.formatter -> t -> unit
+
+  module Set : SetExt.T with type elt = t
+
+  module Map : MapExt.T with type key = t
+end
+
 type syms = Com.DomainId.t Pos.marked Com.DomainIdMap.t
 
 type 'a doms = 'a Com.domain Com.DomainIdMap.t
@@ -30,8 +42,8 @@ type rule = {
   rule_tmp_vars :
     (string Pos.marked * Mast.table_size Pos.marked option) StrMap.t;
   rule_instrs : Mast.instruction Pos.marked list;
-  rule_in_vars : StrSet.t;
-  rule_out_vars : StrSet.t;
+  rule_in_vars : MarkedVarNames.Set.t;
+  rule_out_vars : MarkedVarNames.Set.t;
   rule_seq : int;
 }
 

--- a/src/mlang/m_ir/com.mli
+++ b/src/mlang/m_ir/com.mli
@@ -141,9 +141,7 @@ module Var : sig
 
   module Set : SetExt.T with type elt = t
 
-  module Map : sig
-    include MapExt.T with type key = t
-  end
+  module Map : MapExt.T with type key = t
 
   (* val compare_name_ref : (string -> string -> int) ref
 

--- a/src/mlang/m_ir/mir_number.mli
+++ b/src/mlang/m_ir/mir_number.mli
@@ -79,7 +79,7 @@ module IntervalNumber : NumberInterface
 module RationalNumber : NumberInterface
 
 module BigIntFixedPointNumber : functor
-  (P : sig
+  (_ : sig
      val scaling_factor_bits : int ref
    end)
   -> NumberInterface

--- a/src/mlang/m_ir/mir_roundops.mli
+++ b/src/mlang/m_ir/mir_roundops.mli
@@ -38,7 +38,7 @@ module MultiRoundOps : RoundOpsFunctor
     behavior depends on the sie of the `long` type, this size must be given as
     an argument (and should be either 32 or 64). *)
 module MainframeRoundOps : functor
-  (L : sig
+  (_ : sig
      val max_long : Int64.t ref
    end)
   -> RoundOpsFunctor

--- a/src/mlang/utils/errors.ml
+++ b/src/mlang/utils/errors.ml
@@ -63,3 +63,7 @@ let raise_spanned_error_with_continuation (msg : string)
 let print_spanned_warning (msg : string) ?(span_msg : string option)
     (span : Pos.t) : unit =
   Cli.warning_print "%a" format_structured_error (msg, [ (span_msg, span) ])
+
+let print_multispanned_warning (msg : string)
+    (spans : (string option * Pos.t) list) =
+  Cli.warning_print "%a" format_structured_error (msg, spans)

--- a/src/mlang/utils/errors.mli
+++ b/src/mlang/utils/errors.mli
@@ -39,3 +39,5 @@ val raise_spanned_error_with_continuation :
 (* {2 Prints warnings with useful error messages }*)
 
 val print_spanned_warning : string -> ?span_msg:string -> Pos.t -> unit
+
+val print_multispanned_warning : string -> (string option * Pos.t) list -> unit

--- a/src/mlang/utils/strings.ml
+++ b/src/mlang/utils/strings.ml
@@ -14,17 +14,17 @@
    You should have received a copy of the GNU General Public License along with
    this program. If not, see <https://www.gnu.org/licenses/>. *)
 
-let sanitize_str (s, p) =
-  String.map
-    (fun c ->
-      if c >= Char.chr 128 then
-        let () =
-          Cli.warning_print "Replaced char code %d by space %a" (Char.code c)
-            Pos.format_position p
-        in
-        ' '
-      else c)
-    s
+(* let sanitize_str (s, p) =
+   String.map
+     (fun c ->
+       if c >= Char.chr 128 then
+         let () =
+           Cli.warning_print "Replaced char code %d by space %a" (Char.code c)
+             Pos.format_position p
+         in
+         ' '
+       else c)
+     s *)
 
 let compare_default = String.compare
 

--- a/src/mlang/utils/strings.mli
+++ b/src/mlang/utils/strings.mli
@@ -14,10 +14,10 @@
    You should have received a copy of the GNU General Public License along with
    this program. If not, see <https://www.gnu.org/licenses/>. *)
 
-val sanitize_str : string * Pos.t -> string
+(* val sanitize_str : string * Pos.t -> string *)
 (** DGFiP sources are encoded in iso-8859-1 which is not compatible with some
     backend compilers such as Java and Python, this function transforms illegal
-    characters with a space. *)
+    characters with a space. - not useful anymore (for now) *)
 
 val compare_default : string -> string -> int
 


### PR DESCRIPTION
- Raise a warning if a variable is defined twice within the same rule
- Raise an error if a variable is defined in two different rules (within the same chaining). This brings back the same behaviour as the legacy compiler.
- Improve the error message for an auto-cycle (the warning typically happens if instructions within a rule are in the wrong order, so that a variable is used before being defined)
