### PR TITLE
Adding tests of 2023

### DIFF
--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -16,12 +16,12 @@ MUSL_HOME?=/usr/local/musl
 MPP_FUNCTION_BACKEND?=enchainement_primitif
 MPP_FUNCTION?=enchainement_primitif_interpreteur
 SOURCE_EXT_FILES?=$(call source_dir_ext,$(ROOT_DIR)/m_ext/$(YEAR)/)
-# Add a TESTS_DIR for 2023 when available
-ifeq ($(filter $(YEAR), 2023 2024), $(YEAR))
+# Add a TESTS_DIR for 2024 when available
+ifeq ($(filter $(YEAR), 2024), $(YEAR))
 	#$(warning WARNING: the source M files and fuzzer tests have not yet been published for year: $(YEAR). Should you choose to provide your own source files, you can create a directory ir-calcul/M_SVN/$(YEAR) and put them in there)
 	SOURCE_FILES?=$(call source_dir,$(ROOT_DIR)/ir-calcul/M_SVN/$(YEAR)/code_m/)
 	TESTS_DIR?=$(ROOT_DIR)/tests/$(YEAR)/fuzzing
-else ifeq ($(filter $(YEAR), 2019 2020 2021 2022), $(YEAR))
+else ifeq ($(filter $(YEAR), 2019 2020 2021 2022 2023), $(YEAR))
 	SOURCE_FILES?=$(call source_dir,$(ROOT_DIR)/ir-calcul/sources$(YEAR)*/)
 	TESTS_DIR?=$(ROOT_DIR)/tests/$(YEAR)/fuzzing
 else ifeq ($(filter $(YEAR), 0), $(YEAR))


### PR DESCRIPTION
Updates the ir-calcul submodule to include the latest M code and updates the makefile accordingly

How to test : 
$  make clean build YEAR=2023 test_dgfip_c_backend