### PR TITLE
Not recompiling already compiled files when possible

### DIFF
--- a/src/irj_checker/irj_checker.ml
+++ b/src/irj_checker/irj_checker.ml
@@ -14,10 +14,11 @@
    this program. If not, see <https://www.gnu.org/licenses/>. *)
 
 (** The Irj_checker Module is a simple entry point to use the Mlang IRJ file
-    parser in order to perform syntactic checks on test files or produce other IR
-    test formats.
+    parser in order to perform syntactic checks on test files or produce other
+    IR test formats.
 
-    Usage: irj_checker.exe [--message-format=VAL] <test_file.irj> [transformation-target]*)
+    Usage: irj_checker.exe [--message-format=VAL] <test_file.irj>
+    [transformation-target]*)
 
 open Cmdliner
 open Mlang

--- a/src/mlang/backend_compilers/decoupledExpr.mli
+++ b/src/mlang/backend_compilers/decoupledExpr.mli
@@ -39,7 +39,9 @@ val new_local : unit -> local_var
 
     would turn into
 
-    {[ mult (lit 0.5) (plus (local_var x) (local_var y)) ]}
+    {[
+      mult (lit 0.5) (plus (local_var x) (local_var y))
+    ]}
 
     where [x] and [y] are previously defined {!local_var}s *)
 
@@ -116,7 +118,8 @@ val ite : constr -> constr -> constr -> constr
 (** {2 Decoupled expressions} *)
 
 (** While {!constr} is the expression language for decoupled values, the
-    following represents complete and optimized expressions for M computations *)
+    following represents complete and optimized expressions for M computations
+*)
 
 type expression_composition = {
   set_vars : (dflag * string * constr) list;
@@ -139,7 +142,8 @@ type t
 (** Decoupled expression type. Closed representation of a computation. *)
 
 val is_always_true : t -> bool
-(** Tells if the expression [t] reprensents a value statically different to zero *)
+(** Tells if the expression [t] reprensents a value statically different to zero
+*)
 
 type local_decls
 (** Representation of local variables existing in an expression *)

--- a/src/mlang/driver.ml
+++ b/src/mlang/driver.ml
@@ -158,7 +158,7 @@ let set_opts (files : string list) (application_names : string list)
     (run_test : string option) (mpp_function : string)
     (optimize_unsafe_float : bool) (precision : string option)
     (roundops : string option) (comparison_error_margin : float option)
-    (income_year : int option) (m_clean_calls : bool)
+    (income_year : int option) (m_clean_calls : bool) (lazy_c_generation : bool)
     (dgfip_options : string list option) =
   let value_sort =
     let precision = Option.get precision in
@@ -224,8 +224,8 @@ let set_opts (files : string list) (application_names : string list)
   Cli.set_all_arg_refs files application_names without_dgfip_m debug
     var_info_debug display_time dep_graph_file print_cycles output
     optimize_unsafe_float m_clean_calls comparison_error_margin income_year
-    value_sort round_ops backend dgfip_test_filter mpp_function dgfip_flags
-    execution_mode
+    value_sort round_ops backend dgfip_test_filter mpp_function
+    lazy_c_generation dgfip_flags execution_mode
 
 let run_single_test m_program test =
   Mir_interpreter.repl_debug := true;

--- a/src/mlang/m_frontend/expander.ml
+++ b/src/mlang/m_frontend/expander.ml
@@ -514,9 +514,11 @@ let rec iterate_all_combinations (ld : loop_domain) : loop_context list =
     iterated values.
 
     In OCaml terms, if you want [translate_loop_variables lvs f ctx], then you
-    should define [f] by [let f = fun lc i ctx -> ...] and use {!val:
-    merge_loop_ctx} inside [...] before translating the loop body. [lc] is the
-    loop context, [i] the loop sequence index and [ctx] the translation context. *)
+    should define [f] by [let f = fun lc i ctx -> ...] and use
+    {!val:
+    merge_loop_ctx} inside [...] before translating the loop body.
+    [lc] is the loop context, [i] the loop sequence index and [ctx] the
+    translation context. *)
 
 let expand_loop_variables (lvs : Com.m_var_name Com.loop_variables Pos.marked)
     (const_map : const_context) : (loop_context -> 'a) -> 'a list =

--- a/src/mlang/m_frontend/mast_to_mir.ml
+++ b/src/mlang/m_frontend/mast_to_mir.ml
@@ -589,7 +589,7 @@ let complete_stats ((prog : Validator.program), (stats : Mir.stats)) :
   in
   (prog, { stats with nb_all_tmps; sz_all_tmps; nb_all_refs })
 
-(** {1 Translation } *)
+(** {1 Translation} *)
 
 (** {2 General translation context} *)
 

--- a/src/mlang/m_ir/mir_roundops.mli
+++ b/src/mlang/m_ir/mir_roundops.mli
@@ -32,7 +32,8 @@ module DefaultRoundOps : RoundOpsFunctor
 (** Default rounding operations: those used in the PC/single-thread context *)
 
 module MultiRoundOps : RoundOpsFunctor
-(** Multithread rounding operations: those used in the PC/multi-thread context *)
+(** Multithread rounding operations: those used in the PC/multi-thread context
+*)
 
 (** Mainframe rounding operations: those used in the mainframe context. As the
     behavior depends on the sie of the `long` type, this size must be given as

--- a/src/mlang/utils/cli.ml
+++ b/src/mlang/utils/cli.ml
@@ -173,6 +173,14 @@ let m_clean_calls =
           "Clean the value of computed variables between two m calls (to check \
            that there is no hidden state kept between two calls)")
 
+let lazy_c_gen =
+  Arg.(
+    value & flag
+    & info [ "lazy-c-generation" ]
+        ~doc:
+          "When set, does not regenerate C files that have not changed, \
+           preserving their metadata.")
+
 let dgfip_options =
   Arg.(
     value
@@ -188,7 +196,7 @@ let mlang_t f =
     $ display_time $ dep_graph_file $ no_print_cycles $ backend $ output
     $ run_all_tests $ dgfip_test_filter $ run_test $ mpp_function
     $ optimize_unsafe_float $ precision $ roundops $ comparison_error_margin_cli
-    $ income_year_cli $ m_clean_calls $ dgfip_options)
+    $ income_year_cli $ m_clean_calls $ lazy_c_gen $ dgfip_options)
 
 let info =
   let doc =
@@ -292,6 +300,8 @@ let dgfip_test_filter = ref false
 
 let mpp_function = ref ""
 
+let lazy_c_generation = ref false
+
 let dgfip_flags = ref Dgfip_options.default_flags
 
 let execution_mode = ref Extraction
@@ -309,8 +319,8 @@ let set_all_arg_refs (files_ : files) applications_ (without_dgfip_m_ : bool)
     (m_clean_calls_ : bool) (comparison_error_margin_ : float option)
     (income_year_ : int option) (value_sort_ : value_sort)
     (round_ops_ : round_ops) (backend_ : backend) (dgfip_test_filter_ : bool)
-    (mpp_function_ : string) (dgfip_flags_ : Dgfip_options.flags)
-    (execution_mode_ : execution_mode) =
+    (mpp_function_ : string) (lazy_c_generation_ : bool)
+    (dgfip_flags_ : Dgfip_options.flags) (execution_mode_ : execution_mode) =
   source_files := files_;
   application_names := applications_;
   without_dgfip_m := without_dgfip_m_;
@@ -332,6 +342,7 @@ let set_all_arg_refs (files_ : files) applications_ (without_dgfip_m_ : bool)
   backend := backend_;
   dgfip_test_filter := dgfip_test_filter_;
   mpp_function := mpp_function_;
+  lazy_c_generation := lazy_c_generation_;
   dgfip_flags := dgfip_flags_;
   match output_file_ with
   | None -> ()
@@ -367,7 +378,7 @@ let add_prefix_to_each_line (s : string) (prefix : int -> string) =
 
 (**{2 Markers}*)
 
-(** Prints [\[INFO\]] in blue on the terminal standard output *)
+(** Prints [[INFO]] in blue on the terminal standard output *)
 let var_info_marker () =
   ANSITerminal.printf [ ANSITerminal.Bold; ANSITerminal.blue ] "[VAR INFO] "
 
@@ -390,28 +401,28 @@ let format_with_style (styles : ANSITerminal.style list)
   if true (* can depend on a stylr flag *) then ANSITerminal.sprintf styles str
   else Printf.sprintf str
 
-(** Prints [\[DEBUG\]] in purple on the terminal standard output as well as
-    timing since last debug *)
+(** Prints [[DEBUG]] in purple on the terminal standard output as well as timing
+    since last debug *)
 let debug_marker (f_time : bool) =
   if f_time then time_marker ();
   ANSITerminal.printf [ ANSITerminal.Bold; ANSITerminal.magenta ] "[DEBUG] "
 
-(** Prints [\[ERROR\]] in red on the terminal error output *)
+(** Prints [[ERROR]] in red on the terminal error output *)
 let error_marker () =
   ANSITerminal.eprintf [ ANSITerminal.Bold; ANSITerminal.red ] "[ERROR] "
 
-(** Prints [\[WARNING\]] in yellow on the terminal standard output *)
+(** Prints [[WARNING]] in yellow on the terminal standard output *)
 let warning_marker () =
   ANSITerminal.printf [ ANSITerminal.Bold; ANSITerminal.yellow ] "[WARNING] "
 
-(** Prints [\[RESULT\]] in green on the terminal standard output *)
+(** Prints [[RESULT]] in green on the terminal standard output *)
 let result_marker () =
   ANSITerminal.printf [ ANSITerminal.Bold; ANSITerminal.green ] "[RESULT] "
 
 let clocks =
   Array.of_list [ "🕛"; "🕐"; "🕑"; "🕒"; "🕓"; "🕔"; "🕕"; "🕖"; "🕗"; "🕘"; "🕙"; "🕚" ]
 
-(** Prints [\[🕛\]] in blue on the terminal standard output *)
+(** Prints [[🕛]] in blue on the terminal standard output *)
 let clock_marker i =
   let new_time = Unix.gettimeofday () in
   let initial_time = !initial_time in

--- a/src/mlang/utils/cli.mli
+++ b/src/mlang/utils/cli.mli
@@ -39,6 +39,7 @@ val mlang_t :
   float option ->
   int option ->
   bool ->
+  bool ->
   string list option ->
   'a) ->
   'a Cmdliner.Term.t
@@ -136,6 +137,8 @@ val dgfip_test_filter : bool ref
 
 val mpp_function : string ref
 
+val lazy_c_generation : bool ref
+
 val dgfip_flags : Dgfip_options.flags ref
 
 val execution_mode : execution_mode ref
@@ -159,6 +162,7 @@ val set_all_arg_refs :
   backend ->
   (* dgfip_test_filter *) bool ->
   (* mpp_function *) string ->
+  (* lazy_c_generation *) bool ->
   (* dgfip_flags *) Dgfip_options.flags ->
   (* execution_mode *) execution_mode ->
   unit

--- a/src/mlang/utils/pos.ml
+++ b/src/mlang/utils/pos.ml
@@ -78,8 +78,8 @@ let format fmt (pos : t) =
 
 type 'a marked =
   | Mark of 'a * t
-      (** Everything related to the source code should keep its t stored, to improve
-    error messages *)
+      (** Everything related to the source code should keep its t stored, to
+          improve error messages *)
 
 (** Placeholder t *)
 let none : t =

--- a/src/mlang/utils/pos.mli
+++ b/src/mlang/utils/pos.mli
@@ -27,14 +27,16 @@ val make_between : t -> t -> t
 val format_short : Format.formatter -> t -> unit
 
 val format_gnu : Format.formatter -> t -> unit
-(** Respects https://www.gnu.org/prep/standards/standards.html#Formatting-Error-Messages *)
+(** Respects
+    https://www.gnu.org/prep/standards/standards.html#Formatting-Error-Messages
+*)
 
 val format : Format.formatter -> t -> unit
 
 type 'a marked =
   | Mark of 'a * t
-      (** Everything related to the source code should keep its t stored, to improve
-    error messages *)
+      (** Everything related to the source code should keep its t stored, to
+          improve error messages *)
 
 val none : t
 (** Placeholder t *)


### PR DESCRIPTION
Adds two options to mlang.

* --stats : displays time statistics of the parsing & compilation ;
*  --only-compile-new : tries to only compile the M files that have been updated.

This last option is checks for each file M that:
* it has not been modified;
* the constants that have changed were not used in the file;
* the variables are the same.

It generates a project-data.internal file in the output directory that contains a marshalled representation of the whole AST + constants for each file + the set of variables.