### PR TITLE
Fix interpretation of undefined variables

### DIFF
--- a/src/mlang/m_ir/mir_interpreter.ml
+++ b/src/mlang/m_ir/mir_interpreter.ml
@@ -862,7 +862,7 @@ let prepare_interp (sort : Cli.value_sort) (roundops : Cli.round_ops) : unit =
 
 let evaluate_program (p : Mir.program) (inputs : Com.literal Com.Var.Map.t)
     (sort : Cli.value_sort) (roundops : Cli.round_ops) :
-    float option StrMap.t * StrSet.t =
+    Com.literal StrMap.t * StrSet.t =
   prepare_interp sort roundops;
   let module Interp = (val get_interp sort roundops : S) in
   let ctx = Interp.empty_ctx p in
@@ -873,9 +873,7 @@ let evaluate_program (p : Mir.program) (inputs : Com.literal Com.Var.Map.t)
       if Com.Var.is_given_back var then
         let fVal =
           let litt = ctx.ctx_tgv.(Com.Var.loc_int var) in
-          match Interp.value_to_literal litt with
-          | Com.Float f -> Some f
-          | Com.Undefined -> None
+          Interp.value_to_literal litt
         in
         StrMap.add name fVal res
       else res

--- a/src/mlang/m_ir/mir_interpreter.mli
+++ b/src/mlang/m_ir/mir_interpreter.mli
@@ -158,7 +158,7 @@ val evaluate_program :
   Com.literal Com.Var.Map.t ->
   Cli.value_sort ->
   Cli.round_ops ->
-  float option StrMap.t * StrSet.t
+  Com.literal StrMap.t * StrSet.t
 (** Main interpreter function *)
 
 val evaluate_expr :

--- a/src/mlang/test_framework/test_interpreter.ml
+++ b/src/mlang/test_framework/test_interpreter.ml
@@ -157,9 +157,12 @@ let check_all_tests (p : Mir.program) (test_dir : string)
   Cli.display_time := true;
   Cli.result_print "Test results: %d successes" (List.length s);
 
-  if StrMap.cardinal f = 0 then Cli.result_print "No failures!"
+  let failing = StrMap.cardinal f in
+  if failing = 0 then Cli.result_print "No failures!"
   else (
-    Cli.warning_print "Failures:";
     StrMap.iter
-      (fun name nbErr -> Cli.error_print "\t%d errors in files %s" nbErr name)
-      f)
+      (fun name nbErr -> Cli.error_print "\t%d errors in file %s" nbErr name)
+      f;
+    Errors.raise_error
+      (Format.asprintf "%d failing out of %d files" failing
+         (Array.length arr)))

--- a/src/mlang/test_framework/test_interpreter.ml
+++ b/src/mlang/test_framework/test_interpreter.ml
@@ -95,7 +95,8 @@ let check_test (program : Mir.program) (test_name : string)
   let nbErrs = check_vars expVars varMap + check_anos expAnos anoSet in
   if nbErrs > 0 then raise (InterpError nbErrs)
 
-type process_acc = string list * int StrMap.t
+type process_acc = int StrMap.t
+(* Number of errors encounters in each file *)
 
 let check_all_tests (p : Mir.program) (test_dir : string)
     (value_sort : Cli.value_sort) (round_ops : Cli.round_ops)
@@ -114,8 +115,7 @@ let check_all_tests (p : Mir.program) (test_dir : string)
   Cli.warning_flag := false;
   Cli.display_time := false;
   (* let _, finish = Cli.create_progress_bar "Testing files" in*)
-  let process (name : string) ((successes, failures) : process_acc) :
-      process_acc =
+  let process (name : string) (failures : process_acc) : process_acc =
     let module Interp = (val Mir_interpreter.get_interp value_sort round_ops
                            : Mir_interpreter.S)
     in
@@ -124,38 +124,37 @@ let check_all_tests (p : Mir.program) (test_dir : string)
       check_test p (test_dir ^ name) value_sort round_ops;
       Cli.debug_flag := true;
       Cli.result_print "%s" name;
-      (name :: successes, failures)
+      failures
     with
-    | InterpError nbErr -> (successes, StrMap.add name nbErr failures)
+    | InterpError nbErr -> StrMap.add name nbErr failures
     | Errors.StructuredError (msg, pos, kont) ->
         Cli.error_print "Error in test %s: %a" name
           Errors.format_structured_error (msg, pos);
         (match kont with None -> () | Some kont -> kont ());
-        (successes, failures)
+        failures
     | Interp.RuntimeError (run_error, _) -> (
         match run_error with
         | Interp.StructuredError (msg, pos, kont) ->
             Cli.error_print "Error in test %s: %a" name
               Errors.format_structured_error (msg, pos);
             (match kont with None -> () | Some kont -> kont ());
-            (successes, failures)
+            failures
         | Interp.NanOrInf (msg, (_, pos)) ->
             Cli.error_print "Runtime error in test %s: NanOrInf (%s, %a)" name
               msg Pos.format_position pos;
-            (successes, failures))
+            failures)
     | e ->
         Cli.error_print "Uncatched exception: %s" (Printexc.to_string e);
         raise e
   in
-  let s, f =
-    Parmap.parfold ~chunksize:5 process (Parmap.A arr) ([], StrMap.empty)
-      (fun (old_s, old_f) (new_s, new_f) ->
-        (new_s @ old_s, StrMap.union (fun _ x1 x2 -> Some (x1 + x2)) old_f new_f))
+  let f =
+    Parmap.parfold ~chunksize:5 process (Parmap.A arr) StrMap.empty
+      (fun old_f new_f ->
+        StrMap.union (fun _ x1 x2 -> Some (x1 + x2)) old_f new_f)
   in
   (* finish "done!"; *)
   Cli.warning_flag := true;
   Cli.display_time := true;
-  Cli.result_print "Test results: %d successes" (List.length s);
 
   let failing = StrMap.cardinal f in
   if failing = 0 then Cli.result_print "No failures!"
@@ -164,5 +163,4 @@ let check_all_tests (p : Mir.program) (test_dir : string)
       (fun name nbErr -> Cli.error_print "\t%d errors in file %s" nbErr name)
       f;
     Errors.raise_error
-      (Format.asprintf "%d failing out of %d files" failing
-         (Array.length arr)))
+      (Format.asprintf "%d failing out of %d files" failing (Array.length arr)))

--- a/src/mlang/test_framework/test_interpreter.ml
+++ b/src/mlang/test_framework/test_interpreter.ml
@@ -67,14 +67,16 @@ let check_test (program : Mir.program) (test_name : string)
     let test_error_margin = 0.01 in
     let fold var f nb =
       match StrMap.find_opt var vars with
-      | Some (Some f') ->
-          if abs_float (f -. f') > test_error_margin then (
-            Cli.error_print "KO | %s expected: %f - evaluated: %f" var f f';
-            nb + 1)
-          else nb
-      | _ ->
-          Cli.error_print "KO | %s is either undefined or not given back" var;
+      | None ->
+          Cli.error_print "KO | %s is not given back" var;
           nb + 1
+      | Some Com.Undefined ->
+          Cli.error_print "KO | %s is undefined" var;
+          nb + 1
+      | Some (Com.Float f') when abs_float (f -. f') > test_error_margin ->
+          Cli.error_print "KO | %s expected: %f - evaluated: %f" var f f';
+          nb + 1
+      | Some (Com.Float _) -> nb
     in
     StrMap.fold fold exp 0
   in

--- a/src/mlang/test_framework/test_interpreter.ml
+++ b/src/mlang/test_framework/test_interpreter.ml
@@ -65,16 +65,21 @@ let check_test (program : Mir.program) (test_name : string)
   in
   let check_vars exp vars =
     let test_error_margin = 0.01 in
-    let fold var f nb =
-      match StrMap.find_opt var vars with
+    let fold e f nb =
+      match StrMap.find_opt e vars with
       | None ->
-          Cli.error_print "KO | %s is not given back" var;
+          Cli.error_print "KO | %s is not given back, expected %f" e f;
           nb + 1
+      | Some Com.Undefined when f = 0. ->
+          (* Fuzzer tests of 2020 and before generates a lot of variables equal
+             to 0.000000 as a default result value, hence if a value is interpreted
+             as undefined, we accept strict equality with 0. *)
+          nb
       | Some Com.Undefined ->
-          Cli.error_print "KO | %s is undefined" var;
+          Cli.error_print "KO | %s is undefined, expected: %f" e f;
           nb + 1
       | Some (Com.Float f') when abs_float (f -. f') > test_error_margin ->
-          Cli.error_print "KO | %s expected: %f - evaluated: %f" var f f';
+          Cli.error_print "KO | %s expected: %f - evaluated: %f" e f f';
           nb + 1
       | Some (Com.Float _) -> nb
     in


### PR DESCRIPTION
Fuzzer tests before 2020 used 0.000000 as an expected value for 'undefined'. Since https://github.com/MLanguage/mlang/pull/262 this equivalence have been lost and make tests fails.

This PR adds more details on variable status after intepretation and accepts 'Undefined' as a correct value for 0.